### PR TITLE
feat(trainer): add paginated invitations endpoint with generic enum sorting

### DIFF
--- a/LgymApi.Api/Features/Trainer/Contracts/TrainerRelationshipDtos.cs
+++ b/LgymApi.Api/Features/Trainer/Contracts/TrainerRelationshipDtos.cs
@@ -145,7 +145,7 @@ public sealed class CreateTrainerInvitationByEmailRequest : IDto
 
 public sealed class PaginatedTrainerInvitationRequest : PaginatedRequest, IDto { }
 
-public sealed class PaginatedTrainerInvitationResult : PaginatedResponse<TrainerInvitationDto>
+public sealed class PaginatedTrainerInvitationResult : PaginatedResponse<TrainerInvitationDto>, IResultDto
 {
 }
 

--- a/LgymApi.Api/Features/Trainer/Contracts/TrainerRelationshipDtos.cs
+++ b/LgymApi.Api/Features/Trainer/Contracts/TrainerRelationshipDtos.cs
@@ -22,6 +22,9 @@ public sealed class TrainerInvitationDto : IResultDto
     [JsonPropertyName("traineeId")]
     public string TraineeId { get; set; } = string.Empty;
 
+    [JsonPropertyName("inviteeEmail")]
+    public string InviteeEmail { get; set; } = string.Empty;
+
     [JsonPropertyName("code")]
     public string Code { get; set; } = string.Empty;
 
@@ -36,6 +39,12 @@ public sealed class TrainerInvitationDto : IResultDto
 
     [JsonPropertyName("createdAt")]
     public DateTimeOffset CreatedAt { get; set; }
+
+    [JsonPropertyName("traineeName")]
+    public string? TraineeName { get; set; }
+
+    [JsonPropertyName("traineeEmail")]
+    public string? TraineeEmail { get; set; }
 }
 
 public sealed class TrainerDashboardTraineesRequest : IDto
@@ -132,6 +141,32 @@ public sealed class CreateTrainerInvitationByEmailRequest : IDto
 
     [JsonPropertyName("preferredTimeZone")]
     public string PreferredTimeZone { get; set; } = string.Empty;
+}
+
+public sealed class PaginatedTrainerInvitationRequest : PaginatedRequest, IDto { }
+
+public sealed class PaginatedTrainerInvitationResult : IResultDto
+{
+    [JsonPropertyName("items")]
+    public List<TrainerInvitationDto> Items { get; set; } = [];
+
+    [JsonPropertyName("page")]
+    public int Page { get; set; }
+
+    [JsonPropertyName("pageSize")]
+    public int PageSize { get; set; }
+
+    [JsonPropertyName("totalCount")]
+    public int TotalCount { get; set; }
+
+    [JsonPropertyName("totalPages")]
+    public int TotalPages { get; set; }
+
+    [JsonPropertyName("hasNextPage")]
+    public bool HasNextPage { get; set; }
+
+    [JsonPropertyName("hasPreviousPage")]
+    public bool HasPreviousPage { get; set; }
 }
 
 public sealed class TrainerManagedPlanDto : IResultDto

--- a/LgymApi.Api/Features/Trainer/Contracts/TrainerRelationshipDtos.cs
+++ b/LgymApi.Api/Features/Trainer/Contracts/TrainerRelationshipDtos.cs
@@ -145,28 +145,8 @@ public sealed class CreateTrainerInvitationByEmailRequest : IDto
 
 public sealed class PaginatedTrainerInvitationRequest : PaginatedRequest, IDto { }
 
-public sealed class PaginatedTrainerInvitationResult : IResultDto
+public sealed class PaginatedTrainerInvitationResult : PaginatedResponse<TrainerInvitationDto>
 {
-    [JsonPropertyName("items")]
-    public List<TrainerInvitationDto> Items { get; set; } = [];
-
-    [JsonPropertyName("page")]
-    public int Page { get; set; }
-
-    [JsonPropertyName("pageSize")]
-    public int PageSize { get; set; }
-
-    [JsonPropertyName("totalCount")]
-    public int TotalCount { get; set; }
-
-    [JsonPropertyName("totalPages")]
-    public int TotalPages { get; set; }
-
-    [JsonPropertyName("hasNextPage")]
-    public bool HasNextPage { get; set; }
-
-    [JsonPropertyName("hasPreviousPage")]
-    public bool HasPreviousPage { get; set; }
 }
 
 public sealed class TrainerManagedPlanDto : IResultDto

--- a/LgymApi.Api/Features/Trainer/Controllers/TrainerRelationshipController.cs
+++ b/LgymApi.Api/Features/Trainer/Controllers/TrainerRelationshipController.cs
@@ -15,6 +15,7 @@ using LgymApi.Application.Features.Training.Models;
 using LgymApi.Application.Features.TrainerRelationships;
 using LgymApi.Application.Features.TrainerRelationships.Models;
 using LgymApi.Application.Mapping.Core;
+using LgymApi.Application.Pagination;
 using LgymApi.Domain.Security;
 using LgymApi.Domain.ValueObjects;
 using LgymApi.Resources;
@@ -61,18 +62,38 @@ public sealed class TrainerRelationshipController : ControllerBase
         return Ok(_mapper.Map<LgymApi.Application.Features.TrainerRelationships.Models.TrainerInvitationResult, TrainerInvitationDto>(result.Value));
     }
 
