### PR TITLE
test: consolidate duplicated integration test scenarios with parameterized cases

### DIFF
--- a/LgymApi.ArchitectureTests/AdminFlagParameterizedGuardTests.cs
+++ b/LgymApi.ArchitectureTests/AdminFlagParameterizedGuardTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LgymApi.ArchitectureTests;
+
+[TestFixture]
+public sealed class AdminFlagParameterizedGuardTests
+{
+    private static readonly string[] LegacyDuplicatedMethodNames =
+    [
+        "IsAdmin_WithNonAdminUser_ReturnsFalse",
+        "IsAdmin_WithNullAdminFlag_ReturnsFalse",
+        "IsAdmin_WithNonExistentUser_ReturnsFalse",
+        "IsAdmin_WithInvalidGuidFormat_ReturnsFalse"
+    ];
+
+    [Test]
+    public void AdminFlagValidation_Should_UseParameterizedTestCases()
+    {
+        var repoRoot = ResolveRepositoryRoot();
+        var filePath = Path.Combine(repoRoot, "LgymApi.IntegrationTests", "AdminFlagTests.cs");
+
+        Assert.That(File.Exists(filePath), Is.True, $"Required test file '{filePath}' was not found.");
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(File.ReadAllText(filePath), path: filePath);
+        var root = syntaxTree.GetCompilationUnitRoot();
+
+        var methods = root.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
+
+        // Guard 1: No legacy duplicated methods exist as standalone methods
+        var legacyMethods = methods
+            .Where(method => LegacyDuplicatedMethodNames.Contains(method.Identifier.Text, StringComparer.Ordinal))
+            .ToList();
+
+        Assert.That(
+            legacyMethods,
+            Is.Empty,
+            "Duplicated AdminFlag IsAdmin methods were reintroduced. Use a single parameterized test with [TestCaseSource].");
+
+        // Guard 2: Parameterized test method exists
+        var parameterizedMethod = methods.FirstOrDefault(method => method.Identifier.Text == "IsAdmin_WithVariousNonAdminScenarios_ReturnsFalse");
+        Assert.That(
+            parameterizedMethod,
+            Is.Not.Null,
+            "Expected parameterized method 'IsAdmin_WithVariousNonAdminScenarios_ReturnsFalse' was not found.");
+
+        // Guard 3: TestCaseSource method exists and contains SetName calls covering all legacy scenarios
+        var sourceMethod = methods.FirstOrDefault(method => method.Identifier.Text == "IsAdmin_FalseResultCases");
+        Assert.That(
+            sourceMethod,
+            Is.Not.Null,
+            "Expected TestCaseSource method 'IsAdmin_FalseResultCases' was not found.");
+
+        var setNames = ExtractSetNameValues(sourceMethod!);
+        Assert.That(
+            setNames,
+            Is.SupersetOf(LegacyDuplicatedMethodNames),
+            "The AdminFlag TestCaseSource must preserve all original IsAdmin false-returning scenarios via .SetName().");
+    }
+
+    private static HashSet<string> ExtractSetNameValues(MethodDeclarationSyntax method)
+    {
+        return method.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(invocation => invocation.Expression is MemberAccessExpressionSyntax memberAccess
+                && memberAccess.Name.Identifier.Text == "SetName")
+            .SelectMany(invocation => invocation.ArgumentList.Arguments)
+            .Select(arg => arg.Expression)
+            .OfType<LiteralExpressionSyntax>()
+            .Where(literal => literal.Kind() == SyntaxKind.StringLiteralExpression)
+            .Select(literal => literal.Token.ValueText)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "LgymApi.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to locate repository root.");
+    }
+}

