### PR TITLE
add unit of work abstraction and ef implementation

### DIFF
--- a/LgymApi.Application/Repositories/IUnitOfWork.cs
+++ b/LgymApi.Application/Repositories/IUnitOfWork.cs
@@ -1,0 +1,13 @@
+namespace LgymApi.Application.Repositories;
+
+public interface IUnitOfWork
+{
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+    Task<IUnitOfWorkTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
+}
+
+public interface IUnitOfWorkTransaction : IAsyncDisposable
+{
+    Task CommitAsync(CancellationToken cancellationToken = default);
+    Task RollbackAsync(CancellationToken cancellationToken = default);
+}

--- a/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
+++ b/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using LgymApi.Application.Services;
 using LgymApi.Infrastructure.Data;
 using LgymApi.Infrastructure.Services;
+using LgymApi.Infrastructure.UnitOfWork;
 using LgymApi.Application.Repositories;
 using LgymApi.Infrastructure.Repositories;
 using Microsoft.EntityFrameworkCore;
@@ -47,6 +48,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IGymRepository, GymRepository>();
         services.AddScoped<IEloRegistryRepository, EloRegistryRepository>();
         services.AddScoped<IAppConfigRepository, AppConfigRepository>();
+        services.AddScoped<IUnitOfWork, EfUnitOfWork>();
 
         return services;
     }

--- a/LgymApi.Infrastructure/UnitOfWork/EfUnitOfWork.cs
+++ b/LgymApi.Infrastructure/UnitOfWork/EfUnitOfWork.cs
@@ -1,0 +1,25 @@
+using LgymApi.Application.Repositories;
+using LgymApi.Infrastructure.Data;
+
+namespace LgymApi.Infrastructure.UnitOfWork;
+
+public sealed class EfUnitOfWork : IUnitOfWork
+{
+    private readonly AppDbContext _dbContext;
+
+    public EfUnitOfWork(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        return _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<IUnitOfWorkTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+        return new EfUnitOfWorkTransaction(transaction);
+    }
+}

--- a/LgymApi.Infrastructure/UnitOfWork/EfUnitOfWorkTransaction.cs
+++ b/LgymApi.Infrastructure/UnitOfWork/EfUnitOfWorkTransaction.cs
@@ -1,0 +1,29 @@
+using LgymApi.Application.Repositories;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace LgymApi.Infrastructure.UnitOfWork;
+
+public sealed class EfUnitOfWorkTransaction : IUnitOfWorkTransaction
+{
+    private readonly IDbContextTransaction _transaction;
+
+    public EfUnitOfWorkTransaction(IDbContextTransaction transaction)
+    {
+        _transaction = transaction;
+    }
+
+    public Task CommitAsync(CancellationToken cancellationToken = default)
+    {
+        return _transaction.CommitAsync(cancellationToken);
+    }
+
+    public Task RollbackAsync(CancellationToken cancellationToken = default)
+    {
+        return _transaction.RollbackAsync(cancellationToken);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return _transaction.DisposeAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- add `IUnitOfWork` and `IUnitOfWorkTransaction` contracts in the Application layer
- add EF-backed `EfUnitOfWork` and transaction wrapper in Infrastructure
- register `IUnitOfWork` in DI so services can commit at use-case boundaries in next refactor steps