### PR TITLE
move commit orchestration to application services

### DIFF
--- a/LgymApi.Application/AppConfig/AppConfigService.cs
+++ b/LgymApi.Application/AppConfig/AppConfigService.cs
@@ -10,11 +10,13 @@ public sealed class AppConfigService : IAppConfigService
 {
     private readonly IUserRepository _userRepository;
     private readonly IAppConfigRepository _appConfigRepository;
+    private readonly IUnitOfWork _unitOfWork;
 
-    public AppConfigService(IUserRepository userRepository, IAppConfigRepository appConfigRepository)
+    public AppConfigService(IUserRepository userRepository, IAppConfigRepository appConfigRepository, IUnitOfWork unitOfWork)
     {
         _userRepository = userRepository;
         _appConfigRepository = appConfigRepository;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task<AppConfigEntity> GetLatestByPlatformAsync(string platformRaw)
@@ -80,5 +82,6 @@ public sealed class AppConfigService : IAppConfigService
         };
 
         await _appConfigRepository.AddAsync((global::LgymApi.Domain.Entities.AppConfig)config);
+        await _unitOfWork.SaveChangesAsync();
     }
 }

--- a/LgymApi.Application/Exercise/ExerciseService.cs
+++ b/LgymApi.Application/Exercise/ExerciseService.cs
@@ -14,15 +14,18 @@ public sealed class ExerciseService : IExerciseService
     private readonly IUserRepository _userRepository;
     private readonly IExerciseRepository _exerciseRepository;
     private readonly IExerciseScoreRepository _exerciseScoreRepository;
+    private readonly IUnitOfWork _unitOfWork;
 
     public ExerciseService(
         IUserRepository userRepository,
         IExerciseRepository exerciseRepository,
-        IExerciseScoreRepository exerciseScoreRepository)
+        IExerciseScoreRepository exerciseScoreRepository,
+        IUnitOfWork unitOfWork)
     {
         _userRepository = userRepository;
         _exerciseRepository = exerciseRepository;
         _exerciseScoreRepository = exerciseScoreRepository;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task AddExerciseAsync(string name, string bodyPart, string? description, string? image)
@@ -48,6 +51,7 @@ public sealed class ExerciseService : IExerciseService
         };
 
         await _exerciseRepository.AddAsync(exercise);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task AddUserExerciseAsync(Guid userId, string name, string bodyPart, string? description, string? image)
@@ -85,6 +89,7 @@ public sealed class ExerciseService : IExerciseService
         };
 
         await _exerciseRepository.AddAsync(exercise);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task DeleteExerciseAsync(Guid userId, Guid exerciseId)
@@ -126,6 +131,7 @@ public sealed class ExerciseService : IExerciseService
         }
 
         await _exerciseRepository.UpdateAsync(exercise);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task UpdateExerciseAsync(string exerciseId, string? name, string? bodyPart, string? description, string? image)
@@ -155,6 +161,7 @@ public sealed class ExerciseService : IExerciseService
         exercise.Image = image;
 
         await _exerciseRepository.UpdateAsync(exercise);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task AddGlobalTranslationAsync(UserEntity currentUser, Guid routeUserId, string exerciseId, string? culture, string? name)
@@ -209,6 +216,7 @@ public sealed class ExerciseService : IExerciseService
 
         var normalizedCulture = cultureInput.ToLowerInvariant();
         await _exerciseRepository.UpsertTranslationAsync(exerciseGuid, normalizedCulture, nameInput);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task<ExercisesWithTranslations> GetAllExercisesAsync(Guid userId, IReadOnlyList<string> cultures)

--- a/LgymApi.Application/Gym/GymService.cs
+++ b/LgymApi.Application/Gym/GymService.cs
@@ -11,11 +11,13 @@ public sealed class GymService : IGymService
 {
     private readonly IGymRepository _gymRepository;
     private readonly ITrainingRepository _trainingRepository;
+    private readonly IUnitOfWork _unitOfWork;
 
-    public GymService(IGymRepository gymRepository, ITrainingRepository trainingRepository)
+    public GymService(IGymRepository gymRepository, ITrainingRepository trainingRepository, IUnitOfWork unitOfWork)
     {
         _gymRepository = gymRepository;
         _trainingRepository = trainingRepository;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task AddGymAsync(UserEntity currentUser, Guid routeUserId, string name, string? address)
@@ -51,6 +53,7 @@ public sealed class GymService : IGymService
         };
 
         await _gymRepository.AddAsync(gym);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task DeleteGymAsync(UserEntity currentUser, Guid gymId)
@@ -78,6 +81,7 @@ public sealed class GymService : IGymService
 
         gym.IsDeleted = true;
         await _gymRepository.UpdateAsync(gym);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task<GymListContext> GetGymsAsync(UserEntity currentUser, Guid routeUserId)
@@ -164,5 +168,6 @@ public sealed class GymService : IGymService
         }
 
         await _gymRepository.UpdateAsync(gym);