--- a/LgymApi.ArchitectureTests/AppConfigPlatformValidationParameterizedGuardTests.cs
+++ b/LgymApi.ArchitectureTests/AppConfigPlatformValidationParameterizedGuardTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LgymApi.ArchitectureTests;
+
+[TestFixture]
+public sealed class AppConfigPlatformValidationParameterizedGuardTests
+{
+    private static readonly string[] LegacyGetMethodNames =
+    [
+        "GetAppVersion_WithInvalidPlatform_ReturnsBadRequest",
+        "GetAppVersion_WithMissingPlatform_ReturnsBadRequest",
+        "GetAppVersion_WithNumericPlatform_ReturnsBadRequest"
+    ];
+
+    private static readonly string[] LegacyCreateMethodNames =
+    [
+        "CreateNewAppVersion_WithInvalidPlatform_ReturnsBadRequest",
+        "CreateNewAppVersion_WithMissingPlatform_ReturnsBadRequest",
+        "CreateNewAppVersion_WithNumericPlatform_ReturnsBadRequest"
+    ];
+
+    [Test]
+    public void AppConfigPlatformValidation_Should_UseParameterizedTestCases()
+    {
+        var repoRoot = ResolveRepositoryRoot();
+        var filePath = Path.Combine(repoRoot, "LgymApi.IntegrationTests", "AppConfigTests.cs");
+
+        Assert.That(File.Exists(filePath), Is.True, $"Required test file '{filePath}' was not found.");
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(File.ReadAllText(filePath), path: filePath);
+        var root = syntaxTree.GetCompilationUnitRoot();
+
+        var methods = root.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
+        var allLegacyNames = LegacyGetMethodNames.Concat(LegacyCreateMethodNames).ToArray();
+
+        // Guard 1: No legacy duplicated methods exist as standalone methods
+        var legacyMethods = methods
+            .Where(method => allLegacyNames.Contains(method.Identifier.Text, StringComparer.Ordinal))
+            .ToList();
+
+        Assert.That(
+            legacyMethods,
+            Is.Empty,
+            "Duplicated AppConfig platform validation methods were reintroduced. Use parameterized tests with [TestCaseSource].");
+
+        // Guard 2: Parameterized test methods exist
+        var getMethod = methods.FirstOrDefault(method => method.Identifier.Text == "GetAppVersion_WithInvalidPlatformData_ReturnsBadRequest");
+        Assert.That(
+            getMethod,
+            Is.Not.Null,
+            "Expected parameterized method 'GetAppVersion_WithInvalidPlatformData_ReturnsBadRequest' was not found.");
+
+        var createMethod = methods.FirstOrDefault(method => method.Identifier.Text == "CreateNewAppVersion_WithInvalidPlatformData_ReturnsBadRequest");
+        Assert.That(
+            createMethod,
+            Is.Not.Null,
+            "Expected parameterized method 'CreateNewAppVersion_WithInvalidPlatformData_ReturnsBadRequest' was not found.");
+
+        // Guard 3: TestCaseSource methods exist and contain SetName calls covering all legacy scenarios
+        var allMethodsAndMembers = root.DescendantNodes();
+
+        var getSourceMethod = methods.FirstOrDefault(method => method.Identifier.Text == "GetAppVersion_InvalidPlatformCases");
+        Assert.That(
+            getSourceMethod,
+            Is.Not.Null,
+            "Expected TestCaseSource method 'GetAppVersion_InvalidPlatformCases' was not found.");
+
+        var getSetNames = ExtractSetNameValues(getSourceMethod!);
+        Assert.That(
+            getSetNames,
+            Is.SupersetOf(LegacyGetMethodNames),
+            "The GetAppVersion TestCaseSource must preserve all original GET scenarios via .SetName().");
+
+        var createSourceMethod = methods.FirstOrDefault(method => method.Identifier.Text == "CreateNewAppVersion_InvalidPlatformCases");
+        Assert.That(
+            createSourceMethod,
+            Is.Not.Null,
+            "Expected TestCaseSource method 'CreateNewAppVersion_InvalidPlatformCases' was not found.");
+
+        var createSetNames = ExtractSetNameValues(createSourceMethod!);
+        Assert.That(
+            createSetNames,
+            Is.SupersetOf(LegacyCreateMethodNames),
+            "The CreateNewAppVersion TestCaseSource must preserve all original CREATE scenarios via .SetName().");
+    }
+
+    private static HashSet<string> ExtractSetNameValues(MethodDeclarationSyntax method)
+    {
+        return method.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(invocation => invocation.Expression is MemberAccessExpressionSyntax memberAccess
+                && memberAccess.Name.Identifier.Text == "SetName")
+            .SelectMany(invocation => invocation.ArgumentList.Arguments)
+            .Select(arg => arg.Expression)
+            .OfType<LiteralExpressionSyntax>()
+            .Where(literal => literal.Kind() == SyntaxKind.StringLiteralExpression)
+            .Select(literal => literal.Token.ValueText)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "LgymApi.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to locate repository root.");
+    }
+}