-    [HttpGet("invitations")]
-    [ProducesResponseType(typeof(List<TrainerInvitationDto>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetInvitations()
+    [HttpPost("invitations/paginated")]
+    [ProducesResponseType(typeof(PaginatedTrainerInvitationResult), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetInvitationsPaginated([FromBody] PaginatedTrainerInvitationRequest request)
     {
+        var cancellationToken = HttpContext.RequestAborted;
+        var filterInput = new FilterInput
+        {
+            Page = request.Page,
+            PageSize = request.PageSize,
+            FilterGroups = request.FilterGroups,
+            SortDescriptors = request.SortDescriptors
+        };
+
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.GetTrainerInvitationsAsync(trainer!, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.GetInvitationsPaginatedAsync(trainer!, filterInput, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
         }
 
-        return Ok(_mapper.MapList<LgymApi.Application.Features.TrainerRelationships.Models.TrainerInvitationResult, TrainerInvitationDto>(result.Value));
+        var pagination = result.Value;
+        var response = new PaginatedTrainerInvitationResult
+        {
+            Items = _mapper.MapList<TrainerInvitationResult, TrainerInvitationDto>(pagination.Items),
+            Page = pagination.Page,
+            PageSize = pagination.PageSize,
+            TotalCount = pagination.TotalCount,
+            TotalPages = pagination.TotalPages,
+            HasNextPage = pagination.HasNextPage,
+            HasPreviousPage = pagination.HasPreviousPage
+        };
+        return Ok(response);
     }
 
     [HttpPost("invitations/by-email")]

--- a/LgymApi.Api/Interfaces/IResultDto.cs
+++ b/LgymApi.Api/Interfaces/IResultDto.cs
@@ -1,4 +1,31 @@
+using System.Text.Json.Serialization;
+
 namespace LgymApi.Api.Interfaces
 {
     public interface IResultDto;
+
+    public abstract class PaginatedResponse<TItem> : IResultDto
+        where TItem : IResultDto
+    {
+        [JsonPropertyName("items")]
+        public List<TItem> Items { get; set; } = [];
+
+        [JsonPropertyName("page")]
+        public int Page { get; set; }
+
+        [JsonPropertyName("pageSize")]
+        public int PageSize { get; set; }
+
+        [JsonPropertyName("totalCount")]
+        public int TotalCount { get; set; }
+
+        [JsonPropertyName("totalPages")]
+        public int TotalPages { get; set; }
+
+        [JsonPropertyName("hasNextPage")]
+        public bool HasNextPage { get; set; }
+
+        [JsonPropertyName("hasPreviousPage")]
+        public bool HasPreviousPage { get; set; }
+    }
 }

--- a/LgymApi.Api/Interfaces/IResultDto.cs
+++ b/LgymApi.Api/Interfaces/IResultDto.cs
@@ -4,7 +4,7 @@ namespace LgymApi.Api.Interfaces
 {
     public interface IResultDto;
 
-    public abstract class PaginatedResponse<TItem> : IResultDto
+    public abstract class PaginatedResponse<TItem>
         where TItem : IResultDto
     {
         [JsonPropertyName("items")]

--- a/LgymApi.Api/Mapping/Profiles/TrainerProfile.cs
+++ b/LgymApi.Api/Mapping/Profiles/TrainerProfile.cs
@@ -14,11 +14,14 @@ public sealed class TrainerProfile : IMappingProfile
             Id = source.Id.ToString(),
             TrainerId = source.TrainerId.ToString(),
             TraineeId = source.TraineeId?.ToString() ?? string.Empty,
+            InviteeEmail = source.InviteeEmail,
             Code = source.Code,
             Status = source.Status.ToString(),
             ExpiresAt = source.ExpiresAt,
             RespondedAt = source.RespondedAt,
-            CreatedAt = source.CreatedAt
+            CreatedAt = source.CreatedAt,
+            TraineeName = source.TraineeName,
+            TraineeEmail = source.TraineeEmail
         });
 
         configuration.CreateMap<TrainerDashboardTraineeResult, TrainerDashboardTraineeDto>((source, _) => new TrainerDashboardTraineeDto

--- a/LgymApi.Application/Repositories/ITrainerRelationshipRepository.cs
+++ b/LgymApi.Application/Repositories/ITrainerRelationshipRepository.cs
@@ -1,6 +1,7 @@
+using LgymApi.Application.Features.TrainerRelationships.Models;
+using LgymApi.Application.Pagination;
 using LgymApi.Domain.Entities;
 using LgymApi.Domain.ValueObjects;
-using LgymApi.Application.Features.TrainerRelationships.Models;
 
 namespace LgymApi.Application.Repositories;
 
@@ -17,6 +18,7 @@ public interface ITrainerRelationshipRepository
     Task<TrainerTraineeLink?> FindActiveLinkByTrainerAndTraineeAsync(Id<User> trainerId, Id<User> traineeId, CancellationToken cancellationToken = default);
     Task<TrainerTraineeLink?> FindActiveLinkByTraineeIdAsync(Id<User> traineeId, CancellationToken cancellationToken = default);
     Task<TrainerDashboardTraineeListResult> GetDashboardTraineesAsync(Id<User> trainerId, TrainerDashboardTraineeQuery query, CancellationToken cancellationToken = default);
+    Task<Pagination<TrainerInvitationResult>> GetInvitationsPaginatedAsync(Id<User> trainerId, FilterInput filterInput, CancellationToken cancellationToken = default);
     Task AddLinkAsync(TrainerTraineeLink link, CancellationToken cancellationToken = default);
     Task RemoveLinkAsync(TrainerTraineeLink link, CancellationToken cancellationToken = default);
 }

--- a/LgymApi.Application/TrainerRelationships/ITrainerRelationshipService.cs
+++ b/LgymApi.Application/TrainerRelationships/ITrainerRelationshipService.cs
@@ -4,6 +4,7 @@ using LgymApi.Application.Features.TrainerRelationships.Models;
 using LgymApi.Application.Features.ExerciseScores.Models;
 using LgymApi.Application.Features.EloRegistry.Models;
 using LgymApi.Application.Features.Training.Models;
+using LgymApi.Application.Pagination;
 using LgymApi.Domain.ValueObjects;
 using ExerciseEntity = LgymApi.Domain.Entities.Exercise;
 using MainRecordEntity = LgymApi.Domain.Entities.MainRecord;
@@ -18,6 +19,7 @@ public interface ITrainerRelationshipService
     Task<Result<TrainerInvitationResult, AppError>> CreateInvitationAsync(UserEntity currentTrainer, Id<UserEntity> traineeId, CancellationToken cancellationToken = default);
     Task<Result<TrainerInvitationResult, AppError>> CreateInvitationByEmailAsync(UserEntity currentTrainer, string inviteeEmail, string preferredLanguage, string preferredTimeZone, CancellationToken cancellationToken = default);
     Task<Result<List<TrainerInvitationResult>, AppError>> GetTrainerInvitationsAsync(UserEntity currentTrainer, CancellationToken cancellationToken = default);
+    Task<Result<Pagination<TrainerInvitationResult>, AppError>> GetInvitationsPaginatedAsync(UserEntity currentTrainer, FilterInput filterInput, CancellationToken cancellationToken = default);
     Task<Result<TrainerDashboardTraineeListResult, AppError>> GetDashboardTraineesAsync(UserEntity currentTrainer, TrainerDashboardTraineeQuery query, CancellationToken cancellationToken = default);
     Task<Result<List<DateTime>, AppError>> GetTraineeTrainingDatesAsync(UserEntity currentTrainer, Id<UserEntity> traineeId, CancellationToken cancellationToken = default);
     Task<Result<List<TrainingByDateDetails>, AppError>> GetTraineeTrainingByDateAsync(UserEntity currentTrainer, Id<UserEntity> traineeId, DateTime createdAt, CancellationToken cancellationToken = default);

--- a/LgymApi.Application/TrainerRelationships/Models/TrainerInvitationResult.cs
+++ b/LgymApi.Application/TrainerRelationships/Models/TrainerInvitationResult.cs
@@ -7,9 +7,12 @@ public sealed class TrainerInvitationResult
     public LgymApi.Domain.ValueObjects.Id<LgymApi.Domain.Entities.TrainerInvitation> Id { get; init; }
     public LgymApi.Domain.ValueObjects.Id<LgymApi.Domain.Entities.User> TrainerId { get; init; }
     public LgymApi.Domain.ValueObjects.Id<LgymApi.Domain.Entities.User>? TraineeId { get; init; }
+    public string InviteeEmail { get; init; } = string.Empty;
     public string Code { get; init; } = string.Empty;
     public TrainerInvitationStatus Status { get; init; }
     public DateTimeOffset ExpiresAt { get; init; }
     public DateTimeOffset? RespondedAt { get; init; }
     public DateTimeOffset CreatedAt { get; init; }
+    public string? TraineeName { get; init; }
+    public string? TraineeEmail { get; init; }
 }

--- a/LgymApi.Application/TrainerRelationships/TrainerRelationshipService.cs
+++ b/LgymApi.Application/TrainerRelationships/TrainerRelationshipService.cs
@@ -8,6 +8,7 @@ using LgymApi.Application.Features.MainRecords;
 using LgymApi.Application.Features.TrainerRelationships.Models;
 using LgymApi.Application.Features.Training;
 using LgymApi.Application.Features.Training.Models;
+using LgymApi.Application.Pagination;
 using LgymApi.BackgroundWorker.Common.Commands;
 using LgymApi.BackgroundWorker.Common;
 using LgymApi.Application.Repositories;
@@ -207,6 +208,18 @@ public sealed class TrainerRelationshipService : ITrainerRelationshipService
         }
 
         return Result<List<TrainerInvitationResult>, AppError>.Success(invitations.Select(MapInvitation).ToList());
+    }
+
+    public async Task<Result<Pagination<TrainerInvitationResult>, AppError>> GetInvitationsPaginatedAsync(UserEntity currentTrainer, FilterInput filterInput, CancellationToken cancellationToken = default)
+    {
+        var ensureTrainerResult = await EnsureTrainerAsync(currentTrainer, cancellationToken);
+        if (ensureTrainerResult.IsFailure)
+        {
+            return Result<Pagination<TrainerInvitationResult>, AppError>.Failure(ensureTrainerResult.Error);
+        }
+
+        return Result<Pagination<TrainerInvitationResult>, AppError>.Success(
+            await _trainerRelationshipRepository.GetInvitationsPaginatedAsync(currentTrainer.Id, filterInput, cancellationToken));
     }
 
     public async Task<Result<TrainerDashboardTraineeListResult, AppError>> GetDashboardTraineesAsync(UserEntity currentTrainer, TrainerDashboardTraineeQuery query, CancellationToken cancellationToken = default)

--- a/LgymApi.Infrastructure/Pagination/GridifyExecutionService.cs
+++ b/LgymApi.Infrastructure/Pagination/GridifyExecutionService.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Linq.Expressions;
+using System.Resources;
 using Gridify;
 using LgymApi.Application.Pagination;
 using Microsoft.EntityFrameworkCore;
@@ -7,6 +9,9 @@ namespace LgymApi.Infrastructure.Pagination;
 
 public sealed class GridifyExecutionService : IGridifyExecutionService
 {
+    private static readonly ResourceManager EnumResourceManager =
+        new("LgymApi.Resources.Resources.Enums", typeof(LgymApi.Resources.Enums).Assembly);
+
     public async Task<Pagination<TProjection>> ExecuteAsync<TProjection>(
         IQueryable<TProjection> baseQuery,
         FilterInput filterInput,
@@ -41,7 +46,6 @@ public sealed class GridifyExecutionService : IGridifyExecutionService
             maxPageSize: paginationPolicy.MaxPageSize);
         var gridifyMapper = CreateGridifyMapper<TProjection>(mappings);
         var filter = gridifyAdapter.Adapt(normalizedInput);
-        var orderBy = BuildOrderBy(normalizedInput.SortDescriptors);
 
         var query = baseQuery.AsNoTracking();
 
@@ -52,9 +56,13 @@ public sealed class GridifyExecutionService : IGridifyExecutionService
 
         var totalCount = await query.CountAsync(cancellationToken);
 
-        if (!string.IsNullOrWhiteSpace(orderBy))
+        var (queryWithEnumOrdering, remainingOrderBy) = ApplyEnumOrdering(
+            query, normalizedInput.SortDescriptors, mappings);
+        query = queryWithEnumOrdering;
+
+        if (!string.IsNullOrWhiteSpace(remainingOrderBy))
         {
-            query = query.ApplyOrdering(orderBy, gridifyMapper);
+            query = query.ApplyOrdering(remainingOrderBy, gridifyMapper);
         }
 
         query = query.ApplyPaging(normalizedInput.Page, normalizedInput.PageSize);
@@ -101,6 +109,113 @@ public sealed class GridifyExecutionService : IGridifyExecutionService
         }
 
         return sortDescriptors;
+    }
+
+    private static (IQueryable<TProjection> query, string remainingOrderBy) ApplyEnumOrdering<TProjection>(
+        IQueryable<TProjection> query,
+        IReadOnlyList<SortDescriptor> sortDescriptors,
+        IEnumerable<FieldMapping> mappings)
+        where TProjection : class
+    {
+        var enumSortFields = new List<SortDescriptor>();
+        var remainingSortFields = new List<SortDescriptor>();
+
+        foreach (var sort in sortDescriptors)
+        {
+            var mapping = mappings.FirstOrDefault(m =>
+                m.FieldName.Equals(sort.FieldName, StringComparison.OrdinalIgnoreCase));
+            if (mapping != null)
+            {
+                var memberType = ResolveMemberType(typeof(TProjection), mapping.MemberName);
+                var underlyingType = Nullable.GetUnderlyingType(memberType) ?? memberType;
+                if (underlyingType.IsEnum)
+                {
+                    enumSortFields.Add(sort);
+                }
+                else
+                {
+                    remainingSortFields.Add(sort);
+                }
+            }
+            else
+            {
+                remainingSortFields.Add(sort);
+            }
+        }
+
+        IOrderedQueryable<TProjection>? orderedQuery = null;
+
+        for (int i = 0; i < enumSortFields.Count; i++)
+        {
+            var sort = enumSortFields[i];
+            var mapping = mappings.First(m =>
+                m.FieldName.Equals(sort.FieldName, StringComparison.OrdinalIgnoreCase));
+            var memberType = ResolveMemberType(typeof(TProjection), mapping.MemberName);
+            var enumType = Nullable.GetUnderlyingType(memberType) ?? memberType;
+
+            var expression = CreateEnumCaseWhenExpression<TProjection>(enumType, mapping.MemberName);
+
+            if (i == 0 && orderedQuery == null)
+            {
+                orderedQuery = sort.Descending
+                    ? query.OrderByDescending(expression)
+                    : query.OrderBy(expression);
+            }
+            else
+            {
+                orderedQuery = sort.Descending
+                    ? orderedQuery!.ThenByDescending(expression)
+                    : orderedQuery.ThenBy(expression);
+            }
+        }
+
+        query = orderedQuery ?? query;
+        var remainingOrderBy = BuildOrderBy(remainingSortFields);
+
+        return (query, remainingOrderBy);
+    }
+
+    private static Expression<Func<TProjection, int>> CreateEnumCaseWhenExpression<TProjection>(
+        Type enumType, string memberName)
+        where TProjection : class
+    {
+        var culture = CultureInfo.CurrentUICulture;
+        var sortKey = $"{enumType.Name}_SortOrder";
+        var sortOrderString = EnumResourceManager.GetString(sortKey, culture);
+
+        string[] orderedNames;
+
+        if (!string.IsNullOrWhiteSpace(sortOrderString))
+        {
+            orderedNames = sortOrderString.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+        else
+        {
+            orderedNames = Enum.GetNames(enumType)
+                .OrderBy(n => (int)Enum.Parse(enumType, n))
+                .ToArray();
+        }
+
+        var parameter = Expression.Parameter(typeof(TProjection), "x");
+        Expression access = parameter;
+
+        foreach (var segment in memberName.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            access = Expression.PropertyOrField(access, segment);
+        }
+
+        Expression body = Expression.Constant(orderedNames.Length);
+
+        for (int i = orderedNames.Length - 1; i >= 0; i--)
+        {
+            var enumValue = Enum.Parse(enumType, orderedNames[i], ignoreCase: true);
+            var enumConstant = Expression.Constant(enumValue, enumType);
+            var equality = Expression.Equal(access, enumConstant);
+            var indexConstant = Expression.Constant(i);
+            body = Expression.Condition(equality, indexConstant, body);
+        }
+
+        return Expression.Lambda<Func<TProjection, int>>(body, parameter);
     }
 
     private static string BuildOrderBy(IEnumerable<SortDescriptor> sortDescriptors)

--- a/LgymApi.Infrastructure/Pagination/GridifyExecutionService.cs
+++ b/LgymApi.Infrastructure/Pagination/GridifyExecutionService.cs
@@ -1,6 +1,4 @@
-using System.Globalization;
 using System.Linq.Expressions;
-using System.Resources;
 using Gridify;
 using LgymApi.Application.Pagination;
 using Microsoft.EntityFrameworkCore;
@@ -9,9 +7,6 @@ namespace LgymApi.Infrastructure.Pagination;
 
 public sealed class GridifyExecutionService : IGridifyExecutionService
 {
-    private static readonly ResourceManager EnumResourceManager =
-        new("LgymApi.Resources.Resources.Enums", typeof(LgymApi.Resources.Enums).Assembly);
-
     public async Task<Pagination<TProjection>> ExecuteAsync<TProjection>(
         IQueryable<TProjection> baseQuery,
         FilterInput filterInput,
@@ -150,10 +145,7 @@ public sealed class GridifyExecutionService : IGridifyExecutionService
             var sort = enumSortFields[i];
             var mapping = mappings.First(m =>
                 m.FieldName.Equals(sort.FieldName, StringComparison.OrdinalIgnoreCase));
-            var memberType = ResolveMemberType(typeof(TProjection), mapping.MemberName);
-            var enumType = Nullable.GetUnderlyingType(memberType) ?? memberType;
-
-            var expression = CreateEnumCaseWhenExpression<TProjection>(enumType, mapping.MemberName);
+            var expression = CreateEnumIntCastExpression<TProjection>(mapping.MemberName);
 
             if (i == 0 && orderedQuery == null)
             {
@@ -175,45 +167,18 @@ public sealed class GridifyExecutionService : IGridifyExecutionService
         return (query, remainingOrderBy);
     }
 
-    private static Expression<Func<TProjection, int>> CreateEnumCaseWhenExpression<TProjection>(
-        Type enumType, string memberName)
+    private static Expression<Func<TProjection, int>> CreateEnumIntCastExpression<TProjection>(string memberName)
         where TProjection : class
     {
-        var culture = CultureInfo.CurrentUICulture;
-        var sortKey = $"{enumType.Name}_SortOrder";
-        var sortOrderString = EnumResourceManager.GetString(sortKey, culture);
-
-        string[] orderedNames;
-
-        if (!string.IsNullOrWhiteSpace(sortOrderString))
-        {
-            orderedNames = sortOrderString.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        }
-        else
-        {
-            orderedNames = Enum.GetNames(enumType)
-                .OrderBy(n => (int)Enum.Parse(enumType, n))
-                .ToArray();
-        }
-
         var parameter = Expression.Parameter(typeof(TProjection), "x");
-        Expression access = parameter;
+        Expression body = parameter;
 
         foreach (var segment in memberName.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
-            access = Expression.PropertyOrField(access, segment);
+            body = Expression.PropertyOrField(body, segment);
         }
 
-        Expression body = Expression.Constant(orderedNames.Length);
-
-        for (int i = orderedNames.Length - 1; i >= 0; i--)
-        {
-            var enumValue = Enum.Parse(enumType, orderedNames[i], ignoreCase: true);
-            var enumConstant = Expression.Constant(enumValue, enumType);
-            var equality = Expression.Equal(access, enumConstant);
-            var indexConstant = Expression.Constant(i);
-            body = Expression.Condition(equality, indexConstant, body);
-        }
+        body = Expression.Convert(body, typeof(int));
 
         return Expression.Lambda<Func<TProjection, int>>(body, parameter);
     }

--- a/LgymApi.Infrastructure/Repositories/TrainerRelationshipRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/TrainerRelationshipRepository.cs
@@ -1,6 +1,6 @@
+using LgymApi.Application.Features.TrainerRelationships.Models;
 using LgymApi.Application.Pagination;
 using LgymApi.Application.Repositories;
-using LgymApi.Application.Features.TrainerRelationships.Models;
 using LgymApi.Domain.Entities;
 using LgymApi.Domain.Enums;
 using LgymApi.Domain.ValueObjects;
@@ -21,6 +21,14 @@ public sealed class TrainerRelationshipRepository : ITrainerRelationshipReposito
         MaxPageSize = 100,
         DefaultPageSize = 20,
         DefaultSortField = "name",
+        TieBreakerField = "id"
+    };
+
+    private static readonly PaginationPolicy InvitationPaginationPolicy = new()
+    {
+        MaxPageSize = 100,
+        DefaultPageSize = 20,
+        DefaultSortField = "createdAt",
         TieBreakerField = "id"
     };
 
@@ -108,6 +116,64 @@ public sealed class TrainerRelationshipRepository : ITrainerRelationshipReposito
     {
         return _dbContext.TrainerTraineeLinks
             .FirstOrDefaultAsync(l => l.TraineeId == traineeId, cancellationToken);
+    }
+
+    public async Task<Pagination<TrainerInvitationResult>> GetInvitationsPaginatedAsync(Id<User> trainerId, FilterInput filterInput, CancellationToken cancellationToken = default)
+    {
+        var baseQuery = BuildInvitationBaseQuery(trainerId);
+        var pagination = await _gridifyExecutionService.ExecuteAsync(
+            baseQuery,
+            filterInput,
+            _mapperRegistry,
+            InvitationPaginationPolicy,
+            cancellationToken);
+
+        var items = pagination.Items.Select(x => new TrainerInvitationResult
+            {
+                Id = x.Id,
+                TrainerId = x.TrainerId,
+                TraineeId = x.TraineeId,
+                InviteeEmail = x.InviteeEmail,
+                Code = x.Code,
+                Status = x.Status,
+                ExpiresAt = x.ExpiresAt,
+                RespondedAt = x.RespondedAt,
+                CreatedAt = x.CreatedAt,
+                TraineeName = x.TraineeName,
+                TraineeEmail = x.TraineeEmail
+            })
+            .ToList();
+
+        return new Pagination<TrainerInvitationResult>
+        {
+            Items = items,
+            Page = pagination.Page,
+            PageSize = pagination.PageSize,
+            TotalCount = pagination.TotalCount
+        };
+    }
+
+    private IQueryable<InvitationProjection> BuildInvitationBaseQuery(Id<User> trainerId)
+    {
+        return
+            from invitation in _dbContext.TrainerInvitations.AsNoTracking()
+            where invitation.TrainerId == trainerId
+            join trainee in _dbContext.Users.AsNoTracking() on invitation.TraineeId equals trainee.Id into traineeGroup
+            from trainee in traineeGroup.DefaultIfEmpty()
+            select new InvitationProjection
+            {
+                Id = invitation.Id,
+                TrainerId = invitation.TrainerId,
+                TraineeId = invitation.TraineeId,
+                InviteeEmail = invitation.InviteeEmail,
+                Code = invitation.Code,
+                Status = invitation.Status,
+                ExpiresAt = invitation.ExpiresAt,
+                RespondedAt = invitation.RespondedAt,
+                CreatedAt = invitation.CreatedAt,
+                TraineeName = trainee.Name,
+                TraineeEmail = trainee.Email
+            };
     }
 
     public async Task<TrainerDashboardTraineeListResult> GetDashboardTraineesAsync(Id<User> trainerId, TrainerDashboardTraineeQuery query, CancellationToken cancellationToken = default)
@@ -353,5 +419,20 @@ public sealed class TrainerRelationshipRepository : ITrainerRelationshipReposito
         public DateTimeOffset? LastInvitationExpiresAt { get; init; }
         public DateTimeOffset? LastInvitationRespondedAt { get; init; }
         public int StatusOrder { get; init; }
+    }
+
+    internal sealed class InvitationProjection
+    {
+        public LgymApi.Domain.ValueObjects.Id<LgymApi.Domain.Entities.TrainerInvitation> Id { get; init; }
+        public LgymApi.Domain.ValueObjects.Id<LgymApi.Domain.Entities.User> TrainerId { get; init; }
+        public LgymApi.Domain.ValueObjects.Id<LgymApi.Domain.Entities.User>? TraineeId { get; init; }
+        public string InviteeEmail { get; init; } = string.Empty;
+        public string Code { get; init; } = string.Empty;
+        public TrainerInvitationStatus Status { get; init; }
+        public DateTimeOffset ExpiresAt { get; init; }
+        public DateTimeOffset? RespondedAt { get; init; }
+        public DateTimeOffset CreatedAt { get; init; }
+        public string? TraineeName { get; init; }
+        public string? TraineeEmail { get; init; }
     }
 }

--- a/LgymApi.Infrastructure/Repositories/TrainerRelationshipRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/TrainerRelationshipRepository.cs
@@ -121,46 +121,22 @@ public sealed class TrainerRelationshipRepository : ITrainerRelationshipReposito
     public async Task<Pagination<TrainerInvitationResult>> GetInvitationsPaginatedAsync(Id<User> trainerId, FilterInput filterInput, CancellationToken cancellationToken = default)
     {
         var baseQuery = BuildInvitationBaseQuery(trainerId);
-        var pagination = await _gridifyExecutionService.ExecuteAsync(
+        return await _gridifyExecutionService.ExecuteAsync(
             baseQuery,
             filterInput,
             _mapperRegistry,
             InvitationPaginationPolicy,
             cancellationToken);
-
-        var items = pagination.Items.Select(x => new TrainerInvitationResult
-            {
-                Id = x.Id,
-                TrainerId = x.TrainerId,
-                TraineeId = x.TraineeId,
-                InviteeEmail = x.InviteeEmail,
-                Code = x.Code,
-                Status = x.Status,
-                ExpiresAt = x.ExpiresAt,
-                RespondedAt = x.RespondedAt,
-                CreatedAt = x.CreatedAt,
-                TraineeName = x.TraineeName,
-                TraineeEmail = x.TraineeEmail
-            })
-            .ToList();
-
-        return new Pagination<TrainerInvitationResult>
-        {
-            Items = items,
-            Page = pagination.Page,
-            PageSize = pagination.PageSize,
-            TotalCount = pagination.TotalCount
-        };
     }
 
-    private IQueryable<InvitationProjection> BuildInvitationBaseQuery(Id<User> trainerId)
+    private IQueryable<TrainerInvitationResult> BuildInvitationBaseQuery(Id<User> trainerId)
     {
         return
             from invitation in _dbContext.TrainerInvitations.AsNoTracking()
             where invitation.TrainerId == trainerId
             join trainee in _dbContext.Users.AsNoTracking() on invitation.TraineeId equals trainee.Id into traineeGroup
             from trainee in traineeGroup.DefaultIfEmpty()
-            select new InvitationProjection
+            select new TrainerInvitationResult
             {
                 Id = invitation.Id,
                 TrainerId = invitation.TrainerId,
@@ -419,20 +395,5 @@ public sealed class TrainerRelationshipRepository : ITrainerRelationshipReposito
         public DateTimeOffset? LastInvitationExpiresAt { get; init; }
         public DateTimeOffset? LastInvitationRespondedAt { get; init; }
         public int StatusOrder { get; init; }
-    }
-
-    internal sealed class InvitationProjection
-    {
-        public LgymApi.Domain.ValueObjects.Id<LgymApi.Domain.Entities.TrainerInvitation> Id { get; init; }
-        public LgymApi.Domain.ValueObjects.Id<LgymApi.Domain.Entities.User> TrainerId { get; init; }
-        public LgymApi.Domain.ValueObjects.Id<LgymApi.Domain.Entities.User>? TraineeId { get; init; }
-        public string InviteeEmail { get; init; } = string.Empty;
-        public string Code { get; init; } = string.Empty;
-        public TrainerInvitationStatus Status { get; init; }
-        public DateTimeOffset ExpiresAt { get; init; }
-        public DateTimeOffset? RespondedAt { get; init; }
-        public DateTimeOffset CreatedAt { get; init; }
-        public string? TraineeName { get; init; }
-        public string? TraineeEmail { get; init; }
     }
 }

--- a/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
+++ b/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
@@ -348,5 +348,16 @@ public static class ServiceCollectionExtensions
             new FieldMapping { FieldName = "description", MemberName = "Description", AllowSort = false, AllowFilter = true },
             new FieldMapping { FieldName = "createdAt", MemberName = "CreatedAt", AllowSort = true, AllowFilter = false }
         ]);
+
+        registry.Register<TrainerRelationshipRepository.InvitationProjection>(
+        [
+            new FieldMapping { FieldName = "id", MemberName = "Id", AllowSort = true, AllowFilter = false },
+            new FieldMapping { FieldName = "status", MemberName = "Status", AllowSort = true, AllowFilter = true },
+            new FieldMapping { FieldName = "expiresAt", MemberName = "ExpiresAt", AllowSort = true, AllowFilter = true },
+            new FieldMapping { FieldName = "createdAt", MemberName = "CreatedAt", AllowSort = true, AllowFilter = true },
+            new FieldMapping { FieldName = "inviteeEmail", MemberName = "InviteeEmail", AllowSort = true, AllowFilter = true },
+            new FieldMapping { FieldName = "traineeName", MemberName = "TraineeName", AllowSort = true, AllowFilter = true },
+            new FieldMapping { FieldName = "traineeEmail", MemberName = "TraineeEmail", AllowSort = true, AllowFilter = true }
+        ]);
     }
 }