+        await _unitOfWork.SaveChangesAsync();
     }
 }

--- a/LgymApi.Application/MainRecords/MainRecordsService.cs
+++ b/LgymApi.Application/MainRecords/MainRecordsService.cs
@@ -14,17 +14,20 @@ public sealed class MainRecordsService : IMainRecordsService
     private readonly IExerciseRepository _exerciseRepository;
     private readonly IMainRecordRepository _mainRecordRepository;
     private readonly IExerciseScoreRepository _exerciseScoreRepository;
+    private readonly IUnitOfWork _unitOfWork;
 
     public MainRecordsService(
         IUserRepository userRepository,
         IExerciseRepository exerciseRepository,
         IMainRecordRepository mainRecordRepository,
-        IExerciseScoreRepository exerciseScoreRepository)
+        IExerciseScoreRepository exerciseScoreRepository,
+        IUnitOfWork unitOfWork)
     {
         _userRepository = userRepository;
         _exerciseRepository = exerciseRepository;
         _mainRecordRepository = mainRecordRepository;
         _exerciseScoreRepository = exerciseScoreRepository;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task AddNewRecordAsync(Guid userId, string exerciseId, double weight, string unit, DateTime date)
@@ -58,6 +61,7 @@ public sealed class MainRecordsService : IMainRecordsService
         };
 
         await _mainRecordRepository.AddAsync(record);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task<List<MainRecordEntity>> GetMainRecordsHistoryAsync(Guid userId)
@@ -133,6 +137,7 @@ public sealed class MainRecordsService : IMainRecordsService
         }
 
         await _mainRecordRepository.DeleteAsync(record);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task UpdateMainRecordAsync(Guid userId, string recordId, string exerciseId, double weight, string unit, DateTime date)
@@ -177,6 +182,7 @@ public sealed class MainRecordsService : IMainRecordsService
         existingRecord.Date = new DateTimeOffset(DateTime.SpecifyKind(date, DateTimeKind.Utc));
 
         await _mainRecordRepository.UpdateAsync(existingRecord);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task<PossibleRecordResult> GetRecordOrPossibleRecordInExerciseAsync(Guid userId, string exerciseId)

--- a/LgymApi.Application/Measurements/MeasurementsService.cs
+++ b/LgymApi.Application/Measurements/MeasurementsService.cs
@@ -10,10 +10,12 @@ namespace LgymApi.Application.Features.Measurements;
 public sealed class MeasurementsService : IMeasurementsService
 {
     private readonly IMeasurementRepository _measurementRepository;
+    private readonly IUnitOfWork _unitOfWork;
 
-    public MeasurementsService(IMeasurementRepository measurementRepository)
+    public MeasurementsService(IMeasurementRepository measurementRepository, IUnitOfWork unitOfWork)
     {
         _measurementRepository = measurementRepository;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task AddMeasurementAsync(UserEntity currentUser, string bodyPart, string unit, double value)
@@ -41,6 +43,7 @@ public sealed class MeasurementsService : IMeasurementsService
         };
 
         await _measurementRepository.AddAsync(measurement);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task<MeasurementEntity> GetMeasurementDetailAsync(UserEntity currentUser, Guid measurementId)

--- a/LgymApi.Application/PlanDay/PlanDayService.cs
+++ b/LgymApi.Application/PlanDay/PlanDayService.cs
@@ -15,19 +15,22 @@ public sealed class PlanDayService : IPlanDayService
     private readonly IPlanDayExerciseRepository _planDayExerciseRepository;
     private readonly IExerciseRepository _exerciseRepository;
     private readonly ITrainingRepository _trainingRepository;
+    private readonly IUnitOfWork _unitOfWork;
 
     public PlanDayService(
         IPlanRepository planRepository,
         IPlanDayRepository planDayRepository,
         IPlanDayExerciseRepository planDayExerciseRepository,
         IExerciseRepository exerciseRepository,
-        ITrainingRepository trainingRepository)
+        ITrainingRepository trainingRepository,
+        IUnitOfWork unitOfWork)
     {
         _planRepository = planRepository;
         _planDayRepository = planDayRepository;
         _planDayExerciseRepository = planDayExerciseRepository;
         _exerciseRepository = exerciseRepository;
         _trainingRepository = trainingRepository;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task CreatePlanDayAsync(UserEntity currentUser, Guid planId, string name, IReadOnlyCollection<PlanDayExerciseInput> exercises)
@@ -85,6 +88,8 @@ public sealed class PlanDayService : IPlanDayService
         {
             await _planDayExerciseRepository.AddRangeAsync(exercisesToAdd);
         }
+
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task UpdatePlanDayAsync(UserEntity currentUser, string planDayId, string name, IReadOnlyCollection<PlanDayExerciseInput> exercises)
@@ -148,6 +153,8 @@ public sealed class PlanDayService : IPlanDayService
         {
             await _planDayExerciseRepository.AddRangeAsync(exercisesToAdd);
         }
+
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task<PlanDayDetailsContext> GetPlanDayAsync(UserEntity currentUser, Guid planDayId)
@@ -272,6 +279,7 @@ public sealed class PlanDayService : IPlanDayService
         }
 
         await _planDayRepository.MarkDeletedAsync(planDay.Id);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task<PlanDaysInfoContext> GetPlanDaysInfoAsync(UserEntity currentUser, Guid planId)