--- a/LgymApi.ArchitectureTests/DashboardValidationParameterizedGuardTests.cs
+++ b/LgymApi.ArchitectureTests/DashboardValidationParameterizedGuardTests.cs
@@ -1,0 +1,105 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LgymApi.ArchitectureTests;
+
+[TestFixture]
+public sealed class DashboardValidationParameterizedGuardTests
+{
+    private static readonly string[] LegacyDuplicatedMethodNames =
+    [
+        "GetDashboardTrainees_WithInvalidSortBy_ReturnsBadRequestWithResourceMessage",
+        "GetDashboardTrainees_WithInvalidStatus_ReturnsBadRequestWithResourceMessage",
+        "GetDashboardTrainees_WithInvalidPage_ReturnsBadRequestWithResourceMessage",
+        "GetDashboardTrainees_WithTooLargePage_ReturnsBadRequestWithResourceMessage",
+        "GetDashboardTrainees_WithInvalidSortDirection_ReturnsBadRequestWithResourceMessage"
+    ];
+
+    [Test]
+    public void DashboardValidation_Should_UseParameterizedTestCases()
+    {
+        var repoRoot = ResolveRepositoryRoot();
+        var filePath = Path.Combine(repoRoot, "LgymApi.IntegrationTests", "TrainerRelationshipTests.cs");
+
+        Assert.That(File.Exists(filePath), Is.True, $"Required test file '{filePath}' was not found.");
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(File.ReadAllText(filePath), path: filePath);
+        var root = syntaxTree.GetCompilationUnitRoot();
+
+        var methods = root.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
+
+        var legacyMethods = methods
+            .Where(method => LegacyDuplicatedMethodNames.Contains(method.Identifier.Text, StringComparer.Ordinal))
+            .ToList();
+
+        Assert.That(
+            legacyMethods,
+            Is.Empty,
+            "Duplicated dashboard validation methods were reintroduced. Use a single parameterized test with [TestCase] attributes.");
+
+        var parameterizedMethod = methods.FirstOrDefault(method => method.Identifier.Text == "GetDashboardTrainees_WithInvalidQueryParam_ReturnsBadRequestWithResourceMessage");
+
+        Assert.That(
+            parameterizedMethod,
+            Is.Not.Null,
+            "Expected parameterized method 'GetDashboardTrainees_WithInvalidQueryParam_ReturnsBadRequestWithResourceMessage' was not found.");
+
+        var testCaseNames = parameterizedMethod!
+            .AttributeLists
+            .SelectMany(list => list.Attributes)
+            .Where(attribute => IsTestCaseAttribute(attribute.Name.ToString()))
+            .Select(attribute => attribute.ArgumentList?.Arguments
+                .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "TestName")
+                ?.Expression
+            )
+            .Select(ExtractTestName)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(name => name!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.That(
+            testCaseNames,
+            Is.SupersetOf(LegacyDuplicatedMethodNames),
+            "The parameterized dashboard validation test must preserve all original scenarios.");
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "LgymApi.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to locate repository root.");
+    }
+
+    private static bool IsTestCaseAttribute(string attributeName)
+    {
+        return attributeName.EndsWith("TestCase", StringComparison.Ordinal)
+            || attributeName.EndsWith("TestCaseAttribute", StringComparison.Ordinal);
+    }
+
+    private static string? ExtractTestName(ExpressionSyntax? expression)
+    {
+        if (expression is LiteralExpressionSyntax literal && literal.Kind() == SyntaxKind.StringLiteralExpression)
+        {
+            return literal.Token.ValueText;
+        }
+
+        if (expression is InvocationExpressionSyntax invocation
+            && invocation.Expression is IdentifierNameSyntax identifier
+            && identifier.Identifier.Text == "nameof"
+            && invocation.ArgumentList.Arguments.Count == 1)
+        {
+            return invocation.ArgumentList.Arguments[0].Expression.ToString();
+        }
+
+        return expression?.ToString().Trim('"');
+    }
+}

