### PR TITLE
Enforce feature-folder architecture for controller features

### DIFF
--- a/LgymApi.Api/Features/EloRegistry/Validation/ValidationMarker.cs
+++ b/LgymApi.Api/Features/EloRegistry/Validation/ValidationMarker.cs
@@ -1,3 +1,3 @@
 namespace LgymApi.Api.Features.EloRegistry.Validation;
 
-public static class ValidationMarker;
+public interface IValidationMarker;

--- a/LgymApi.Api/Features/Enum/Validation/ValidationMarker.cs
+++ b/LgymApi.Api/Features/Enum/Validation/ValidationMarker.cs
@@ -1,3 +1,3 @@
 namespace LgymApi.Api.Features.Enum.Validation;
 
-public static class ValidationMarker;
+public interface IValidationMarker;

--- a/LgymApi.ArchitectureTests/FeatureFolderStructureGuardTests.cs
+++ b/LgymApi.ArchitectureTests/FeatureFolderStructureGuardTests.cs
@@ -34,8 +34,6 @@ public sealed class FeatureFolderStructureGuardTests
 
         foreach (var featureDirectory in featureDirectories)
         {
-            var featureName = Path.GetFileName(featureDirectory);
-
             var hasController = Directory
                 .EnumerateFiles(featureDirectory, "*Controller.cs", SearchOption.AllDirectories)
                 .Any();


### PR DESCRIPTION
## Summary
- add an architecture guard test that enforces `Contracts`, `Controllers`, and `Validation` folders for every feature that contains at least one controller
- align existing feature layout by adding missing `Validation` folders for `EloRegistry` and `Enum`
- keep non-controller features out of scope so the rule is generic and stable for API modules

## Verification
- `dotnet test LgymApi.ArchitectureTests/LgymApi.ArchitectureTests.csproj`