### PR TITLE
[#87] Start trainer plan management API module

### DIFF
--- a/LgymApi.Api/Features/Trainer/Contracts/TrainerRelationshipDtos.cs
+++ b/LgymApi.Api/Features/Trainer/Contracts/TrainerRelationshipDtos.cs
@@ -107,3 +107,24 @@ public sealed class TrainerDashboardTraineesResponse
     [JsonPropertyName("items")]
     public List<TrainerDashboardTraineeDto> Items { get; set; } = [];
 }
+
+public sealed class TrainerPlanFormRequest
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+}
+
+public sealed class TrainerManagedPlanDto
+{
+    [JsonPropertyName("_id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("isActive")]
+    public bool IsActive { get; set; }
+
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/LgymApi.Api/Features/Trainer/Controllers/TraineeRelationshipController.cs
+++ b/LgymApi.Api/Features/Trainer/Controllers/TraineeRelationshipController.cs
@@ -1,7 +1,9 @@
 using LgymApi.Api.Features.Common.Contracts;
+using LgymApi.Api.Features.Trainer.Contracts;
 using LgymApi.Api.Middleware;
 using LgymApi.Application.Exceptions;
 using LgymApi.Application.Features.TrainerRelationships;
+using LgymApi.Application.Features.TrainerRelationships.Models;
 using LgymApi.Application.Mapping.Core;
 using LgymApi.Resources;
 using Microsoft.AspNetCore.Authorization;
@@ -58,5 +60,14 @@ public sealed class TraineeRelationshipController : ControllerBase
         var trainee = HttpContext.GetCurrentUser();
         await _trainerRelationshipService.DetachFromTrainerAsync(trainee!);
         return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
+    }
+
+    [HttpGet("plan/active")]
+    [ProducesResponseType(typeof(TrainerManagedPlanDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetActiveAssignedPlan()
+    {
+        var trainee = HttpContext.GetCurrentUser();
+        var plan = await _trainerRelationshipService.GetActiveAssignedPlanAsync(trainee!);
+        return Ok(_mapper.Map<TrainerManagedPlanResult, TrainerManagedPlanDto>(plan));
     }
 }

--- a/LgymApi.Api/Features/Trainer/Controllers/TrainerRelationshipController.cs
+++ b/LgymApi.Api/Features/Trainer/Controllers/TrainerRelationshipController.cs
@@ -179,4 +179,103 @@ public sealed class TrainerRelationshipController : ControllerBase
         await _trainerRelationshipService.UnlinkTraineeAsync(trainer!, parsedTraineeId);
         return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
     }
+
+    [HttpGet("trainees/{traineeId}/plans")]
+    [ProducesResponseType(typeof(List<TrainerManagedPlanDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetTraineePlans([FromRoute] string traineeId)
+    {
+        if (!Guid.TryParse(traineeId, out var parsedTraineeId))
+        {
+            throw AppException.BadRequest(Messages.UserIdRequired);
+        }
+
+        var trainer = HttpContext.GetCurrentUser();
+        var plans = await _trainerRelationshipService.GetTraineePlansAsync(trainer!, parsedTraineeId);
+        return Ok(_mapper.MapList<TrainerManagedPlanResult, TrainerManagedPlanDto>(plans));
+    }
+
+    [HttpPost("trainees/{traineeId}/plans")]
+    [ProducesResponseType(typeof(TrainerManagedPlanDto), StatusCodes.Status201Created)]
+    public async Task<IActionResult> CreateTraineePlan([FromRoute] string traineeId, [FromBody] TrainerPlanFormRequest request)
+    {
+        if (!Guid.TryParse(traineeId, out var parsedTraineeId))
+        {
+            throw AppException.BadRequest(Messages.UserIdRequired);
+        }
+
+        var trainer = HttpContext.GetCurrentUser();
+        var plan = await _trainerRelationshipService.CreateTraineePlanAsync(trainer!, parsedTraineeId, request.Name);
+        return StatusCode(StatusCodes.Status201Created, _mapper.Map<TrainerManagedPlanResult, TrainerManagedPlanDto>(plan));
+    }
+
+    [HttpPost("trainees/{traineeId}/plans/{planId}/update")]
+    [ProducesResponseType(typeof(TrainerManagedPlanDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> UpdateTraineePlan([FromRoute] string traineeId, [FromRoute] string planId, [FromBody] TrainerPlanFormRequest request)
+    {
+        if (!Guid.TryParse(traineeId, out var parsedTraineeId))
+        {
+            throw AppException.BadRequest(Messages.UserIdRequired);
+        }
+
+        if (!Guid.TryParse(planId, out var parsedPlanId))
+        {
+            throw AppException.BadRequest(Messages.FieldRequired);
+        }
+
+        var trainer = HttpContext.GetCurrentUser();
+        var plan = await _trainerRelationshipService.UpdateTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, request.Name);
+        return Ok(_mapper.Map<TrainerManagedPlanResult, TrainerManagedPlanDto>(plan));
+    }
+
+    [HttpPost("trainees/{traineeId}/plans/{planId}/delete")]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> DeleteTraineePlan([FromRoute] string traineeId, [FromRoute] string planId)
+    {
+        if (!Guid.TryParse(traineeId, out var parsedTraineeId))
+        {
+            throw AppException.BadRequest(Messages.UserIdRequired);
+        }
+
+        if (!Guid.TryParse(planId, out var parsedPlanId))
+        {
+            throw AppException.BadRequest(Messages.FieldRequired);
+        }
+
+        var trainer = HttpContext.GetCurrentUser();
+        await _trainerRelationshipService.DeleteTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId);
+        return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Deleted));
+    }
+
+    [HttpPost("trainees/{traineeId}/plans/{planId}/assign")]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> AssignTraineePlan([FromRoute] string traineeId, [FromRoute] string planId)
+    {
+        if (!Guid.TryParse(traineeId, out var parsedTraineeId))
+        {
+            throw AppException.BadRequest(Messages.UserIdRequired);
+        }
+
+        if (!Guid.TryParse(planId, out var parsedPlanId))
+        {
+            throw AppException.BadRequest(Messages.FieldRequired);
+        }
+
+        var trainer = HttpContext.GetCurrentUser();
+        await _trainerRelationshipService.AssignTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId);
+        return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
+    }
+
+    [HttpPost("trainees/{traineeId}/plans/unassign")]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> UnassignTraineePlan([FromRoute] string traineeId)
+    {
+        if (!Guid.TryParse(traineeId, out var parsedTraineeId))
+        {
+            throw AppException.BadRequest(Messages.UserIdRequired);
+        }
+
+        var trainer = HttpContext.GetCurrentUser();
+        await _trainerRelationshipService.UnassignTraineePlanAsync(trainer!, parsedTraineeId);
+        return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
+    }
 }

--- a/LgymApi.Api/Mapping/Profiles/TrainerProfile.cs
+++ b/LgymApi.Api/Mapping/Profiles/TrainerProfile.cs
@@ -35,5 +35,13 @@ public sealed class TrainerProfile : IMappingProfile
             LastInvitationRespondedAt = source.LastInvitationRespondedAt
         });
 
+        configuration.CreateMap<TrainerManagedPlanResult, TrainerManagedPlanDto>((source, _) => new TrainerManagedPlanDto
+        {
+            Id = source.Id.ToString(),
+            Name = source.Name,
+            IsActive = source.IsActive,
+            CreatedAt = source.CreatedAt
+        });
+
     }
 }