--- a/LgymApi.ArchitectureTests/RegistrationValidationParameterizedGuardTests.cs
+++ b/LgymApi.ArchitectureTests/RegistrationValidationParameterizedGuardTests.cs
@@ -1,0 +1,104 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LgymApi.ArchitectureTests;
+
+[TestFixture]
+public sealed class RegistrationValidationParameterizedGuardTests
+{
+    private static readonly string[] LegacyDuplicatedMethodNames =
+    [
+        "Register_WithEmptyName_ReturnsError",
+        "Register_WithInvalidEmail_ReturnsError",
+        "Register_WithShortPassword_ReturnsError",
+        "Register_WithMismatchedPasswords_ReturnsError"
+    ];
+
+    [Test]
+    public void UserAuthRegistrationValidation_Should_UseParameterizedTestCases()
+    {
+        var repoRoot = ResolveRepositoryRoot();
+        var filePath = Path.Combine(repoRoot, "LgymApi.IntegrationTests", "UserAuthTests.cs");
+
+        Assert.That(File.Exists(filePath), Is.True, $"Required test file '{filePath}' was not found.");
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(File.ReadAllText(filePath), path: filePath);
+        var root = syntaxTree.GetCompilationUnitRoot();
+
+        var methods = root.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
+
+        var legacyMethods = methods
+            .Where(method => LegacyDuplicatedMethodNames.Contains(method.Identifier.Text, StringComparer.Ordinal))
+            .ToList();
+
+        Assert.That(
+            legacyMethods,
+            Is.Empty,
+            "Duplicated registration validation methods were reintroduced. Use a single parameterized test with [TestCase] attributes.");
+
+        var parameterizedMethod = methods.FirstOrDefault(method => method.Identifier.Text == "Register_WithInvalidData_ReturnsBadRequest");
+
+        Assert.That(
+            parameterizedMethod,
+            Is.Not.Null,
+            "Expected parameterized method 'Register_WithInvalidData_ReturnsBadRequest' was not found.");
+
+        var testCaseNames = parameterizedMethod!
+            .AttributeLists
+            .SelectMany(list => list.Attributes)
+            .Where(attribute => IsTestCaseAttribute(attribute.Name.ToString()))
+            .Select(attribute => attribute.ArgumentList?.Arguments
+                .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "TestName")
+                ?.Expression
+            )
+            .Select(ExtractTestName)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(name => name!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.That(
+            testCaseNames,
+            Is.SupersetOf(LegacyDuplicatedMethodNames),
+            "The parameterized registration validation test must preserve all original scenarios.");
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "LgymApi.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to locate repository root.");
+    }
+
+    private static bool IsTestCaseAttribute(string attributeName)
+    {
+        return attributeName.EndsWith("TestCase", StringComparison.Ordinal)
+            || attributeName.EndsWith("TestCaseAttribute", StringComparison.Ordinal);
+    }
+
+    private static string? ExtractTestName(ExpressionSyntax? expression)
+    {
+        if (expression is LiteralExpressionSyntax literal && literal.Kind() == SyntaxKind.StringLiteralExpression)
+        {
+            return literal.Token.ValueText;
+        }
+
+        if (expression is InvocationExpressionSyntax invocation
+            && invocation.Expression is IdentifierNameSyntax identifier
+            && identifier.Identifier.Text == "nameof"
+            && invocation.ArgumentList.Arguments.Count == 1)
+        {
+            return invocation.ArgumentList.Arguments[0].Expression.ToString();
+        }
+
+        return expression?.ToString().Trim('"');
+    }
+}

--- a/LgymApi.IntegrationTests/AdminFlagTests.cs
+++ b/LgymApi.IntegrationTests/AdminFlagTests.cs
@@ -21,56 +21,49 @@ public sealed class AdminFlagTests : IntegrationTestBase
         result.Should().BeTrue();
     }
 
-    [Test]
-    public async Task IsAdmin_WithNonAdminUser_ReturnsFalse()
+    private static IEnumerable<TestCaseData> IsAdmin_FalseResultCases()
     {
-        var normalUser = await SeedUserAsync(name: "normaluser", email: "normal@example.com", isAdmin: false);
-        SetAuthorizationHeader(normalUser.Id);
+        yield return new TestCaseData(
+                new Func<AdminFlagTests, Task<(Guid authUserId, string queryId)>>(async self =>
+                {
+                    var user = await self.SeedUserAsync(name: "normaluser", email: "normal@example.com", isAdmin: false);
+                    return (user.Id, user.Id.ToString());
+                }))
+            .SetName("IsAdmin_WithNonAdminUser_ReturnsFalse");
 
-        var response = await Client.GetAsync($"/api/{normalUser.Id}/isAdmin");
+        yield return new TestCaseData(
+                new Func<AdminFlagTests, Task<(Guid authUserId, string queryId)>>(async self =>
+                {
+                    var user = await self.SeedUserAsync(name: "nulladmin", email: "nulladmin@example.com");
+                    return (user.Id, user.Id.ToString());
+                }))
+            .SetName("IsAdmin_WithNullAdminFlag_ReturnsFalse");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        yield return new TestCaseData(
+                new Func<AdminFlagTests, Task<(Guid authUserId, string queryId)>>(async self =>
+                {
+                    var user = await self.SeedUserAsync(name: "authuser", email: "auth-nonexistent@example.com");
+                    return (user.Id, Guid.NewGuid().ToString());
+                }))
+            .SetName("IsAdmin_WithNonExistentUser_ReturnsFalse");
 
-        var result = await response.Content.ReadFromJsonAsync<bool>();
-        result.Should().BeFalse();
+        yield return new TestCaseData(
+                new Func<AdminFlagTests, Task<(Guid authUserId, string queryId)>>(async self =>
+                {
+                    var user = await self.SeedUserAsync(name: "authuser", email: "auth-invalid@example.com");
+                    return (user.Id, "invalid-guid");
+                }))
+            .SetName("IsAdmin_WithInvalidGuidFormat_ReturnsFalse");
     }
 
