### PR TITLE
fix getLastExerciseScores gymName mapping

### DIFF
--- a/LgymApi.IntegrationTests/ExerciseScoresTests.cs
+++ b/LgymApi.IntegrationTests/ExerciseScoresTests.cs
@@ -175,6 +175,7 @@ public sealed class ExerciseScoresTests : IntegrationTestBase
         body.Should().NotBeNull();
         body!.SeriesScores[0].Score.Should().NotBeNull();
         body.SeriesScores[0].Score!.Weight.Should().Be(60.0);
+        body.SeriesScores[0].Score!.GymName.Should().Be("LastScores Gym");
     }
 
     [Test]
@@ -285,6 +286,9 @@ public sealed class ExerciseScoresTests : IntegrationTestBase
 
         [JsonPropertyName("weight")]
         public double Weight { get; set; }
+
+        [JsonPropertyName("gymName")]
+        public string? GymName { get; set; }
     }
 
     private sealed class ExerciseHistoryItem


### PR DESCRIPTION
## Summary
- Fix latest-per-series score query to load `Training -> Gym`, so `seriesScores[*].score.gymName` is returned by `getLastExerciseScores`.
- Keep latest-per-series behavior by selecting latest IDs first, then loading full entities with gym relation.
- Extend integration coverage to assert `gymName` in `GetLastExerciseScores_WithExistingScores_ReturnsPreviousScores`.

## Issue
Closes #104