--- a/LgymApi.Application/Repositories/IPlanRepository.cs
+++ b/LgymApi.Application/Repositories/IPlanRepository.cs
@@ -11,6 +11,7 @@ public interface IPlanRepository
     Task AddAsync(Plan plan, CancellationToken cancellationToken = default);
     Task UpdateAsync(Plan plan, CancellationToken cancellationToken = default);
     Task SetActivePlanAsync(Guid userId, Guid planId, CancellationToken cancellationToken = default);
+    Task ClearActivePlansAsync(Guid userId, CancellationToken cancellationToken = default);
     Task<Plan> CopyPlanByShareCodeAsync(string shareCode, Guid userId, CancellationToken cancellationToken = default);
     Task<string> GenerateShareCodeAsync(Guid planId, Guid userId, CancellationToken cancellationToken = default);
 }

--- a/LgymApi.Application/TrainerRelationships/ITrainerRelationshipService.cs
+++ b/LgymApi.Application/TrainerRelationships/ITrainerRelationshipService.cs
@@ -17,6 +17,13 @@ public interface ITrainerRelationshipService
     Task<List<ExerciseScoresChartData>> GetTraineeExerciseScoresChartDataAsync(UserEntity currentTrainer, Guid traineeId, Guid exerciseId);
     Task<List<EloRegistryChartEntry>> GetTraineeEloChartAsync(UserEntity currentTrainer, Guid traineeId);
     Task<List<MainRecordEntity>> GetTraineeMainRecordsHistoryAsync(UserEntity currentTrainer, Guid traineeId);
