### PR TITLE
[#102] Refactor API mapping profiles to reuse nested mappings

### DIFF
--- a/LgymApi.Api/Mapping/Profiles/ExerciseScoreProfile.cs
+++ b/LgymApi.Api/Mapping/Profiles/ExerciseScoreProfile.cs
@@ -28,13 +28,18 @@ public sealed class ExerciseScoreProfile : IMappingProfile
             Unit = source.Unit.ToLookup()
         });
 
-        configuration.CreateMap<ExerciseScore, ScoreWithGymDto>((source, _) => new ScoreWithGymDto
+        configuration.CreateMap<ExerciseScore, ScoreWithGymDto>((source, context) =>
         {
-            Id = source.Id.ToString(),
-            Reps = source.Reps,
-            Weight = source.Weight,
-            Unit = source.Unit.ToLookup(),
-            GymName = source.Training?.Gym?.Name
+            var score = context!.Map<ExerciseScore, ScoreDto>(source);
+
+            return new ScoreWithGymDto
+            {
+                Id = score.Id,
+                Reps = score.Reps,
+                Weight = score.Weight,
+                Unit = score.Unit,
+                GymName = source.Training?.Gym?.Name
+            };
         });
     }
 }

--- a/LgymApi.Api/Mapping/Profiles/GymProfile.cs
+++ b/LgymApi.Api/Mapping/Profiles/GymProfile.cs
@@ -15,6 +15,20 @@ public sealed class GymProfile : IMappingProfile
     {
         configuration.AllowContextKey(Keys.LastTrainingMap);
 
+        configuration.CreateMap<PlanDay, LastTrainingGymPlanDayInfoDto>((source, _) => new LastTrainingGymPlanDayInfoDto
+        {
+            Id = source.Id.ToString(),
+            Name = source.Name
+        });
+
+        configuration.CreateMap<LgymApi.Domain.Entities.Training, LastTrainingGymInfoDto>((source, context) => new LastTrainingGymInfoDto
+        {
+            Id = source.Id.ToString(),
+            CreatedAt = source.CreatedAt.UtcDateTime,
+            Type = source.PlanDay == null ? null : context!.Map<PlanDay, LastTrainingGymPlanDayInfoDto>(source.PlanDay),
+            Name = source.PlanDay?.Name
+        });
+
         configuration.CreateMap<Gym, GymFormDto>((source, _) => new GymFormDto
         {
             Id = source.Id.ToString(),
@@ -36,17 +50,7 @@ public sealed class GymProfile : IMappingProfile
                 Id = source.Id.ToString(),
                 Name = source.Name,
                 Address = source.AddressId?.ToString(),
-                LastTrainingInfo = training == null ? null : new LastTrainingGymInfoDto
-                {
-                    Id = training.Id.ToString(),
-                    CreatedAt = training.CreatedAt.UtcDateTime,
-                    Type = training.PlanDay == null ? null : new LastTrainingGymPlanDayInfoDto
-                    {
-                        Id = training.PlanDay.Id.ToString(),
-                        Name = training.PlanDay.Name
-                    },
-                    Name = training.PlanDay?.Name
-                }
+                LastTrainingInfo = training == null ? null : context!.Map<LgymApi.Domain.Entities.Training, LastTrainingGymInfoDto>(training)
             };
         });
     }