-    [Test]
-    public async Task IsAdmin_WithNullAdminFlag_ReturnsFalse()
+    [TestCaseSource(nameof(IsAdmin_FalseResultCases))]
+    public async Task IsAdmin_WithVariousNonAdminScenarios_ReturnsFalse(
+        Func<AdminFlagTests, Task<(Guid authUserId, string queryId)>> setupAsync)
     {
-        var user = await SeedUserAsync(name: "nulladmin", email: "nulladmin@example.com");
-        SetAuthorizationHeader(user.Id);
+        var (authUserId, queryId) = await setupAsync(this);
+        SetAuthorizationHeader(authUserId);
 
-        var response = await Client.GetAsync($"/api/{user.Id}/isAdmin");
-
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var result = await response.Content.ReadFromJsonAsync<bool>();
-        result.Should().BeFalse();
-    }
-
-    [Test]
-    public async Task IsAdmin_WithNonExistentUser_ReturnsFalse()
-    {
-        var user = await SeedUserAsync(name: "authuser", email: "auth@example.com");
-        SetAuthorizationHeader(user.Id);
-
-        var nonExistentId = Guid.NewGuid();
-        var response = await Client.GetAsync($"/api/{nonExistentId}/isAdmin");
-
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var result = await response.Content.ReadFromJsonAsync<bool>();
-        result.Should().BeFalse();
-    }
-
-    [Test]
-    public async Task IsAdmin_WithInvalidGuidFormat_ReturnsFalse()
-    {
-        var user = await SeedUserAsync(name: "authuser", email: "auth@example.com");
-        SetAuthorizationHeader(user.Id);
-
-        var response = await Client.GetAsync("/api/invalid-guid/isAdmin");
+        var response = await Client.GetAsync($"/api/{queryId}/isAdmin");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 

--- a/LgymApi.IntegrationTests/AppConfigTests.cs
+++ b/LgymApi.IntegrationTests/AppConfigTests.cs
@@ -42,26 +42,25 @@ public sealed class AppConfigTests : IntegrationTestBase
         body.ReleaseNotes.Should().Be("Bug fixes and improvements");
     }
 
-    [Test]
-    public async Task GetAppVersion_WithInvalidPlatform_ReturnsBadRequest()
+    private static IEnumerable<TestCaseData> GetAppVersion_InvalidPlatformCases()
     {
-        var user = await SeedUserAsync(name: "testuser", email: "test@example.com");
-        SetAuthorizationHeader(user.Id);
-
-        var request = new { platform = "InvalidPlatform" };
-        var response = await Client.PostAsJsonAsync("/api/appConfig/getAppVersion", request);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        yield return new TestCaseData(new { platform = "InvalidPlatform" })
+            .SetName("GetAppVersion_WithInvalidPlatform_ReturnsBadRequest");
+        yield return new TestCaseData(new { })
+            .SetName("GetAppVersion_WithMissingPlatform_ReturnsBadRequest");
+        yield return new TestCaseData(new { platform = 1 })
+            .SetName("GetAppVersion_WithNumericPlatform_ReturnsBadRequest");
     }
 
