### PR TITLE
add GitHub Actions tests for PRs and main

### DIFF
--- a/.github/workflows/pr-and-main-tests.yml
+++ b/.github/workflows/pr-and-main-tests.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
-          cache: true
 
       - name: Restore
         run: dotnet restore LgymApi.sln


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on pull requests to `main` and pushes to `main`
- restore/build solution and run both `LgymApi.UnitTests` and `LgymApi.IntegrationTests` on `ubuntu-latest`
- publish `.trx` reports as artifacts and post test summaries to GitHub Checks for easier PR review