### PR TITLE
Add Gridify pagination issue template and design docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/gridify-pagination-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/gridify-pagination-implementation.yml
@@ -1,0 +1,78 @@
+name: Gridify Pagination Implementation
+about: Implement generic pagination/filter/sort service with Gridify wrappers and PoC adoption in trainer dashboard.
+title: "[Pagination] Implement Gridify-backed generic pagination service"
+labels:
+  - enhancement
+  - backend
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Implement a reusable pagination service for query-driven read endpoints using Gridify as the execution engine behind internal wrappers/facade.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      value: |
+        Build generic pagination/filter/sort pipeline with:
+        - validated multi-sort,
+        - nested AND/OR filters,
+        - deterministic tie-breaker ordering,
+        - DTO/projection output,
+        - field whitelist and validation policies.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope (v1)
+      value: |
+        - Add application contracts for pagination/filter/sort.
+        - Add infrastructure Gridify translator/mapper/executor with Count + Skip/Take + ToList.
+        - Add validation policies (page/pageSize/depth/operator compatibility/duplicate sort checks).
+        - Integrate only trainer dashboard flow as PoC.
+        - Add unit + integration tests in existing test projects.
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals (v1)
+      value: |
+        - No MediatR/CQRS dispatcher rewrite.
+        - No cursor/keyset pagination.
+        - No broad migration of all listing endpoints.
+        - No IQueryable leakage to Application/API.
+
+  - type: checkboxes
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      options:
+        - label: All filter/sort fields are explicitly whitelisted
+        - label: Nested AND/OR groups are supported with max-depth guardrails
+        - label: No path materializes full collection before Skip/Take
+        - label: Application contracts remain EF/IQueryable agnostic
+        - label: Unit and integration tests pass for pagination behavior and PoC flow
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification Commands
+      value: |
+        dotnet test LgymApi.UnitTests/LgymApi.UnitTests.csproj --configuration Release --no-build
+        dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --configuration Release --no-build
+
+  - type: textarea
+    id: rollout
+    attributes:
+      label: Implementation Waves
+      value: |
+        1) Contracts + RED test scaffolding
+        2) Validation + Gridify translator/mapper + tie-breaker sorting
+        3) Infrastructure pagination executor + DI
+        4) Trainer dashboard PoC integration
+        5) Architecture/regression hardening

--- a/docs/GITHUB_ISSUE_GRIDIFY_PAGINATION.md
+++ b/docs/GITHUB_ISSUE_GRIDIFY_PAGINATION.md
@@ -1,0 +1,49 @@
+# Issue draft: Generic pagination query service using Gridify wrappers/facade
+
+## Summary
+Prepare and implement a reusable pagination service for query-driven read endpoints, using **Gridify as the query engine** (sorting + filtering) but exposed through our own contracts/wrappers to preserve application boundaries.
+
+## Background
+The current trainer dashboard pagination path contains logic that should be generalized and includes an anti-pattern where sorting may materialize data before paging. We want a common mechanism that supports:
+- validated multi-column sorting (`asc/desc`),
+- nested `AND/OR` filter groups,
+- deterministic ordering with tie-breaker,
+- DTO/projection-based results,
+- strict field whitelists and validation policies.
+
+## Scope (v1)
+- Add generic pagination/filter/sort contracts in `Application`.
+- Add infrastructure executor wrapping Gridify for `CountAsync + Skip/Take + ToListAsync`.
+- Add validation policy (page limits, max depth, operator compatibility, duplicate sort fields).
+- Integrate as PoC in trainer dashboard flow only.
+- Add TDD coverage in `LgymApi.UnitTests` and `LgymApi.IntegrationTests`.
+
+## Non-goals (v1)
+- No MediatR/CQRS dispatcher overhaul.
+- No keyset/cursor pagination.
+- No broad migration of all list endpoints.
+- No `IQueryable` leakage into application/api layers.
+
+## Acceptance criteria
+- All filter/sort fields are explicitly whitelisted.
+- Nested `AND/OR` groups work with max-depth guardrails.
+- No query path materializes full collection before `Skip/Take`.
+- Application contracts remain EF/IQueryable agnostic.
+- Unit and integration test suites pass for the new pagination behavior and PoC flow.
+
+## Proposed implementation waves
+1. Contracts + test scaffolding (RED).
+2. Validation + Gridify translator/mapper + sorting tie-breaker.
+3. Infrastructure pagination executor + DI.
+4. Trainer dashboard PoC adoption (GREEN integration tests).
+5. Architecture/regression hardening.
+
+## Verification commands
+```bash
+dotnet test LgymApi.UnitTests/LgymApi.UnitTests.csproj --configuration Release --no-build
+dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --configuration Release --no-build
+```
+
+## Notes
+- Keep current API contracts stable where possible.
+- Use wrappers/facade over Gridify to avoid syntax leakage into public API models.