-    [Test]
-    public async Task GetAppVersion_WithMissingPlatform_ReturnsBadRequest()
+    [TestCaseSource(nameof(GetAppVersion_InvalidPlatformCases))]
+    public async Task GetAppVersion_WithInvalidPlatformData_ReturnsBadRequest(object requestBody)
     {
-        var user = await SeedUserAsync(name: "testuser", email: "test@example.com");
+        var user = await SeedUserAsync(
+            name: $"testuser-{TestContext.CurrentContext.Test.Name}",
+            email: $"test-{Guid.NewGuid():N}@example.com");
         SetAuthorizationHeader(user.Id);
 
-        var request = new { };
-        var response = await Client.PostAsJsonAsync("/api/appConfig/getAppVersion", request);
+        var response = await Client.PostAsJsonAsync("/api/appConfig/getAppVersion", requestBody);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
@@ -148,37 +147,34 @@ public sealed class AppConfigTests : IntegrationTestBase
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
-    [Test]
-    public async Task CreateNewAppVersion_WithInvalidPlatform_ReturnsBadRequest()
+    private static IEnumerable<TestCaseData> CreateNewAppVersion_InvalidPlatformCases()
     {
-        var admin = await SeedAdminAsync();
-        SetAuthorizationHeader(admin.Id);
-
-        var request = new
+        yield return new TestCaseData(new
         {
             platform = "InvalidPlatform",
             minRequiredVersion = "1.0.0",
             latestVersion = "2.0.0"
-        };
-
-        var response = await Client.PostAsJsonAsync($"/api/appConfig/createNewAppVersion/{admin.Id}", request);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }).SetName("CreateNewAppVersion_WithInvalidPlatform_ReturnsBadRequest");
+        yield return new TestCaseData(new
+        {
+            minRequiredVersion = "1.0.0",
+            latestVersion = "2.0.0"
+        }).SetName("CreateNewAppVersion_WithMissingPlatform_ReturnsBadRequest");
+        yield return new TestCaseData(new
+        {
+            platform = 1,
+            minRequiredVersion = "1.0.0",
+            latestVersion = "2.0.0"
+        }).SetName("CreateNewAppVersion_WithNumericPlatform_ReturnsBadRequest");
     }
 
-    [Test]
-    public async Task CreateNewAppVersion_WithMissingPlatform_ReturnsBadRequest()
+    [TestCaseSource(nameof(CreateNewAppVersion_InvalidPlatformCases))]
+    public async Task CreateNewAppVersion_WithInvalidPlatformData_ReturnsBadRequest(object requestBody)
     {
         var admin = await SeedAdminAsync();
         SetAuthorizationHeader(admin.Id);
 
-        var request = new
-        {
-            minRequiredVersion = "1.0.0",
-            latestVersion = "2.0.0"
-        };
-
-        var response = await Client.PostAsJsonAsync($"/api/appConfig/createNewAppVersion/{admin.Id}", request);
+        var response = await Client.PostAsJsonAsync($"/api/appConfig/createNewAppVersion/{admin.Id}", requestBody);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
@@ -217,36 +213,6 @@ public sealed class AppConfigTests : IntegrationTestBase
         body!.LatestVersion.Should().Be("2.0.0");
         body.MinRequiredVersion.Should().Be("1.5.0");
         body.ForceUpdate.Should().BeTrue();
-    }
-
-    [Test]
-    public async Task GetAppVersion_WithNumericPlatform_ReturnsBadRequest()
-    {
-        var user = await SeedUserAsync(name: "testuser2", email: "test2@example.com");
-        SetAuthorizationHeader(user.Id);
-
-        var request = new { platform = 1 };
-        var response = await Client.PostAsJsonAsync("/api/appConfig/getAppVersion", request);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-    }
-
-    [Test]
-    public async Task CreateNewAppVersion_WithNumericPlatform_ReturnsBadRequest()
-    {
-        var admin = await SeedAdminAsync();
-        SetAuthorizationHeader(admin.Id);
-
-        var request = new
-        {
-            platform = 1,
-            minRequiredVersion = "1.0.0",
-            latestVersion = "2.0.0"
-        };
-
-        var response = await Client.PostAsJsonAsync($"/api/appConfig/createNewAppVersion/{admin.Id}", request);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     private sealed class MessageResponse

--- a/LgymApi.IntegrationTests/TrainerRelationshipTests.cs
+++ b/LgymApi.IntegrationTests/TrainerRelationshipTests.cs
@@ -588,13 +588,18 @@ public sealed class TrainerRelationshipTests : IntegrationTestBase
         body.Items.Should().ContainSingle(x => x.Id == matching.Id.ToString());
     }
 
