### PR TITLE
Add architecture guards for contracts/controllers/validators

### DIFF
--- a/LgymApi.Api/Features/Enum/Contracts/EnumLookupDtos.cs
+++ b/LgymApi.Api/Features/Enum/Contracts/EnumLookupDtos.cs
@@ -3,7 +3,7 @@ using LgymApi.Api.Interfaces;
 
 namespace LgymApi.Api.Features.Enum.Contracts;
 
-public sealed class EnumLookupDto
+public sealed class EnumLookupDto : IResultDto
 {
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;

--- a/LgymApi.Api/Features/Exercise/Contracts/ExerciseDtos.cs
+++ b/LgymApi.Api/Features/Exercise/Contracts/ExerciseDtos.cs
@@ -59,7 +59,7 @@ public sealed class ExerciseTranslationDto : IDto
     public string Name { get; set; } = string.Empty;
 }
 
-public sealed class SeriesScoreDto
+public sealed class SeriesScoreDto : IResultDto
 {
     [JsonPropertyName("series")]
     public int Series { get; set; }
@@ -68,7 +68,7 @@ public sealed class SeriesScoreDto
     public ScoreDto? Score { get; set; }
 }
 
-public class ScoreDto
+public class ScoreDto : IResultDto
 {
     [JsonPropertyName("reps")]
     public int Reps { get; set; }
@@ -89,7 +89,7 @@ public class ScoreWithGymDto : ScoreDto
     public string? GymName { get; set; }
 }
 
-public sealed class SeriesScoreWithGymDto
+public sealed class SeriesScoreWithGymDto : IResultDto
 {
     [JsonPropertyName("series")]
     public int Series { get; set; }

--- a/LgymApi.Api/Features/ExerciseScores/Contracts/ExerciseScoresDtos.cs
+++ b/LgymApi.Api/Features/ExerciseScores/Contracts/ExerciseScoresDtos.cs
@@ -28,7 +28,7 @@ public sealed class ExerciseScoresChartRequestDto : IDto
     public string ExerciseId { get; set; } = string.Empty;
 }
 
-public class ExerciseScoresFormDto : ExerciseScoresTrainingFormDto
+public class ExerciseScoresFormDto : ExerciseScoresTrainingFormDto, IResultDto
 {
     [JsonPropertyName("user")]
     public string UserId { get; set; } = string.Empty;

--- a/LgymApi.Api/Features/Gym/Contracts/GymDtos.cs
+++ b/LgymApi.Api/Features/Gym/Contracts/GymDtos.cs
@@ -15,7 +15,7 @@ public sealed class GymFormDto : IDto, IResultDto
     public string? Id { get; set; }
 }
 
-public sealed class LastTrainingGymPlanDayInfoDto
+public sealed class LastTrainingGymPlanDayInfoDto : IResultDto
 {
     [JsonPropertyName("_id")]
     public string Id { get; set; } = string.Empty;
@@ -24,7 +24,7 @@ public sealed class LastTrainingGymPlanDayInfoDto
     public string Name { get; set; } = string.Empty;
 }
 
