### PR TITLE
fix(generator): stabilize resources analyzer builds (#235)

### DIFF
--- a/LgymApi.Resources.Generator/AnalyzerReleases.Shipped.md
+++ b/LgymApi.Resources.Generator/AnalyzerReleases.Shipped.md
@@ -1,0 +1,13 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+## Release 1.0.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+LGYMRES001 | Resources | Error | Failed to parse resource file
+LGYMRES002 | Resources | Warning | No resource keys found
+LGYMRES003 | Resources | Error | Failed to parse Enums.resx
+LGYMRES004 | Resources | Warning | No resource keys found in Enums.resx

--- a/LgymApi.Resources.Generator/AnalyzerReleases.Unshipped.md
+++ b/LgymApi.Resources.Generator/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,1 @@
+; Unshipped analyzer releases

--- a/LgymApi.Resources.Generator/EnumsResxGenerator.cs
+++ b/LgymApi.Resources.Generator/EnumsResxGenerator.cs
@@ -20,7 +20,7 @@ public sealed class EnumsResxGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor ResxNoKeys = new(
         id: "LGYMRES004",
         title: "No resource keys found in Enums.resx",
-        messageFormat: "No resource keys found in Enums.resx at '{0}'.",
+        messageFormat: "No resource keys found in Enums.resx at '{0}'",
         category: "Resources",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);

--- a/LgymApi.Resources.Generator/LgymApi.Resources.Generator.csproj
+++ b/LgymApi.Resources.Generator/LgymApi.Resources.Generator.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/LgymApi.Resources.Generator/MessagesResxGenerator.cs
+++ b/LgymApi.Resources.Generator/MessagesResxGenerator.cs
@@ -20,7 +20,7 @@ public sealed class MessagesResxGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor ResxNoKeys = new(
         id: "LGYMRES002",
         title: "No resource keys found",
-        messageFormat: "No resource keys found in '{0}' at '{1}'.",
+        messageFormat: "No resource keys found in '{0}' at '{1}'",
         category: "Resources",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);

--- a/LgymApi.Resources/LgymApi.Resources.csproj
+++ b/LgymApi.Resources/LgymApi.Resources.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\LgymApi.Resources.Generator\LgymApi.Resources.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\LgymApi.Resources.Generator\LgymApi.Resources.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add analyzer release tracking for `LGYMRES001`-`LGYMRES004` and fix the RS1032 descriptor text formatting in the resources generator
- harden generator loading by marking `LgymApi.Resources.Generator` as a Roslyn component and preventing analyzer copy-to-output from `LgymApi.Resources`
- preserve generated resource behavior while validating repeated Debug builds and downstream Unit, Architecture, Integration, and DataSeeder suites

## Verification
- `dotnet build LgymApi.Resources.Generator/LgymApi.Resources.Generator.csproj -c Debug`
- `dotnet build LgymApi.sln -c Debug` (repeated sequentially)
- `dotnet test LgymApi.UnitTests/LgymApi.UnitTests.csproj -c Debug --no-build`
- `dotnet test LgymApi.ArchitectureTests/LgymApi.ArchitectureTests.csproj -c Debug --no-build`
- `dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj -c Debug --no-build`
- `dotnet test LgymApi.DataSeeder.Tests/LgymApi.DataSeeder.Tests.csproj -c Debug --no-build`