--- a/docs/PAGINATION_GRIDIFY_PLAN.md
+++ b/docs/PAGINATION_GRIDIFY_PLAN.md
@@ -1,0 +1,116 @@
+# Generic Pagination Query Service Plan (Gridify-based)
+
+## TL;DR
+
+Wprowadzamy **generyczny serwis paginacji** oparty o **Gridify jako silnik filtrowania/sortowania**, ale zamkniety za naszymi kontraktami i fasadą, aby:
+- zachowac obecne warstwy `Controller -> Service -> Repository`,
+- nie wypuscic `IQueryable` poza infrastrukture,
+- miec whitelisty pol i operatorow,
+- uniknac materializacji calej kolekcji przed `Skip/Take`.
+
+## Dlaczego Gridify
+
+Gridify dobrze pokrywa wymagania v1:
+- multi-sort,
+- filtrowanie tekstowe i porownania,
+- mapowanie nazw pol (whitelist),
+- integracja z EF Core (`IQueryable`) bez reimplementowania parsera od zera.
+
+Dzieki temu redukujemy ryzyko i czas implementacji: zamiast budowac pelny expression-engine od zera, dodajemy **adaptery + walidacje + polityki domenowe**.
+
+## Architektura docelowa
+
+### Application (kontrakty)
+- `Pagination<TProjection>`
+- `QueryPageRequest` (`Page`, `PageSize`)
+- `QuerySort` (`Field`, `Direction`)
+- `FilterGroup`/`FilterCondition` (nasz model wejscia API/serwisu)
+- `IPaginationQueryService` (fasada aplikacyjna)
+
+### Infrastructure (implementacja)
+- `GridifyFilterTranslator` (mapuje `FilterGroup` -> bezpieczny Gridify filter string)
+- `GridifyMapperFactory<TProjection>` (whitelist/mapa pol)
+- `GridifyPaginationExecutor`:
+  1. `AsNoTracking()`
+  2. `Where` (Gridify)
+  3. `OrderBy` (Gridify + tie-breaker)
+  4. `CountAsync`
+  5. `Skip/Take`
+  6. `ToListAsync`
+- `PaginationValidationPolicy` (max page size, max depth, allowed operators)
+
+## Guardrails (bezwzgledne)
+
+1. Brak `ToListAsync()` przed `Skip/Take`.
+2. Brak dynamicznego sortowania po dowolnym stringu bez mapy.
+3. Brak wycieku `IQueryable` do `Application`/`Api`.
+4. Brak masowej migracji endpointow - tylko PoC (`TrainerDashboard`).
+5. Deterministyczne sortowanie (tie-breaker, np. `Id`).
+
+## Plan wdrozenia (zaktualizowany)
+
+### Wave 1 - kontrakty + testy RED
+1. Dodac generyczne kontrakty paginacji i filtrow.
+2. Dodac kontrakty whitelist/polityk walidacji.
+3. Dodac unit testy RED (page bounds, duplicate sort, invalid operator).
+4. Dodac integration testy RED dla trainer dashboard (PoC).
+
+### Wave 2 - Gridify adapter + executor
+5. Implementacja `PaginationValidationPolicy` (depth/page/pageSize/operators).
+6. Implementacja `GridifyFilterTranslator` (z `FilterGroup` na Gridify syntax).
+7. Implementacja `GridifyPaginationExecutor` + DI.
+8. Dodanie deterministic tie-breaker w sortowaniu.
+
+### Wave 3 - PoC adopcja
+9. Podlaczyc `TrainerRelationshipRepository` do nowego executora.
+10. Usunac branch in-memory sortowania statusu.
+11. Przepuscic RED->GREEN dla integration testow PoC.
+
+### Wave 4 - hardening
+12. Testy architektoniczne (brak EF/IQueryable w kontraktach Application).
+13. Regression suite: empty IN, page > total, duplicate sort, max depth.
+14. Pelne testy unit + integration w trybie CI-like.
+
+## TDD i weryfikacja
+
+Minimalny zestaw komend:
+
+```bash
+dotnet test LgymApi.UnitTests/LgymApi.UnitTests.csproj --configuration Release --no-build
+dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --configuration Release --no-build
+```
+
+Dodatkowo per-scenario (filtry):
+
+```bash
+dotnet test LgymApi.UnitTests/LgymApi.UnitTests.csproj --filter "FullyQualifiedName~Pagination|FullyQualifiedName~Gridify|FullyQualifiedName~Sorting"
+```
+
+## Zakres v1
+
+W scope v1 zostaje:
+- offset pagination,
+- jeden flow PoC (Trainer Dashboard),
+- wrapper/fasada nad Gridify.
+
+Poza v1:
+- keyset/cursor pagination,
+- migracja wszystkich endpointow listowych,
+- zaawansowane provider-specific operatory SQL.
+
+## Ryzyka i mitigacje
+
+- **Ryzyko**: Gridify syntax leak do API.
+  - **Mitigacja**: API przyjmuje nadal nasz `FilterGroup`; translacja tylko w Infrastructure.
+- **Ryzyko**: niedeterministyczne sortowanie.
+  - **Mitigacja**: globalny tie-breaker i testy stabilnosci.
+- **Ryzyko**: zbyt szeroki rollout.
+  - **Mitigacja**: feature flag / PoC-only wiring.
+
+## Definition of Done
+
+- PoC endpoint trenera dziala na nowym pipeline.
+- Brak in-memory sortowania przed pagingiem.
+- Wszystkie pola filtrowania/sortowania sa whitelisted.
+- Testy unit + integration przechodza.
+- Kontrakty Application pozostaja EF-agnostyczne.


### PR DESCRIPTION
### Motivation
- Provide an issue template and documentation to propose and guide the implementation of a generic Gridify-backed pagination/filter/sort service with a trainer dashboard PoC.
- Capture scope, non-goals, acceptance criteria, verification commands and rollout waves to standardize the implementation approach and testing expectations.

### Description
- Add `.github/ISSUE_TEMPLATE/gridify-pagination-implementation.yml` which defines a structured issue template including summary, scope, non-goals, acceptance criteria, verification commands and rollout waves.
- Add `docs/GITHUB_ISSUE_GRIDIFY_PAGINATION.md` which contains the issue draft, summary, acceptance criteria and quick verification commands for contributors.
- Add `docs/PAGINATION_GRIDIFY_PLAN.md` which contains the detailed architecture, implementation waves, guardrails, TDD guidance and `dotnet test` verification snippets.

### Testing
- No automated tests were executed as these changes only add documentation and an issue template.
- Verification instructions were included for running unit and integration tests via `dotnet test` for future implementation work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d035b201108332814ea1707787fe40)