-public sealed class LastTrainingGymInfoDto
+public sealed class LastTrainingGymInfoDto : IResultDto
 {
     [JsonPropertyName("_id")]
     public string Id { get; set; } = string.Empty;

--- a/LgymApi.Api/Features/PlanDay/Contracts/PlanDayDtos.cs
+++ b/LgymApi.Api/Features/PlanDay/Contracts/PlanDayDtos.cs
@@ -4,7 +4,7 @@ using LgymApi.Api.Interfaces;
 
 namespace LgymApi.Api.Features.PlanDay.Contracts;
 
-public sealed class PlanDayExerciseInputDto
+public sealed class PlanDayExerciseInputDto : IResultDto
 {
     [JsonPropertyName("series")]
     public int Series { get; set; }
@@ -28,7 +28,7 @@ public sealed class PlanDayFormDto : IDto
     public List<PlanDayExerciseInputDto> Exercises { get; set; } = new();
 }
 
-public sealed class PlanDayExerciseVmDto
+public sealed class PlanDayExerciseVmDto : IResultDto
 {
     [JsonPropertyName("series")]
     public int Series { get; set; }

--- a/LgymApi.Api/Features/Training/Contracts/TrainingDtos.cs
+++ b/LgymApi.Api/Features/Training/Contracts/TrainingDtos.cs
@@ -8,7 +8,7 @@ using LgymApi.Domain.Enums;
 
 namespace LgymApi.Api.Features.Training.Contracts;
 
-public class ExerciseScoresTrainingFormDto
+public class ExerciseScoresTrainingFormDto : IResultDto
 {
     [JsonPropertyName("_id")]
     public string? Id { get; set; }
@@ -29,7 +29,7 @@ public class ExerciseScoresTrainingFormDto
     public int Series { get; set; }
 }
 
-public sealed class ExerciseScoreResponseDto
+public sealed class ExerciseScoreResponseDto : IResultDto
 {
     [JsonPropertyName("_id")]
     public string? Id { get; set; }
@@ -91,7 +91,7 @@ public sealed class TrainingByDateRequestDto : IDto
     public DateTime CreatedAt { get; set; }
 }
 
-public sealed class TrainingExerciseScoreRefDto
+public sealed class TrainingExerciseScoreRefDto : IResultDto
 {
     [JsonPropertyName("exerciseScoreId")]
     public string ExerciseScoreId { get; set; } = string.Empty;
@@ -118,7 +118,7 @@ public sealed class TrainingByDateDto : IResultDto
     public List<TrainingExerciseScoreRefDto> Exercises { get; set; } = new();
 }
 
-public sealed class EnrichedExerciseDto
+public sealed class EnrichedExerciseDto : IResultDto
 {
     [JsonPropertyName("exerciseScoreId")]
     public string ExerciseScoreId { get; set; } = string.Empty;
@@ -151,7 +151,7 @@ public sealed class TrainingByDateDetailsDto : IResultDto
     public List<EnrichedExerciseDto> Exercises { get; set; } = new();
 }
 
-public sealed class SeriesComparisonDto
+public sealed class SeriesComparisonDto : IResultDto
 {
     [JsonPropertyName("series")]
     public int Series { get; set; }
@@ -163,7 +163,7 @@ public sealed class SeriesComparisonDto
     public ScoreResultDto? PreviousResult { get; set; }
 }
 
-public sealed class ScoreResultDto
+public sealed class ScoreResultDto : IResultDto
 {
     [JsonPropertyName("reps")]
     public int Reps { get; set; }
@@ -175,7 +175,7 @@ public sealed class ScoreResultDto
     public EnumLookupDto Unit { get; set; } = new();
 }
 
-public sealed class GroupedExerciseComparisonDto
+public sealed class GroupedExerciseComparisonDto : IResultDto
 {
     [JsonPropertyName("exerciseId")]
     public string ExerciseId { get; set; } = string.Empty;

--- a/LgymApi.Api/Features/User/Contracts/UserDtos.cs
+++ b/LgymApi.Api/Features/User/Contracts/UserDtos.cs
@@ -30,7 +30,7 @@ public sealed class LoginRequest : IDto
     public string Password { get; set; } = string.Empty;
 }
 
-public sealed class RankDto
+public sealed class RankDto : IResultDto
 {
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;

--- a/LgymApi.ArchitectureTests/ContractsDtoGuardTests.cs
+++ b/LgymApi.ArchitectureTests/ContractsDtoGuardTests.cs
@@ -1,0 +1,165 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using LgymApi.Api.Interfaces;
+
+namespace LgymApi.ArchitectureTests;
+
+[TestFixture]
+public sealed class ContractsDtoGuardTests
+{
+    [Test]
+    public void Contracts_Should_Define_Only_IDto_Or_IResultDto()
+    {
+        var repoRoot = ResolveRepositoryRoot();
+        var apiRoot = Path.Combine(repoRoot, "LgymApi.Api");
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+
+        Assert.That(Directory.Exists(apiRoot), Is.True, $"Api project directory '{apiRoot}' does not exist.");
+
+        var sourceFiles = Directory
+            .EnumerateFiles(apiRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsInBuildArtifacts(path))
+            .ToList();
+
+        Assert.That(sourceFiles, Is.Not.Empty, $"No source files found in '{apiRoot}'.");
+
+        var syntaxTrees = sourceFiles
+            .Select(path => CSharpSyntaxTree.ParseText(File.ReadAllText(path), options: parseOptions, path: path))
+            .ToList();
+
+        foreach (var tree in syntaxTrees)
+        {
+            var parseErrors = tree
+                .GetDiagnostics()
+                .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                .ToList();
+
+            Assert.That(
+                parseErrors,
+                Is.Empty,
+                $"Failed to parse source file '{tree.FilePath}':{Environment.NewLine}{string.Join(Environment.NewLine, parseErrors)}");
+        }
+
+        var compilation = CSharpCompilation.Create(
+            "ContractsDtoGuard",
+            syntaxTrees,
+            ResolveMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var idtoSymbol = compilation.GetTypeByMetadataName(typeof(IDto).FullName!);
+        var resultDtoSymbol = compilation.GetTypeByMetadataName(typeof(IResultDto).FullName!);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(idtoSymbol, Is.Not.Null, "Unable to resolve IDto symbol.");
+            Assert.That(resultDtoSymbol, Is.Not.Null, "Unable to resolve IResultDto symbol.");
+        });
+
+        var violations = new List<Violation>();
+        var contractTrees = syntaxTrees
+            .Where(tree => IsContractsPath(tree.FilePath))
+            .ToList();
+
+        foreach (var tree in contractTrees)
+        {
+            var semanticModel = compilation.GetSemanticModel(tree, ignoreAccessibility: true);
+            var root = tree.GetCompilationUnitRoot();
+
+            foreach (var typeDeclaration in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+            {
+                var typeSymbol = semanticModel.GetDeclaredSymbol(typeDeclaration) as INamedTypeSymbol;
+                if (typeSymbol == null)
+                {
+                    continue;
+                }
+
+                if (!IsProjectType(typeSymbol, compilation.Assembly))
+                {
+                    continue;
+                }
+
+                if (typeSymbol.TypeKind is not TypeKind.Class and not TypeKind.Struct)
+                {
+                    continue;
+                }
+
+                if (ImplementsDtoInterface(typeSymbol, idtoSymbol!, resultDtoSymbol!))
+                {
+                    continue;
+                }
+
+                var line = typeDeclaration.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                var relativePath = Path.GetRelativePath(repoRoot, tree.FilePath);
+                violations.Add(new Violation(relativePath, line, typeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+            }
+        }
+
+        Assert.That(
+            violations,
+            Is.Empty,
+            "Every type declared inside a Contracts folder must implement IDto or IResultDto." + Environment.NewLine +
+            string.Join(Environment.NewLine, violations.Select(v => v.ToString())));
+    }
+
+    private static bool ImplementsDtoInterface(INamedTypeSymbol typeSymbol, INamedTypeSymbol idtoSymbol, INamedTypeSymbol resultDtoSymbol)
+    {
+        if (typeSymbol.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, idtoSymbol)))
+        {
+            return true;
+        }
+
+        return typeSymbol.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, resultDtoSymbol));
+    }
+
+    private static bool IsProjectType(INamedTypeSymbol typeSymbol, IAssemblySymbol projectAssembly)
+    {
+        return SymbolEqualityComparer.Default.Equals(typeSymbol.ContainingAssembly, projectAssembly);
+    }
+
+    private static bool IsContractsPath(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        return normalized.Contains("/Contracts/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static List<MetadataReference> ResolveMetadataReferences()
+    {
+        return AppDomain.CurrentDomain
+            .GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic)
+            .Select(assembly => assembly.Location)
+            .Where(location => !string.IsNullOrWhiteSpace(location) && File.Exists(location))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(location => (MetadataReference)MetadataReference.CreateFromFile(location))
+            .ToList();
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "LgymApi.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to locate repository root.");
+    }
+
+    private static bool IsInBuildArtifacts(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        return normalized.Contains("/bin/", StringComparison.OrdinalIgnoreCase)
+            || normalized.Contains("/obj/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed record Violation(string File, int Line, string Type)
+    {
+        public override string ToString() => $"{File}:{Line} {Type} does not implement IDto or IResultDto";
+    }
+}

--- a/LgymApi.ArchitectureTests/ControllersInheritanceGuardTests.cs
+++ b/LgymApi.ArchitectureTests/ControllersInheritanceGuardTests.cs
@@ -1,0 +1,161 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LgymApi.ArchitectureTests;
+
+[TestFixture]
+public sealed class ControllersInheritanceGuardTests
+{
+    [Test]
+    public void Controllers_Should_Inherit_ControllerBase()
+    {
+        var repoRoot = ResolveRepositoryRoot();
+        var apiRoot = Path.Combine(repoRoot, "LgymApi.Api");
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+
+        Assert.That(Directory.Exists(apiRoot), Is.True, $"Api project directory '{apiRoot}' does not exist.");
+
+        var sourceFiles = Directory
+            .EnumerateFiles(apiRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsInBuildArtifacts(path))
+            .ToList();
+
+        Assert.That(sourceFiles, Is.Not.Empty, $"No source files found in '{apiRoot}'.");
+
+        var syntaxTrees = sourceFiles
+            .Select(path => CSharpSyntaxTree.ParseText(File.ReadAllText(path), options: parseOptions, path: path))
+            .ToList();
+
+        foreach (var tree in syntaxTrees)
+        {
+            var parseErrors = tree
+                .GetDiagnostics()
+                .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                .ToList();
+
+            Assert.That(
+                parseErrors,
+                Is.Empty,
+                $"Failed to parse source file '{tree.FilePath}':{Environment.NewLine}{string.Join(Environment.NewLine, parseErrors)}");
+        }
+
+        var compilation = CSharpCompilation.Create(
+            "ControllersInheritanceGuard",
+            syntaxTrees,
+            ResolveMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var controllerBaseSymbol = compilation.GetTypeByMetadataName(typeof(ControllerBase).FullName!);
+
+        Assert.That(controllerBaseSymbol, Is.Not.Null, "Unable to resolve ControllerBase symbol.");
+
+        var controllerTrees = syntaxTrees.Where(tree => IsControllersPath(tree.FilePath)).ToList();
+        Assert.That(controllerTrees, Is.Not.Empty, "No controller files found for analysis.");
+
+        var violations = new List<Violation>();
+
+        foreach (var tree in controllerTrees)
+        {
+            var semanticModel = compilation.GetSemanticModel(tree, ignoreAccessibility: true);
+            var root = tree.GetCompilationUnitRoot();
+
+            foreach (var classDeclaration in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
+            {
+                var typeSymbol = semanticModel.GetDeclaredSymbol(classDeclaration) as INamedTypeSymbol;
+                if (typeSymbol == null)
+                {
+                    continue;
+                }
+
+                if (!IsProjectType(typeSymbol, compilation.Assembly))
+                {
+                    continue;
+                }
+
+                if (InheritsFromControllerBase(typeSymbol, controllerBaseSymbol!))
+                {
+                    continue;
+                }
+
+                var line = classDeclaration.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                var relativePath = Path.GetRelativePath(repoRoot, tree.FilePath);
+                violations.Add(new Violation(relativePath, line, typeSymbol.Name));
+            }
+        }
+
+        Assert.That(
+            violations,
+            Is.Empty,
+            "Every class declared under Features/*/Controllers must inherit ControllerBase." + Environment.NewLine +
+            string.Join(Environment.NewLine, violations.Select(v => v.ToString())));
+    }
+
+    private static bool InheritsFromControllerBase(INamedTypeSymbol type, INamedTypeSymbol controllerBaseSymbol)
+    {
+        var current = type;
+        while (current.BaseType != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current.BaseType, controllerBaseSymbol))
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    private static bool IsProjectType(INamedTypeSymbol typeSymbol, IAssemblySymbol projectAssembly)
+    {
+        return SymbolEqualityComparer.Default.Equals(typeSymbol.ContainingAssembly, projectAssembly);
+    }
+
+    private static bool IsControllersPath(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        return normalized.Contains("/Features/") && normalized.Contains("/Controllers/");
+    }
+
+    private static List<MetadataReference> ResolveMetadataReferences()
+    {
+        return AppDomain.CurrentDomain
+            .GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic)
+            .Select(assembly => assembly.Location)
+            .Where(location => !string.IsNullOrWhiteSpace(location) && File.Exists(location))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(location => (MetadataReference)MetadataReference.CreateFromFile(location))
+            .ToList();
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "LgymApi.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to locate repository root.");
+    }
+
+    private static bool IsInBuildArtifacts(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        return normalized.Contains("/bin/", StringComparison.OrdinalIgnoreCase)
+            || normalized.Contains("/obj/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed record Violation(string File, int Line, string TypeName)
+    {
+        public override string ToString() => $"{File}:{Line} {TypeName} does not inherit ControllerBase";
+    }
+}

--- a/LgymApi.ArchitectureTests/FeatureLocationExclusivityGuardTests.cs
+++ b/LgymApi.ArchitectureTests/FeatureLocationExclusivityGuardTests.cs
@@ -1,0 +1,322 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using LgymApi.Api.Interfaces;
+
+namespace LgymApi.ArchitectureTests;
+
+[TestFixture]
+public sealed class FeatureLocationExclusivityGuardTests
+{
+    [Test]
+    public void ContractDto_Types_Only_Appear_Under_Contracts()
+    {
+        var (repoRoot, compilation, syntaxTrees) = PrepareCompilation();
+        var idtoSymbol = compilation.GetTypeByMetadataName(typeof(IDto).FullName!);
+        var resultDtoSymbol = compilation.GetTypeByMetadataName(typeof(IResultDto).FullName!);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(idtoSymbol, Is.Not.Null, "Unable to resolve IDto symbol.");
+            Assert.That(resultDtoSymbol, Is.Not.Null, "Unable to resolve IResultDto symbol.");
+        });
+
+        var violations = new List<Violation>();
+
+        foreach (var tree in syntaxTrees)
+        {
+            var semanticModel = compilation.GetSemanticModel(tree, ignoreAccessibility: true);
+            var root = tree.GetCompilationUnitRoot();
+
+            foreach (var typeDeclaration in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+            {
+                var typeSymbol = semanticModel.GetDeclaredSymbol(typeDeclaration) as INamedTypeSymbol;
+                if (typeSymbol == null)
+                {
+                    continue;
+                }
+
+                if (!IsProjectType(typeSymbol, compilation.Assembly))
+                {
+                    continue;
+                }
+
+                if (!ImplementsDtoInterface(typeSymbol, idtoSymbol!, resultDtoSymbol!))
+                {
+                    continue;
+                }
+
+                var filePath = tree.FilePath;
+                if (IsTestPath(filePath) || IsContractsPath(filePath))
+                {
+                    continue;
+                }
+
+                var line = typeDeclaration.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                var relativePath = Path.GetRelativePath(repoRoot, filePath);
+                violations.Add(new Violation(relativePath, line, typeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+            }
+        }
+
+        Assert.That(
+            violations,
+            Is.Empty,
+            "Types implementing IDto or IResultDto must be contained in Features/*/Contracts folders only." + Environment.NewLine +
+            string.Join(Environment.NewLine, violations.Select(v => v.ToString())));
+    }
+
+    [Test]
+    public void ControllerBase_Derived_Types_Only_Live_Under_Controllers()
+    {
+        var (repoRoot, compilation, syntaxTrees) = PrepareCompilation();
+        var controllerBaseSymbol = compilation.GetTypeByMetadataName(typeof(ControllerBase).FullName!);
+
+        Assert.That(controllerBaseSymbol, Is.Not.Null, "Unable to resolve ControllerBase symbol.");
+
+        var violations = new List<Violation>();
+
+        foreach (var tree in syntaxTrees)
+        {
+            var semanticModel = compilation.GetSemanticModel(tree, ignoreAccessibility: true);
+            var root = tree.GetCompilationUnitRoot();
+
+            foreach (var classDeclaration in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
+            {
+                var typeSymbol = semanticModel.GetDeclaredSymbol(classDeclaration) as INamedTypeSymbol;
+                if (typeSymbol == null)
+                {
+                    continue;
+                }
+
+                if (!IsProjectType(typeSymbol, compilation.Assembly))
+                {
+                    continue;
+                }
+
+                if (!InheritsFromControllerBase(typeSymbol, controllerBaseSymbol!))
+                {
+                    continue;
+                }
+
+                var filePath = tree.FilePath;
+                if (IsTestPath(filePath) || IsControllersPath(filePath))
+                {
+                    continue;
+                }
+
+                var line = classDeclaration.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                var relativePath = Path.GetRelativePath(repoRoot, filePath);
+                violations.Add(new Violation(relativePath, line, typeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+            }
+        }
+
+        Assert.That(
+            violations,
+            Is.Empty,
+            "Controllers inheriting ControllerBase must be declared only inside Features/*/Controllers folders." + Environment.NewLine +
+            string.Join(Environment.NewLine, violations.Select(v => v.ToString())));
+    }
+
+    [Test]
+    public void FluentValidation_Validators_Only_Live_Under_Validation()
+    {
+        var (repoRoot, compilation, syntaxTrees) = PrepareCompilation();
+        var abstractValidatorSymbol = compilation.GetTypeByMetadataName(typeof(AbstractValidator<>).FullName!);
+
+        Assert.That(abstractValidatorSymbol, Is.Not.Null, "Unable to resolve AbstractValidator<T> symbol.");
+
+        var violations = new List<Violation>();
+
+        foreach (var tree in syntaxTrees)
+        {
+            var semanticModel = compilation.GetSemanticModel(tree, ignoreAccessibility: true);
+            var root = tree.GetCompilationUnitRoot();
+
+            foreach (var classDeclaration in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
+            {
+                var typeSymbol = semanticModel.GetDeclaredSymbol(classDeclaration) as INamedTypeSymbol;
+                if (typeSymbol == null)
+                {
+                    continue;
+                }
+
+                if (!IsProjectType(typeSymbol, compilation.Assembly))
+                {
+                    continue;
+                }
+
+                if (!InheritsFromAbstractValidator(typeSymbol, abstractValidatorSymbol!))
+                {
+                    continue;
+                }
+
+                var filePath = tree.FilePath;
+                if (IsTestPath(filePath) || IsValidationPath(filePath))
+                {
+                    continue;
+                }
+
+                var line = classDeclaration.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                var relativePath = Path.GetRelativePath(repoRoot, filePath);
+                violations.Add(new Violation(relativePath, line, typeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+            }
+        }
+
+        Assert.That(
+            violations,
+            Is.Empty,
+            "FluentValidation validators inheriting AbstractValidator<T> must live only within Features/*/Validation folders." + Environment.NewLine +
+            string.Join(Environment.NewLine, violations.Select(v => v.ToString())));
+    }
+
+    private static (string RepoRoot, CSharpCompilation Compilation, IReadOnlyList<SyntaxTree> SyntaxTrees) PrepareCompilation()
+    {
+        var repoRoot = ResolveRepositoryRoot();
+        var apiRoot = Path.Combine(repoRoot, "LgymApi.Api");
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+
+        Assert.That(Directory.Exists(apiRoot), Is.True, $"Api project directory '{apiRoot}' does not exist.");
+
+        var sourceFiles = Directory
+            .EnumerateFiles(apiRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsInBuildArtifacts(path))
+            .ToList();
+
+        Assert.That(sourceFiles, Is.Not.Empty, $"No source files found in '{apiRoot}'.");
+
+        var syntaxTrees = sourceFiles
+            .Select(path => CSharpSyntaxTree.ParseText(File.ReadAllText(path), options: parseOptions, path: path))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            "FeatureLocationExclusivityGuard",
+            syntaxTrees,
+            ResolveMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        return (repoRoot, compilation, syntaxTrees);
+    }
+
+    private static bool ImplementsDtoInterface(INamedTypeSymbol typeSymbol, INamedTypeSymbol idtoSymbol, INamedTypeSymbol resultDtoSymbol)
+    {
+        if (typeSymbol.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, idtoSymbol)))
+        {
+            return true;
+        }
+
+        return typeSymbol.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, resultDtoSymbol));
+    }
+
+    private static bool InheritsFromControllerBase(INamedTypeSymbol typeSymbol, INamedTypeSymbol controllerBaseSymbol)
+    {
+        var current = typeSymbol;
+        while (current.BaseType != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current.BaseType, controllerBaseSymbol))
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    private static bool InheritsFromAbstractValidator(INamedTypeSymbol typeSymbol, INamedTypeSymbol abstractValidatorSymbol)
+    {
+        var current = typeSymbol.BaseType;
+        while (current != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, abstractValidatorSymbol))
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    private static bool IsProjectType(INamedTypeSymbol typeSymbol, IAssemblySymbol projectAssembly)
+    {
+        return SymbolEqualityComparer.Default.Equals(typeSymbol.ContainingAssembly, projectAssembly);
+    }
+
+    private static bool IsContractsPath(string path)
+    {
+        var normalized = Normalize(path);
+        return normalized.Contains("/features/", StringComparison.OrdinalIgnoreCase)
+            && normalized.Contains("/contracts/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsControllersPath(string path)
+    {
+        var normalized = Normalize(path);
+        return normalized.Contains("/features/", StringComparison.OrdinalIgnoreCase)
+            && normalized.Contains("/controllers/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsValidationPath(string path)
+    {
+        var normalized = Normalize(path);
+        return normalized.Contains("/features/", StringComparison.OrdinalIgnoreCase)
+            && normalized.Contains("/validation/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsTestPath(string path)
+    {
+        var normalized = Normalize(path);
+        return normalized.Contains("/tests/", StringComparison.OrdinalIgnoreCase)
+            || normalized.Contains("/unittests/", StringComparison.OrdinalIgnoreCase)
+            || normalized.Contains("/architecturetests/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Normalize(string path)
+    {
+        return path.Replace('\\', '/');
+    }
+
+    private static List<MetadataReference> ResolveMetadataReferences()
+    {
+        return AppDomain.CurrentDomain
+            .GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic)
+            .Select(assembly => assembly.Location)
+            .Where(location => !string.IsNullOrWhiteSpace(location) && File.Exists(location))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(location => (MetadataReference)MetadataReference.CreateFromFile(location))
+            .ToList();
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "LgymApi.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to locate repository root.");
+    }
+
+    private static bool IsInBuildArtifacts(string path)
+    {
+        var normalized = Normalize(path);
+        return normalized.Contains("/bin/", StringComparison.OrdinalIgnoreCase)
+            || normalized.Contains("/obj/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed record Violation(string File, int Line, string TypeName)
+    {
+        public override string ToString() => $"{File}:{Line} {TypeName}";
+    }
+}

--- a/LgymApi.ArchitectureTests/ValidationInheritanceGuardTests.cs
+++ b/LgymApi.ArchitectureTests/ValidationInheritanceGuardTests.cs
@@ -1,0 +1,161 @@
+using FluentValidation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LgymApi.ArchitectureTests;
+
+[TestFixture]
+public sealed class ValidationInheritanceGuardTests
+{
+    [Test]
+    public void ValidationClasses_Should_Inherit_AbstractValidator()
+    {
+        var repoRoot = ResolveRepositoryRoot();
+        var apiRoot = Path.Combine(repoRoot, "LgymApi.Api");
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+
+        Assert.That(Directory.Exists(apiRoot), Is.True, $"Api project directory '{apiRoot}' does not exist.");
+
+        var sourceFiles = Directory
+            .EnumerateFiles(apiRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsInBuildArtifacts(path))
+            .ToList();
+
+        Assert.That(sourceFiles, Is.Not.Empty, $"No source files found in '{apiRoot}'.");
+
+        var syntaxTrees = sourceFiles
+            .Select(path => CSharpSyntaxTree.ParseText(File.ReadAllText(path), options: parseOptions, path: path))
+            .ToList();
+
+        foreach (var tree in syntaxTrees)
+        {
+            var parseErrors = tree
+                .GetDiagnostics()
+                .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                .ToList();
+
+            Assert.That(
+                parseErrors,
+                Is.Empty,
+                $"Failed to parse source file '{tree.FilePath}':{Environment.NewLine}{string.Join(Environment.NewLine, parseErrors)}");
+        }
+
+        var compilation = CSharpCompilation.Create(
+            "ValidationInheritanceGuard",
+            syntaxTrees,
+            ResolveMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var abstractValidatorSymbol = compilation.GetTypeByMetadataName(typeof(AbstractValidator<>).FullName!);
+
+        Assert.That(abstractValidatorSymbol, Is.Not.Null, "Unable to resolve AbstractValidator symbol.");
+
+        var validationTrees = syntaxTrees.Where(tree => IsValidationPath(tree.FilePath)).ToList();
+        Assert.That(validationTrees, Is.Not.Empty, "No validator files found for analysis.");
+
+        var violations = new List<Violation>();
+
+        foreach (var tree in validationTrees)
+        {
+            var semanticModel = compilation.GetSemanticModel(tree, ignoreAccessibility: true);
+            var root = tree.GetCompilationUnitRoot();
+
+            foreach (var classDeclaration in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
+            {
+                var typeSymbol = semanticModel.GetDeclaredSymbol(classDeclaration) as INamedTypeSymbol;
+                if (typeSymbol == null)
+                {
+                    continue;
+                }
+
+                if (!IsProjectType(typeSymbol, compilation.Assembly))
+                {
+                    continue;
+                }
+
+                if (InheritsFromAbstractValidator(typeSymbol, abstractValidatorSymbol!))
+                {
+                    continue;
+                }
+
+                var line = classDeclaration.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                var relativePath = Path.GetRelativePath(repoRoot, tree.FilePath);
+                violations.Add(new Violation(relativePath, line, typeSymbol.Name));
+            }
+        }
+
+        Assert.That(
+            violations,
+            Is.Empty,
+            "Every class declared under Features/*/Validation must inherit AbstractValidator<T>." + Environment.NewLine +
+            string.Join(Environment.NewLine, violations.Select(v => v.ToString())));
+    }
+
+    private static bool InheritsFromAbstractValidator(INamedTypeSymbol typeSymbol, INamedTypeSymbol abstractValidatorSymbol)
+    {
+        var current = typeSymbol.BaseType;
+        while (current != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, abstractValidatorSymbol))
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    private static bool IsProjectType(INamedTypeSymbol typeSymbol, IAssemblySymbol projectAssembly)
+    {
+        return SymbolEqualityComparer.Default.Equals(typeSymbol.ContainingAssembly, projectAssembly);
+    }
+
+    private static bool IsValidationPath(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        return normalized.Contains("/Features/") && normalized.Contains("/Validation/");
+    }
+
+    private static List<MetadataReference> ResolveMetadataReferences()
+    {
+        return AppDomain.CurrentDomain
+            .GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic)
+            .Select(assembly => assembly.Location)
+            .Where(location => !string.IsNullOrWhiteSpace(location) && File.Exists(location))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(location => (MetadataReference)MetadataReference.CreateFromFile(location))
+            .ToList();
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "LgymApi.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to locate repository root.");
+    }
+
+    private static bool IsInBuildArtifacts(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        return normalized.Contains("/bin/", StringComparison.OrdinalIgnoreCase)
+            || normalized.Contains("/obj/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed record Violation(string File, int Line, string TypeName)
+    {
+        public override string ToString() => $"{File}:{Line} {TypeName} does not inherit AbstractValidator<T>";
+    }
+}


### PR DESCRIPTION
## Summary
- add Roslyn-based architecture guards that constrain Contracts, Controllers, and Validation folders
- enforce that all existing Contracts DTOs implement  or  and align dependent DTOs with 
- guarantee FluentValidation validators and controllers live under their respective folders through exclusivity checks

## Testing
- dotnet test LgymApi.ArchitectureTests/LgymApi.ArchitectureTests.csproj --filter FullyQualifiedName~Contracts_Should_Define_Only_IDto_Or_IResultDto