-    [Test]
-    public async Task GetDashboardTrainees_WithInvalidSortBy_ReturnsBadRequestWithResourceMessage()
+    [TestCase("sortBy=unknown", nameof(Messages.DashboardSortByInvalid), TestName = "GetDashboardTrainees_WithInvalidSortBy_ReturnsBadRequestWithResourceMessage")]
+    [TestCase("status=NotAStatus", nameof(Messages.DashboardStatusInvalid), TestName = "GetDashboardTrainees_WithInvalidStatus_ReturnsBadRequestWithResourceMessage")]
+    [TestCase("page=0", nameof(Messages.DashboardPageRange), TestName = "GetDashboardTrainees_WithInvalidPage_ReturnsBadRequestWithResourceMessage")]
+    [TestCase("page=21474838", nameof(Messages.DashboardPageRange), TestName = "GetDashboardTrainees_WithTooLargePage_ReturnsBadRequestWithResourceMessage")]
+    [TestCase("sortDirection=invalid", nameof(Messages.DashboardSortDirectionInvalid), TestName = "GetDashboardTrainees_WithInvalidSortDirection_ReturnsBadRequestWithResourceMessage")]
+    public async Task GetDashboardTrainees_WithInvalidQueryParam_ReturnsBadRequestWithResourceMessage(string queryString, string expectedMessagePropertyName)
     {
-        var trainer = await SeedTrainerAsync("trainer-dashboard-invalid-sort", "trainer-dashboard-invalid-sort@example.com");
+        var uniqueKey = queryString.Replace("=", "-").Replace("&", "-");
+        var trainer = await SeedTrainerAsync($"trainer-dashboard-{uniqueKey}", $"trainer-dashboard-{Guid.NewGuid():N}@example.com");
         SetAuthorizationHeader(trainer.Id);
 
-        var response = await Client.GetAsync("/api/trainer/trainees?sortBy=unknown");
+        var response = await Client.GetAsync($"/api/trainer/trainees?{queryString}");
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var responseBody = await response.Content.ReadAsStringAsync();
@@ -604,82 +609,8 @@ public sealed class TrainerRelationshipTests : IntegrationTestBase
         {
             CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
             CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
-            responseBody.Should().Contain(Messages.DashboardSortByInvalid);
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = originalCulture;
-            CultureInfo.CurrentUICulture = originalUiCulture;
-        }
-    }
-
-    [Test]
-    public async Task GetDashboardTrainees_WithInvalidStatus_ReturnsBadRequestWithResourceMessage()
-    {
-        var trainer = await SeedTrainerAsync("trainer-dashboard-invalid-status", "trainer-dashboard-invalid-status@example.com");
-        SetAuthorizationHeader(trainer.Id);
-
-        var response = await Client.GetAsync("/api/trainer/trainees?status=NotAStatus");
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var responseBody = await response.Content.ReadAsStringAsync();
-        var originalCulture = CultureInfo.CurrentCulture;
-        var originalUiCulture = CultureInfo.CurrentUICulture;
-        try
-        {
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
-            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
-            responseBody.Should().Contain(Messages.DashboardStatusInvalid);
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = originalCulture;
-            CultureInfo.CurrentUICulture = originalUiCulture;
-        }
-    }
-
-    [Test]
-    public async Task GetDashboardTrainees_WithInvalidPage_ReturnsBadRequestWithResourceMessage()
-    {
-        var trainer = await SeedTrainerAsync("trainer-dashboard-invalid-page", "trainer-dashboard-invalid-page@example.com");
-        SetAuthorizationHeader(trainer.Id);
-
-        var response = await Client.GetAsync("/api/trainer/trainees?page=0");
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var responseBody = await response.Content.ReadAsStringAsync();
-        var originalCulture = CultureInfo.CurrentCulture;
-        var originalUiCulture = CultureInfo.CurrentUICulture;
-        try
-        {
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
-            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
-            responseBody.Should().Contain(Messages.DashboardPageRange);
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = originalCulture;
-            CultureInfo.CurrentUICulture = originalUiCulture;
-        }
-    }
-
-    [Test]
-    public async Task GetDashboardTrainees_WithTooLargePage_ReturnsBadRequestWithResourceMessage()
-    {
-        var trainer = await SeedTrainerAsync("trainer-dashboard-invalid-page-max", "trainer-dashboard-invalid-page-max@example.com");
-        SetAuthorizationHeader(trainer.Id);
-
-        var response = await Client.GetAsync("/api/trainer/trainees?page=21474838");
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var responseBody = await response.Content.ReadAsStringAsync();
-        var originalCulture = CultureInfo.CurrentCulture;
-        var originalUiCulture = CultureInfo.CurrentUICulture;
-        try
-        {
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
-            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
-            responseBody.Should().Contain(Messages.DashboardPageRange);
+            var expectedMessage = typeof(Messages).GetProperty(expectedMessagePropertyName)!.GetValue(null) as string;
+            responseBody.Should().Contain(expectedMessage!);
         }
         finally
         {
@@ -707,31 +638,6 @@ public sealed class TrainerRelationshipTests : IntegrationTestBase
             CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
             CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
             responseBody.Should().Contain(Messages.DashboardPageSizeRange);
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = originalCulture;
-            CultureInfo.CurrentUICulture = originalUiCulture;
-        }
-    }
-
-    [Test]
-    public async Task GetDashboardTrainees_WithInvalidSortDirection_ReturnsBadRequestWithResourceMessage()
-    {
-        var trainer = await SeedTrainerAsync("trainer-dashboard-invalid-sortdir", "trainer-dashboard-invalid-sortdir@example.com");
-        SetAuthorizationHeader(trainer.Id);
-
-        var response = await Client.GetAsync("/api/trainer/trainees?sortDirection=invalid");
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var responseBody = await response.Content.ReadAsStringAsync();
-        var originalCulture = CultureInfo.CurrentCulture;
-        var originalUiCulture = CultureInfo.CurrentUICulture;
-        try
-        {
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
-            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
-            responseBody.Should().Contain(Messages.DashboardSortDirectionInvalid);
         }
         finally
         {

--- a/LgymApi.IntegrationTests/UserAuthTests.cs
+++ b/LgymApi.IntegrationTests/UserAuthTests.cs
@@ -163,63 +163,18 @@ public sealed class UserAuthTests : IntegrationTestBase
         emailLog.PayloadJson.Should().Contain("pl-PL");
         // Optionally check the subject/body if stored; else, template test ensures content.
     }
-    [Test]
-    public async Task Register_WithEmptyName_ReturnsError()
+    [TestCase("", "test@example.com", "password123", "password123", TestName = "Register_WithEmptyName_ReturnsError")]
+    [TestCase("testuser", "invalid-email", "password123", "password123", TestName = "Register_WithInvalidEmail_ReturnsError")]
+    [TestCase("testuser", "test@example.com", "12345", "12345", TestName = "Register_WithShortPassword_ReturnsError")]
+    [TestCase("testuser", "test@example.com", "password123", "differentpassword", TestName = "Register_WithMismatchedPasswords_ReturnsError")]
+    public async Task Register_WithInvalidData_ReturnsBadRequest(string name, string email, string password, string cpassword)
     {
         var request = new
         {
-            name = "",
-            email = "test@example.com",
-            password = "password123",
-            cpassword = "password123"
-        };
-
-        var response = await Client.PostAsJsonAsync("/api/register", request);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-    }
-
-    [Test]
-    public async Task Register_WithInvalidEmail_ReturnsError()
-    {
-        var request = new
-        {
-            name = "testuser",
-            email = "invalid-email",
-            password = "password123",
-            cpassword = "password123"
-        };
-
-        var response = await Client.PostAsJsonAsync("/api/register", request);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-    }
-
-    [Test]
-    public async Task Register_WithShortPassword_ReturnsError()
-    {
-        var request = new
-        {
-            name = "testuser",
-            email = "test@example.com",
-            password = "12345",
-            cpassword = "12345"
-        };
-
-        var response = await Client.PostAsJsonAsync("/api/register", request);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-    }
-
-    [Test]
-    public async Task Register_WithMismatchedPasswords_ReturnsError()
-    {
-        var request = new
-        {
-            name = "testuser",
-            email = "test@example.com",
-            password = "password123",
-            cpassword = "differentpassword"
+            name,
+            email,
+            password,
+            cpassword
         };
 
         var response = await Client.PostAsJsonAsync("/api/register", request);


### PR DESCRIPTION
## Summary
- Consolidate repeated invalid-input integration tests into parameterized NUnit coverage across `UserAuthTests`, `TrainerRelationshipTests`, `AppConfigTests`, and `AdminFlagTests`, preserving legacy scenario names via `TestName`/`SetName`.
- Add Roslyn architecture guards to enforce that legacy duplicate methods do not return and that each parameterized replacement maintains full scenario coverage.
- Verify no regression by running architecture and integration test suites after refactor.

## Verification
- `dotnet build LgymApi.ArchitectureTests/LgymApi.ArchitectureTests.csproj --no-restore`
- `dotnet test LgymApi.ArchitectureTests/LgymApi.ArchitectureTests.csproj --no-build --verbosity normal`
- `dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --no-restore --verbosity normal`

Closes #190