+    Task<List<TrainerManagedPlanResult>> GetTraineePlansAsync(UserEntity currentTrainer, Guid traineeId);
+    Task<TrainerManagedPlanResult> CreateTraineePlanAsync(UserEntity currentTrainer, Guid traineeId, string name);
+    Task<TrainerManagedPlanResult> UpdateTraineePlanAsync(UserEntity currentTrainer, Guid traineeId, Guid planId, string name);
+    Task DeleteTraineePlanAsync(UserEntity currentTrainer, Guid traineeId, Guid planId);
+    Task AssignTraineePlanAsync(UserEntity currentTrainer, Guid traineeId, Guid planId);
+    Task UnassignTraineePlanAsync(UserEntity currentTrainer, Guid traineeId);
+    Task<TrainerManagedPlanResult> GetActiveAssignedPlanAsync(UserEntity currentTrainee);
     Task AcceptInvitationAsync(UserEntity currentTrainee, Guid invitationId);
     Task RejectInvitationAsync(UserEntity currentTrainee, Guid invitationId);
     Task UnlinkTraineeAsync(UserEntity currentTrainer, Guid traineeId);

--- a/LgymApi.Application/TrainerRelationships/Models/TrainerManagedPlanResult.cs
+++ b/LgymApi.Application/TrainerRelationships/Models/TrainerManagedPlanResult.cs
@@ -1,0 +1,9 @@
+namespace LgymApi.Application.Features.TrainerRelationships.Models;
+
+public sealed class TrainerManagedPlanResult
+{
+    public Guid Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public bool IsActive { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+}

--- a/LgymApi.Infrastructure/Repositories/PlanRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/PlanRepository.cs
@@ -62,6 +62,13 @@ public sealed class PlanRepository : IPlanRepository
             .StageUpdateAsync(_dbContext, p => p.IsActive, p => true, cancellationToken);
     }
 
+    public Task ClearActivePlansAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.Plans
+            .Where(p => p.UserId == userId && !p.IsDeleted)
+            .StageUpdateAsync(_dbContext, p => p.IsActive, p => false, cancellationToken);
+    }
+
     public async Task<Plan> CopyPlanByShareCodeAsync(string shareCode, Guid userId, CancellationToken cancellationToken = default)
     {
         // 1. Find plan by ShareCode


### PR DESCRIPTION
## Summary
- add trainer-side training plan management endpoints for linked trainees (list/create/update/delete, assign, unassign) with ownership checks in application service
- add trainee endpoint to read currently assigned active plan and extend plan repository/service contracts for active-plan lifecycle operations
- add integration coverage for plan assignment lifecycle and ownership isolation; keep endpoint style aligned with architecture rules (GET/POST)

## Testing
- dotnet test LgymApi.sln