--- a/LgymApi.Application/Training/TrainingService.cs
+++ b/LgymApi.Application/Training/TrainingService.cs
@@ -19,6 +19,7 @@ public sealed class TrainingService : ITrainingService
     private readonly ITrainingExerciseScoreRepository _trainingExerciseScoreRepository;
     private readonly IEloRegistryRepository _eloRepository;
     private readonly IRankService _rankService;
+    private readonly IUnitOfWork _unitOfWork;
 
     public TrainingService(
         IUserRepository userRepository,
@@ -28,7 +29,8 @@ public sealed class TrainingService : ITrainingService
         IExerciseScoreRepository exerciseScoreRepository,
         ITrainingExerciseScoreRepository trainingExerciseScoreRepository,
         IEloRegistryRepository eloRepository,
-        IRankService rankService)
+        IRankService rankService,
+        IUnitOfWork unitOfWork)
     {
         _userRepository = userRepository;
         _gymRepository = gymRepository;
@@ -38,6 +40,7 @@ public sealed class TrainingService : ITrainingService
         _trainingExerciseScoreRepository = trainingExerciseScoreRepository;
         _eloRepository = eloRepository;
         _rankService = rankService;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task<TrainingSummaryResult> AddTrainingAsync(
@@ -160,6 +163,7 @@ public sealed class TrainingService : ITrainingService
                 TrainingId = training.Id
             });
             await _userRepository.UpdateAsync(user);
+            await _unitOfWork.SaveChangesAsync();
 
             var comparison = BuildComparisonReport(exercises, previousScoresMap, exerciseDetailsMap);
 

--- a/LgymApi.Application/User/UserService.cs
+++ b/LgymApi.Application/User/UserService.cs
@@ -16,19 +16,22 @@ public sealed class UserService : IUserService
     private readonly ITokenService _tokenService;
     private readonly ILegacyPasswordService _legacyPasswordService;
     private readonly IRankService _rankService;
+    private readonly IUnitOfWork _unitOfWork;
 
     public UserService(
         IUserRepository userRepository,
         IEloRegistryRepository eloRepository,
         ITokenService tokenService,
         ILegacyPasswordService legacyPasswordService,
-        IRankService rankService)
+        IRankService rankService,
+        IUnitOfWork unitOfWork)
     {
         _userRepository = userRepository;
         _eloRepository = eloRepository;
         _tokenService = tokenService;
         _legacyPasswordService = legacyPasswordService;
         _rankService = rankService;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task RegisterAsync(string name, string email, string password, string confirmPassword, bool? isVisibleInRanking)
@@ -89,6 +92,7 @@ public sealed class UserService : IUserService
             Date = DateTimeOffset.UtcNow,
             Elo = 1000
         });
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task<LoginResult> LoginAsync(string name, string password)
@@ -227,6 +231,7 @@ public sealed class UserService : IUserService
         currentUser.IsDeleted = true;
 
         await _userRepository.UpdateAsync(currentUser);
+        await _unitOfWork.SaveChangesAsync();
     }
 
     public async Task ChangeVisibilityInRankingAsync(UserEntity currentUser, bool isVisibleInRanking)
@@ -238,5 +243,6 @@ public sealed class UserService : IUserService
 
         currentUser.IsVisibleInRanking = isVisibleInRanking;
         await _userRepository.UpdateAsync(currentUser);
+        await _unitOfWork.SaveChangesAsync();
     }
 }


### PR DESCRIPTION
## Summary
- inject `IUnitOfWork` into write-oriented application services
- move persistence commit ownership to service/use-case boundaries via `SaveChangesAsync`
- keep read-only service methods side-effect free (no commits)

## Notes
- Targets `milestone/uow-refactor` directly.
- Transaction boundary hardening is deferred to issue #71.

Refs #70