--- a/LgymApi.Api/Mapping/Profiles/MainRecordProfile.cs
+++ b/LgymApi.Api/Mapping/Profiles/MainRecordProfile.cs
@@ -28,21 +28,10 @@ public sealed class MainRecordProfile : IMappingProfile
 
         configuration.CreateMap<MainRecord, MainRecordsLastDto>((source, context) =>
         {
-            var exerciseDetails = new ExerciseResponseDto();
-
             var exerciseMap = context?.Get(Keys.ExerciseMap);
-            if (exerciseMap != null && exerciseMap.TryGetValue(source.ExerciseId, out var exercise))
-            {
-                exerciseDetails = new ExerciseResponseDto
-                {
-                    Id = exercise.Id.ToString(),
-                    Name = exercise.Name,
-                    BodyPart = exercise.BodyPart.ToLookup(),
-                    Description = exercise.Description,
-                    Image = exercise.Image,
-                    UserId = exercise.UserId?.ToString()
-                };
-            }
+            var exercise = exerciseMap != null && exerciseMap.TryGetValue(source.ExerciseId, out var resolvedExercise)
+                ? resolvedExercise
+                : null;
 
             return new MainRecordsLastDto
             {
@@ -51,7 +40,9 @@ public sealed class MainRecordProfile : IMappingProfile
                 Weight = source.Weight,
                 Unit = source.Unit.ToLookup(),
                 Date = source.Date.UtcDateTime,
-                ExerciseDetails = exerciseDetails
+                ExerciseDetails = exercise == null
+                    ? new ExerciseResponseDto()
+                    : context!.Map<Exercise, ExerciseResponseDto>(exercise)
             };
         });
     }

--- a/LgymApi.Api/Mapping/Profiles/PlanDayProfile.cs
+++ b/LgymApi.Api/Mapping/Profiles/PlanDayProfile.cs
@@ -40,7 +40,7 @@ public sealed class PlanDayProfile : IMappingProfile
                 {
                     Series = exercise.Series,
                     Reps = exercise.Reps,
-                    Exercise = ResolveExerciseDto(exercise, exerciseMap)
+                    Exercise = ResolveExerciseDto(exercise, exerciseMap, context)
                 })
                 .ToList();
 
@@ -73,19 +73,11 @@ public sealed class PlanDayProfile : IMappingProfile
         });
     }
 
-    private static ExerciseResponseDto ResolveExerciseDto(PlanDayExercise exercise, IReadOnlyDictionary<Guid, Exercise>? exerciseMap)
+    private static ExerciseResponseDto ResolveExerciseDto(PlanDayExercise exercise, IReadOnlyDictionary<Guid, Exercise>? exerciseMap, MappingContext? context)
     {
         if (exerciseMap != null && exerciseMap.TryGetValue(exercise.ExerciseId, out var entity))
         {
-            return new ExerciseResponseDto
-            {
-                Id = entity.Id.ToString(),
-                Name = entity.Name,
-                BodyPart = entity.BodyPart.ToLookup(),
-                Description = entity.Description,
-                Image = entity.Image,
-                UserId = entity.UserId?.ToString()
-            };
+            return context!.Map<Exercise, ExerciseResponseDto>(entity);
         }
 
         return new ExerciseResponseDto();

--- a/LgymApi.Api/Mapping/Profiles/TrainingProfile.cs
+++ b/LgymApi.Api/Mapping/Profiles/TrainingProfile.cs
@@ -9,18 +9,14 @@ public sealed class TrainingProfile : IMappingProfile
 {
     public void Configure(MappingConfiguration configuration)
     {
-        configuration.CreateMap<Training, LastTrainingInfoDto>((source, _) => new LastTrainingInfoDto
+        configuration.CreateMap<Training, LastTrainingInfoDto>((source, context) => new LastTrainingInfoDto
         {
             Id = source.Id.ToString(),
             TypePlanDayId = source.TypePlanDayId.ToString(),
             CreatedAt = source.CreatedAt.UtcDateTime,
             PlanDay = source.PlanDay == null
                 ? new PlanDayChooseDto()
-                : new PlanDayChooseDto
-                {
-                    Id = source.PlanDay.Id.ToString(),
-                    Name = source.PlanDay.Name
-                }
+                : context!.Map<PlanDay, PlanDayChooseDto>(source.PlanDay)
         });
     }
 }


### PR DESCRIPTION
## Summary
- refactors API mapping profiles to reuse existing nested mapper compositions instead of duplicating inline nested DTO construction
- composes nested mappings in main record, plan day, gym, training, and exercise score profiles while preserving existing DTO contracts and fallback behavior
- reduces duplicated mapping logic for exercise and plan-day related nested DTOs across the API layer

## Validation
- dotnet test LgymApi.UnitTests/LgymApi.UnitTests.csproj

Part of #100
Depends on #101
Implements #102