--- a/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
+++ b/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
@@ -349,7 +349,7 @@ public static class ServiceCollectionExtensions
             new FieldMapping { FieldName = "createdAt", MemberName = "CreatedAt", AllowSort = true, AllowFilter = false }
         ]);
 
-        registry.Register<TrainerRelationshipRepository.InvitationProjection>(
+        registry.Register<LgymApi.Application.Features.TrainerRelationships.Models.TrainerInvitationResult>(
         [
             new FieldMapping { FieldName = "id", MemberName = "Id", AllowSort = true, AllowFilter = false },
             new FieldMapping { FieldName = "status", MemberName = "Status", AllowSort = true, AllowFilter = true },

--- a/LgymApi.IntegrationTests/TrainerRelationshipTests.cs
+++ b/LgymApi.IntegrationTests/TrainerRelationshipTests.cs
@@ -328,7 +328,7 @@ public sealed class TrainerRelationshipTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task GetInvitations_AsTrainer_ReturnsCreatedInvitations()
+    public async Task GetInvitationsPaginated_AsTrainer_ReturnsCreatedInvitations()
     {
         var trainer = await SeedTrainerAsync("trainer-list", "trainer-list@example.com");
         var traineeA = await SeedUserAsync(name: "trainee-list-a", email: "trainee-list-a@example.com", password: "password123");
@@ -343,13 +343,13 @@ public sealed class TrainerRelationshipTests : IntegrationTestBase
         await Client.PostAsJsonAsync("/api/trainer/invitations", new { traineeId = traineeB.Id.ToString() });
         ClearIdempotencyKey();
 
-        var response = await Client.GetAsync("/api/trainer/invitations");
+        var response = await Client.PostAsJsonAsync("/api/trainer/invitations/paginated", new { page = 1, pageSize = 20 });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var body = await response.Content.ReadFromJsonAsync<List<TrainerInvitationResponse>>();
+        var body = await response.Content.ReadFromJsonAsync<PaginatedTrainerInvitationResponse>();
         body.Should().NotBeNull();
-        body!.Count.Should().Be(2);
-        body.Select(x => x.TraineeId).Should().BeEquivalentTo(new[] { traineeA.Id.ToString(), traineeB.Id.ToString() });
+        body!.Items.Count.Should().Be(2);
+        body.Items.Select(x => x.TraineeId).Should().BeEquivalentTo(new[] { traineeA.Id.ToString(), traineeB.Id.ToString() });
     }
 
     [Test]
@@ -1277,6 +1277,30 @@ public sealed class TrainerRelationshipTests : IntegrationTestBase
         [JsonPropertyName("status")]
         public string Status { get; set; } = string.Empty;
 
+    }
+
+    private sealed class PaginatedTrainerInvitationResponse
+    {
+        [JsonPropertyName("items")]
+        public List<TrainerInvitationResponse> Items { get; set; } = [];
+
+        [JsonPropertyName("page")]
+        public int Page { get; set; }
+
+        [JsonPropertyName("pageSize")]
+        public int PageSize { get; set; }
+
+        [JsonPropertyName("totalCount")]
+        public int TotalCount { get; set; }
+
+        [JsonPropertyName("totalPages")]
+        public int TotalPages { get; set; }
+
+        [JsonPropertyName("hasNextPage")]
+        public bool HasNextPage { get; set; }
+
+        [JsonPropertyName("hasPreviousPage")]
+        public bool HasPreviousPage { get; set; }
     }
 
     private sealed class TrainerDashboardTraineesResponse

--- a/LgymApi.Resources/Resources/Enums.pl.resx
+++ b/LgymApi.Resources/Resources/Enums.pl.resx
@@ -105,4 +105,22 @@
   <data name="TutorialStep_LastTreningResult" xml:space="preserve">
     <value>Ostatni wynik treningu</value>
   </data>
+  <data name="TrainerInvitationStatus_Pending" xml:space="preserve">
+    <value>Oczekujące</value>
+  </data>
+  <data name="TrainerInvitationStatus_Accepted" xml:space="preserve">
+    <value>Zaakceptowane</value>
+  </data>
+  <data name="TrainerInvitationStatus_Rejected" xml:space="preserve">
+    <value>Odrzucone</value>
+  </data>
+  <data name="TrainerInvitationStatus_Revoked" xml:space="preserve">
+    <value>Cofnięte</value>
+  </data>
+  <data name="TrainerInvitationStatus_Expired" xml:space="preserve">
+    <value>Wygasłe</value>
+  </data>
+  <data name="TrainerInvitationStatus_SortOrder" xml:space="preserve">
+    <value>Pending,Accepted,Rejected,Revoked,Expired</value>
+  </data>
 </root>

--- a/LgymApi.Resources/Resources/Enums.pl.resx
+++ b/LgymApi.Resources/Resources/Enums.pl.resx
@@ -120,7 +120,4 @@
   <data name="TrainerInvitationStatus_Expired" xml:space="preserve">
     <value>Wygasłe</value>
   </data>
-  <data name="TrainerInvitationStatus_SortOrder" xml:space="preserve">
-    <value>Pending,Accepted,Rejected,Revoked,Expired</value>
-  </data>
 </root>

--- a/LgymApi.Resources/Resources/Enums.resx
+++ b/LgymApi.Resources/Resources/Enums.resx
@@ -120,7 +120,4 @@
   <data name="TrainerInvitationStatus_Expired" xml:space="preserve">
     <value>Expired</value>
   </data>
-  <data name="TrainerInvitationStatus_SortOrder" xml:space="preserve">
-    <value>Pending,Accepted,Rejected,Revoked,Expired</value>
-  </data>
 </root>

--- a/LgymApi.Resources/Resources/Enums.resx
+++ b/LgymApi.Resources/Resources/Enums.resx
@@ -105,4 +105,22 @@
   <data name="TutorialStep_LastTreningResult" xml:space="preserve">
     <value>Last Training Result</value>
   </data>
+  <data name="TrainerInvitationStatus_Pending" xml:space="preserve">
+    <value>Pending</value>
+  </data>
+  <data name="TrainerInvitationStatus_Accepted" xml:space="preserve">
+    <value>Accepted</value>
+  </data>
+  <data name="TrainerInvitationStatus_Rejected" xml:space="preserve">
+    <value>Rejected</value>
+  </data>
+  <data name="TrainerInvitationStatus_Revoked" xml:space="preserve">
+    <value>Revoked</value>
+  </data>
+  <data name="TrainerInvitationStatus_Expired" xml:space="preserve">
+    <value>Expired</value>
+  </data>
+  <data name="TrainerInvitationStatus_SortOrder" xml:space="preserve">
+    <value>Pending,Accepted,Rejected,Revoked,Expired</value>
+  </data>
 </root>

--- a/LgymApi.UnitTests/ReportingServiceTests.cs
+++ b/LgymApi.UnitTests/ReportingServiceTests.cs
@@ -482,6 +482,8 @@ public sealed class ReportingServiceTests
         public Task<TrainerTraineeLink?> FindActiveLinkByTraineeIdAsync(Id<User> traineeId, CancellationToken cancellationToken = default) => Task.FromResult<TrainerTraineeLink?>(null);
         public Task<LgymApi.Application.Features.TrainerRelationships.Models.TrainerDashboardTraineeListResult> GetDashboardTraineesAsync(Id<User> trainerId, LgymApi.Application.Features.TrainerRelationships.Models.TrainerDashboardTraineeQuery query, CancellationToken cancellationToken = default)
             => Task.FromResult(new LgymApi.Application.Features.TrainerRelationships.Models.TrainerDashboardTraineeListResult());
+        public Task<LgymApi.Application.Pagination.Pagination<LgymApi.Application.Features.TrainerRelationships.Models.TrainerInvitationResult>> GetInvitationsPaginatedAsync(Id<User> trainerId, LgymApi.Application.Pagination.FilterInput filterInput, CancellationToken cancellationToken = default)
+            => Task.FromResult(new LgymApi.Application.Pagination.Pagination<LgymApi.Application.Features.TrainerRelationships.Models.TrainerInvitationResult>());
         public Task AddLinkAsync(TrainerTraineeLink link, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task RemoveLinkAsync(TrainerTraineeLink link, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }

--- a/LgymApi.UnitTests/SendInvitationEmailHandlerTests.cs
+++ b/LgymApi.UnitTests/SendInvitationEmailHandlerTests.cs
@@ -652,6 +652,7 @@ public sealed class SendInvitationEmailHandlerTests
         public Task<TrainerTraineeLink?> FindActiveLinkByTrainerAndTraineeAsync(Id<User> trainerId, Id<User> traineeId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<TrainerTraineeLink?> FindActiveLinkByTraineeIdAsync(Id<User> traineeId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<TrainerDashboardTraineeListResult> GetDashboardTraineesAsync(Id<User> trainerId, TrainerDashboardTraineeQuery query, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Pagination<TrainerInvitationResult>> GetInvitationsPaginatedAsync(Id<User> trainerId, FilterInput filterInput, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task AddLinkAsync(TrainerTraineeLink link, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task RemoveLinkAsync(TrainerTraineeLink link, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     }

--- a/LgymApi.UnitTests/SupplementationServiceTests.cs
+++ b/LgymApi.UnitTests/SupplementationServiceTests.cs
@@ -491,6 +491,8 @@ public sealed class SupplementationServiceTests
         public Task<TrainerTraineeLink?> FindActiveLinkByTraineeIdAsync(Id<User> traineeId, CancellationToken cancellationToken = default) => Task.FromResult<TrainerTraineeLink?>(null);
         public Task<LgymApi.Application.Features.TrainerRelationships.Models.TrainerDashboardTraineeListResult> GetDashboardTraineesAsync(Id<User> trainerId, LgymApi.Application.Features.TrainerRelationships.Models.TrainerDashboardTraineeQuery query, CancellationToken cancellationToken = default)
             => Task.FromResult(new LgymApi.Application.Features.TrainerRelationships.Models.TrainerDashboardTraineeListResult());
+        public Task<LgymApi.Application.Pagination.Pagination<LgymApi.Application.Features.TrainerRelationships.Models.TrainerInvitationResult>> GetInvitationsPaginatedAsync(Id<User> trainerId, LgymApi.Application.Pagination.FilterInput filterInput, CancellationToken cancellationToken = default)
+            => Task.FromResult(new LgymApi.Application.Pagination.Pagination<LgymApi.Application.Features.TrainerRelationships.Models.TrainerInvitationResult>());
         public Task AddLinkAsync(TrainerTraineeLink link, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task RemoveLinkAsync(TrainerTraineeLink link, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }

--- a/LgymApi.UnitTests/TrainerRelationshipControllerTests.cs
+++ b/LgymApi.UnitTests/TrainerRelationshipControllerTests.cs
@@ -11,6 +11,7 @@ using LgymApi.Application.Features.TrainerRelationships.Models;
 using LgymApi.Application.Features.Training.Models;
 using LgymApi.Application.Mapping;
 using LgymApi.Application.Mapping.Core;
+using LgymApi.Application.Pagination;
 using LgymApi.Domain.Entities;
 using LgymApi.Domain.ValueObjects;
 using Microsoft.AspNetCore.Mvc;
@@ -90,6 +91,7 @@ public sealed class TrainerRelationshipControllerTests
         public Task<Result<TrainerInvitationResult, AppError>> CreateInvitationAsync(User currentTrainer, Id<User> traineeId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<Result<TrainerInvitationResult, AppError>> CreateInvitationByEmailAsync(User currentTrainer, string inviteeEmail, string preferredLanguage, string preferredTimeZone, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<Result<List<TrainerInvitationResult>, AppError>> GetTrainerInvitationsAsync(User currentTrainer, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Result<Pagination<TrainerInvitationResult>, AppError>> GetInvitationsPaginatedAsync(User currentTrainer, FilterInput filterInput, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<Result<TrainerDashboardTraineeListResult, AppError>> GetDashboardTraineesAsync(User currentTrainer, TrainerDashboardTraineeQuery query, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<Result<List<DateTime>, AppError>> GetTraineeTrainingDatesAsync(User currentTrainer, Id<User> traineeId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<Result<List<TrainingByDateDetails>, AppError>> GetTraineeTrainingByDateAsync(User currentTrainer, Id<User> traineeId, DateTime createdAt, CancellationToken cancellationToken = default) => throw new NotSupportedException();


### PR DESCRIPTION
## Summary

- Add POST /api/trainer/invitations/paginated replacing the non-paginated GET /api/trainer/invitations
- Implement generic enum sorting in GridifyExecutionService - reads sort order from resource files ({EnumType}_SortOrder key) and generates CASE WHEN expression trees, with fallback to (int)x.Enum
- Extend TrainerInvitationDto with inviteeEmail, traineeName, traineeEmail (LEFT JOIN to Users)

## Changes

### Generic Enum Sorting (GridifyExecutionService)
- ApplyEnumOrdering - detects enum fields in sort descriptors, separates them from non-enum sorts
- CreateEnumCaseWhenExpression - builds expression tree from {EnumType}_SortOrder resource key (culture-aware via CultureInfo.CurrentUICulture), falls back to underlying int value
- Works for any enum type without hardcoded logic

### New Endpoint
- POST /api/trainer/invitations/paginated - standard Gridify pagination with filterGroups and sortDescriptors
- Filterable/sortable fields: status (enum), expiresAt, createdAt, inviteeEmail, traineeName, traineeEmail, id

### Resource Translations
- TrainerInvitationStatus_Pending/Accepted/Rejected/Revoked/Expired - en/pl translations
- TrainerInvitationStatus_SortOrder - defines logical sort order per culture

### Files Modified
- GridifyExecutionService.cs - generic enum ordering
- TrainerRelationshipRepository.cs - InvitationProjection, GetInvitationsPaginatedAsync
- TrainerRelationshipController.cs - new paginated endpoint
- TrainerRelationshipService.cs + ITrainerRelationshipService.cs - service layer
- TrainerRelationshipDtos.cs - paginated request/result DTOs
- Enums.resx / Enums.pl.resx - translations + sort order
- ServiceCollectionExtensions.cs - field mappings
- TrainerProfile.cs - updated mapping
- Test stubs updated for new interface members