### PR TITLE
feat(architecture): add CancellationToken guard for controller actions (#247)

### DIFF
--- a/LgymApi.Api/Features/AdminUser/Controllers/AdminUserController.cs
+++ b/LgymApi.Api/Features/AdminUser/Controllers/AdminUserController.cs
@@ -29,9 +29,8 @@ public sealed class AdminUserController : ControllerBase
 
     [HttpPost("paginated")]
     [ProducesResponseType(typeof(PaginatedAdminUserResult), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetUsersPaginated([FromBody] PaginatedUserRequest request)
+    public async Task<IActionResult> GetUsersPaginated([FromBody] PaginatedUserRequest request, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var filterInput = new FilterInput
         {
             Page = request.Page,
@@ -64,9 +63,8 @@ public sealed class AdminUserController : ControllerBase
     [HttpGet("{id}")]
     [ProducesResponseType(typeof(AdminUserDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetUser([FromRoute] string id)
+    public async Task<IActionResult> GetUser([FromRoute] string id, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var userId = Id<Domain.Entities.User>.TryParse(id, out var parsedUserId) ? parsedUserId : Id<Domain.Entities.User>.Empty;
         var result = await _adminUserService.GetUserAsync(userId, cancellationToken);
 
@@ -82,9 +80,8 @@ public sealed class AdminUserController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> UpdateUser([FromRoute] string id, [FromBody] UpdateUserRequest request)
+    public async Task<IActionResult> UpdateUser([FromRoute] string id, [FromBody] UpdateUserRequest request, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var targetUserId = Id<Domain.Entities.User>.TryParse(id, out var parsedUserId) ? parsedUserId : Id<Domain.Entities.User>.Empty;
         var adminUserId = GetAdminUserId();
         var command = new UpdateUserCommand
@@ -110,9 +107,8 @@ public sealed class AdminUserController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> DeleteUser([FromRoute] string id)
+    public async Task<IActionResult> DeleteUser([FromRoute] string id, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var targetUserId = Id<Domain.Entities.User>.TryParse(id, out var parsedUserId) ? parsedUserId : Id<Domain.Entities.User>.Empty;
         var adminUserId = GetAdminUserId();
         var result = await _adminUserService.DeleteUserAsync(targetUserId, adminUserId, cancellationToken);
@@ -129,9 +125,8 @@ public sealed class AdminUserController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> BlockUser([FromRoute] string id)
+    public async Task<IActionResult> BlockUser([FromRoute] string id, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var targetUserId = Id<Domain.Entities.User>.TryParse(id, out var parsedUserId) ? parsedUserId : Id<Domain.Entities.User>.Empty;
         var adminUserId = GetAdminUserId();
         var result = await _adminUserService.BlockUserAsync(targetUserId, adminUserId, cancellationToken);
@@ -147,9 +142,8 @@ public sealed class AdminUserController : ControllerBase
     [HttpPost("{id}/unblock")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> UnblockUser([FromRoute] string id)
+    public async Task<IActionResult> UnblockUser([FromRoute] string id, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var targetUserId = Id<Domain.Entities.User>.TryParse(id, out var parsedUserId) ? parsedUserId : Id<Domain.Entities.User>.Empty;
         var result = await _adminUserService.UnblockUserAsync(targetUserId, cancellationToken);
 

--- a/LgymApi.Api/Features/AppConfig/Controllers/AppConfigController.cs
+++ b/LgymApi.Api/Features/AppConfig/Controllers/AppConfigController.cs
@@ -29,9 +29,9 @@ public sealed class AppConfigController : ControllerBase
     [ProducesResponseType(typeof(AppConfigInfoDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetAppVersion([FromBody] AppConfigVersionRequestDto request)
+    public async Task<IActionResult> GetAppVersion([FromBody] AppConfigVersionRequestDto request, CancellationToken cancellationToken = default)
     {
-        var result = await _appConfigService.GetLatestByPlatformAsync(request.Platform, HttpContext.RequestAborted);
+        var result = await _appConfigService.GetLatestByPlatformAsync(request.Platform, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -44,7 +44,7 @@ public sealed class AppConfigController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
-    public async Task<IActionResult> CreateNewAppVersion([FromRoute] string id, [FromBody] AppConfigInfoWithPlatformDto form)
+    public async Task<IActionResult> CreateNewAppVersion([FromRoute] string id, [FromBody] AppConfigInfoWithPlatformDto form, CancellationToken cancellationToken = default)
     {
         var guidUserId = HttpContext.ParseRouteUserIdForCurrentAdmin(id);
         var userId = guidUserId;
@@ -55,7 +55,7 @@ public sealed class AppConfigController : ControllerBase
             form.ForceUpdate,
             form.UpdateUrl,
             form.ReleaseNotes);
-        var result = await _appConfigService.CreateNewAppVersionAsync(userId, input, HttpContext.RequestAborted);
+        var result = await _appConfigService.CreateNewAppVersionAsync(userId, input, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();

--- a/LgymApi.Api/Features/EloRegistry/Controllers/EloRegistryController.cs
+++ b/LgymApi.Api/Features/EloRegistry/Controllers/EloRegistryController.cs
@@ -28,10 +28,10 @@ public sealed class EloRegistryController : ControllerBase
     [ProducesResponseType(typeof(List<EloRegistryBaseChartDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetEloRegistryChart([FromRoute] string id)
+    public async Task<IActionResult> GetEloRegistryChart([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
-        var result = await _eloRegistryService.GetChartAsync(userId, HttpContext.RequestAborted);
+        var result = await _eloRegistryService.GetChartAsync(userId, cancellationToken);
         
         if (result.IsFailure)
         {

--- a/LgymApi.Api/Features/Exercise/Controllers/ExerciseController.cs
+++ b/LgymApi.Api/Features/Exercise/Controllers/ExerciseController.cs
@@ -33,9 +33,9 @@ public sealed class ExerciseController : ControllerBase
     [HttpPost("exercise/addExercise")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> AddExercise([FromBody] ExerciseFormDto form)
+    public async Task<IActionResult> AddExercise([FromBody] ExerciseFormDto form, CancellationToken cancellationToken = default)
     {
-        var result = await _exerciseService.AddExerciseAsync(form.Name, form.BodyPart, form.Description, form.Image, HttpContext.RequestAborted);
+        var result = await _exerciseService.AddExerciseAsync(form.Name, form.BodyPart, form.Description, form.Image, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -48,11 +48,11 @@ public sealed class ExerciseController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> AddUserExercise([FromRoute] string id, [FromBody] ExerciseFormDto form)
+    public async Task<IActionResult> AddUserExercise([FromRoute] string id, [FromBody] ExerciseFormDto form, CancellationToken cancellationToken = default)
     {
         var userId = id.ToIdOrEmpty<UserEntity>();
         var input = new AddUserExerciseInput(userId, form.Name, form.BodyPart, form.Description, form.Image);
-        var result = await _exerciseService.AddUserExerciseAsync(input, HttpContext.RequestAborted);
+        var result = await _exerciseService.AddUserExerciseAsync(input, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -66,7 +66,7 @@ public sealed class ExerciseController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> DeleteExercise([FromRoute] string id, [FromBody] Dictionary<string, string> body)
+    public async Task<IActionResult> DeleteExercise([FromRoute] string id, [FromBody] Dictionary<string, string> body, CancellationToken cancellationToken = default)
     {
         if (!body.TryGetValue("id", out var exerciseIdString))
         {
@@ -75,7 +75,7 @@ public sealed class ExerciseController : ControllerBase
 
         var userId = id.ToIdOrEmpty<UserEntity>();
         var exerciseId = exerciseIdString.ToIdOrEmpty<ExerciseEntity>();
-        var result = await _exerciseService.DeleteExerciseAsync(userId, exerciseId, HttpContext.RequestAborted);
+        var result = await _exerciseService.DeleteExerciseAsync(userId, exerciseId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -88,11 +88,11 @@ public sealed class ExerciseController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> UpdateExercise([FromBody] ExerciseFormDto form)
+    public async Task<IActionResult> UpdateExercise([FromBody] ExerciseFormDto form, CancellationToken cancellationToken = default)
     {
         var exerciseId = form.Id.ToIdOrEmpty<ExerciseEntity>();
         var input = new UpdateExerciseInput(exerciseId, form.Name, form.BodyPart, form.Description, form.Image);
-        var result = await _exerciseService.UpdateExerciseAsync(input, HttpContext.RequestAborted);
+        var result = await _exerciseService.UpdateExerciseAsync(input, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -106,13 +106,13 @@ public sealed class ExerciseController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> AddGlobalTranslation([FromRoute] string id, [FromBody] ExerciseTranslationDto form)
+    public async Task<IActionResult> AddGlobalTranslation([FromRoute] string id, [FromBody] ExerciseTranslationDto form, CancellationToken cancellationToken = default)
     {
         var currentUser = HttpContext.GetCurrentUser();
         var routeUserId = id.ToIdOrEmpty<UserEntity>();
         var exerciseId = form.ExerciseId.ToIdOrEmpty<ExerciseEntity>();
         var input = new AddGlobalTranslationInput(routeUserId, exerciseId, form.Culture, form.Name);
-        var result = await _exerciseService.AddGlobalTranslationAsync(currentUser!, input, HttpContext.RequestAborted);
+        var result = await _exerciseService.AddGlobalTranslationAsync(currentUser!, input, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -124,11 +124,11 @@ public sealed class ExerciseController : ControllerBase
     [HttpGet("exercise/{id}/getAllExercises")]
     [ProducesResponseType(typeof(List<ExerciseResponseDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetAllExercises([FromRoute] string id)
+    public async Task<IActionResult> GetAllExercises([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var userId = id.ToIdOrEmpty<UserEntity>();
         var cultures = HttpContext.GetCulturePreferences();
-        var result = await _exerciseService.GetAllExercisesAsync(userId, cultures, HttpContext.RequestAborted);
+        var result = await _exerciseService.GetAllExercisesAsync(userId, cultures, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -144,11 +144,11 @@ public sealed class ExerciseController : ControllerBase
     [HttpGet("exercise/{id}/getAllUserExercises")]
     [ProducesResponseType(typeof(List<ExerciseResponseDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetAllUserExercises([FromRoute] string id)
+    public async Task<IActionResult> GetAllUserExercises([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var userId = id.ToIdOrEmpty<UserEntity>();
         var cultures = HttpContext.GetCulturePreferences();
-        var result = await _exerciseService.GetAllUserExercisesAsync(userId, cultures, HttpContext.RequestAborted);
+        var result = await _exerciseService.GetAllUserExercisesAsync(userId, cultures, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -164,10 +164,10 @@ public sealed class ExerciseController : ControllerBase
     [HttpGet("exercise/getAllGlobalExercises")]
     [ProducesResponseType(typeof(List<ExerciseResponseDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetAllGlobalExercises()
+    public async Task<IActionResult> GetAllGlobalExercises(CancellationToken cancellationToken = default)
     {
         var cultures = HttpContext.GetCulturePreferences();
-        var result = await _exerciseService.GetAllGlobalExercisesAsync(cultures, HttpContext.RequestAborted);
+        var result = await _exerciseService.GetAllGlobalExercisesAsync(cultures, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -184,11 +184,11 @@ public sealed class ExerciseController : ControllerBase
     [ProducesResponseType(typeof(List<ExerciseResponseDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetExerciseByBodyPart([FromRoute] string id, [FromBody] ExerciseByBodyPartRequestDto request)
+    public async Task<IActionResult> GetExerciseByBodyPart([FromRoute] string id, [FromBody] ExerciseByBodyPartRequestDto request, CancellationToken cancellationToken = default)
     {
         var userId = id.ToIdOrEmpty<UserEntity>();
         var cultures = HttpContext.GetCulturePreferences();
-        var result = await _exerciseService.GetExerciseByBodyPartAsync(userId, request.BodyPart, cultures, HttpContext.RequestAborted);
+        var result = await _exerciseService.GetExerciseByBodyPartAsync(userId, request.BodyPart, cultures, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -204,11 +204,11 @@ public sealed class ExerciseController : ControllerBase
     [HttpGet("exercise/{id}/getExercise")]
     [ProducesResponseType(typeof(ExerciseResponseDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetExercise([FromRoute] string id)
+    public async Task<IActionResult> GetExercise([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var exerciseId = id.ToIdOrEmpty<ExerciseEntity>();
         var cultures = HttpContext.GetCulturePreferences();
-        var result = await _exerciseService.GetExerciseAsync(exerciseId, cultures, HttpContext.RequestAborted);
+        var result = await _exerciseService.GetExerciseAsync(exerciseId, cultures, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -223,7 +223,7 @@ public sealed class ExerciseController : ControllerBase
     [HttpPost("exercise/{id}/getLastExerciseScores")]
     [ProducesResponseType(typeof(LastExerciseScoresResponseDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetLastExerciseScores([FromRoute] string id, [FromBody] LastExerciseScoresRequestDto request)
+    public async Task<IActionResult> GetLastExerciseScores([FromRoute] string id, [FromBody] LastExerciseScoresRequestDto request, CancellationToken cancellationToken = default)
     {
         var routeUserId = id.ToIdOrEmpty<UserEntity>();
         var currentUserId = HttpContext.GetCurrentUserId();
@@ -231,7 +231,7 @@ public sealed class ExerciseController : ControllerBase
         var gymId = request.GymId.ToNullableId<LgymApi.Domain.Entities.Gym>();
 
         var input = new GetLastExerciseScoresInput(routeUserId, currentUserId, exerciseId, request.Series, gymId, request.ExerciseName);
-        var result = await _exerciseService.GetLastExerciseScoresAsync(input, HttpContext.RequestAborted);
+        var result = await _exerciseService.GetLastExerciseScoresAsync(input, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -244,11 +244,11 @@ public sealed class ExerciseController : ControllerBase
     [ProducesResponseType(typeof(List<ExerciseTrainingHistoryItemDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetExerciseScoresFromTrainingByExercise([FromBody] RecordOrPossibleRequestDto request)
+    public async Task<IActionResult> GetExerciseScoresFromTrainingByExercise([FromBody] RecordOrPossibleRequestDto request, CancellationToken cancellationToken = default)
     {
         var currentUserId = HttpContext.GetCurrentUserId();
         var exerciseId = request.ExerciseId.ToIdOrEmpty<ExerciseEntity>();
-        var result = await _exerciseService.GetExerciseScoresFromTrainingByExerciseAsync(currentUserId, exerciseId, HttpContext.RequestAborted);
+        var result = await _exerciseService.GetExerciseScoresFromTrainingByExerciseAsync(currentUserId, exerciseId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();

--- a/LgymApi.Api/Features/ExerciseScores/Controllers/ExerciseScoresController.cs
+++ b/LgymApi.Api/Features/ExerciseScores/Controllers/ExerciseScoresController.cs
@@ -28,11 +28,11 @@ public sealed class ExerciseScoresController : ControllerBase
     [ProducesResponseType(typeof(List<ExerciseScoresChartDataDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetExerciseScoresChartData([FromRoute] string id, [FromBody] ExerciseScoresChartRequestDto request)
+    public async Task<IActionResult> GetExerciseScoresChartData([FromRoute] string id, [FromBody] ExerciseScoresChartRequestDto request, CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
         Id<LgymApi.Domain.Entities.Exercise>.TryParse(request.ExerciseId, out var parsedExerciseId);
-        var result = await _exerciseScoresService.GetExerciseScoresChartDataAsync(userId, parsedExerciseId, HttpContext.RequestAborted);
+        var result = await _exerciseScoresService.GetExerciseScoresChartDataAsync(userId, parsedExerciseId, cancellationToken);
         
         if (result.IsFailure)
         {

--- a/LgymApi.Api/Features/Gym/Controllers/GymController.cs
+++ b/LgymApi.Api/Features/Gym/Controllers/GymController.cs
@@ -28,12 +28,12 @@ public sealed class GymController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> AddGym([FromRoute] string id, [FromBody] GymFormDto form)
+    public async Task<IActionResult> AddGym([FromRoute] string id, [FromBody] GymFormDto form, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         var routeUserId = Id<LgymApi.Domain.Entities.User>.TryParse(id, out var parsedUserId) ? parsedUserId : Id<LgymApi.Domain.Entities.User>.Empty;
         
-        var result = await _gymService.AddGymAsync(user!, routeUserId, form.Name, form.Address, HttpContext.RequestAborted);
+        var result = await _gymService.AddGymAsync(user!, routeUserId, form.Name, form.Address, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -47,12 +47,12 @@ public sealed class GymController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> DeleteGym([FromRoute] string id)
+    public async Task<IActionResult> DeleteGym([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         var gymId = Id<LgymApi.Domain.Entities.Gym>.TryParse(id, out var parsedGymId) ? parsedGymId : Id<LgymApi.Domain.Entities.Gym>.Empty;
         
-        var result = await _gymService.DeleteGymAsync(user!, gymId, HttpContext.RequestAborted);
+        var result = await _gymService.DeleteGymAsync(user!, gymId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -65,12 +65,12 @@ public sealed class GymController : ControllerBase
     [ProducesResponseType(typeof(List<GymChoiceInfoDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetGyms([FromRoute] string id)
+    public async Task<IActionResult> GetGyms([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         var routeUserId = Id<LgymApi.Domain.Entities.User>.TryParse(id, out var parsedUserId) ? parsedUserId : Id<LgymApi.Domain.Entities.User>.Empty;
         
-        var result = await _gymService.GetGymsAsync(user!, routeUserId, HttpContext.RequestAborted);
+        var result = await _gymService.GetGymsAsync(user!, routeUserId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -90,12 +90,12 @@ public sealed class GymController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetGym([FromRoute] string id)
+    public async Task<IActionResult> GetGym([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         var gymId = Id<LgymApi.Domain.Entities.Gym>.TryParse(id, out var parsedGymId) ? parsedGymId : Id<LgymApi.Domain.Entities.Gym>.Empty;
         
-        var result = await _gymService.GetGymAsync(user!, gymId, HttpContext.RequestAborted);
+        var result = await _gymService.GetGymAsync(user!, gymId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -109,12 +109,12 @@ public sealed class GymController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> EditGym([FromBody] GymFormDto form)
+    public async Task<IActionResult> EditGym([FromBody] GymFormDto form, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         var gymId = Id<LgymApi.Domain.Entities.Gym>.TryParse(form.Id, out var parsedGymId) ? parsedGymId : Id<LgymApi.Domain.Entities.Gym>.Empty;
         
-        var result = await _gymService.UpdateGymAsync(user!, gymId, form.Name, form.Address, HttpContext.RequestAborted);
+        var result = await _gymService.UpdateGymAsync(user!, gymId, form.Name, form.Address, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();

--- a/LgymApi.Api/Features/InAppNotification/Controllers/InAppNotificationController.cs
+++ b/LgymApi.Api/Features/InAppNotification/Controllers/InAppNotificationController.cs
@@ -31,11 +31,12 @@ public sealed class InAppNotificationController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetNotifications(
         [FromRoute] string id,
-        [FromQuery] GetNotificationsQueryDto query)
+        [FromQuery] GetNotificationsQueryDto query,
+        CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
         var cursorQuery = _mapper.Map<GetNotificationsQueryDto, CursorPaginationQuery>(query);
-        var result = await _notificationService.GetForUserAsync(userId, cursorQuery, HttpContext.RequestAborted);
+        var result = await _notificationService.GetForUserAsync(userId, cursorQuery, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -51,11 +52,12 @@ public sealed class InAppNotificationController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> MarkAsRead(
         [FromRoute] string id,
-        [FromRoute] string notificationId)
+        [FromRoute] string notificationId,
+        CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
         var notifId = notificationId.ToIdOrEmpty<NotificationEntity>();
-        var result = await _notificationService.MarkAsReadAsync(notifId, userId, HttpContext.RequestAborted);
+        var result = await _notificationService.MarkAsReadAsync(notifId, userId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -69,10 +71,11 @@ public sealed class InAppNotificationController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> MarkAllAsRead(
         [FromRoute] string id,
-        [FromQuery] DateTimeOffset? before)
+        [FromQuery] DateTimeOffset? before,
+        CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
-        var result = await _notificationService.MarkAllAsReadAsync(userId, before, HttpContext.RequestAborted);
+        var result = await _notificationService.MarkAllAsReadAsync(userId, before, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -84,10 +87,10 @@ public sealed class InAppNotificationController : ControllerBase
     [HttpGet("{id}/notifications/unread-count")]
     [ProducesResponseType(typeof(UnreadCountDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
-    public async Task<IActionResult> GetUnreadCount([FromRoute] string id)
+    public async Task<IActionResult> GetUnreadCount([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
-        var result = await _notificationService.GetUnreadCountAsync(userId, HttpContext.RequestAborted);
+        var result = await _notificationService.GetUnreadCountAsync(userId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();

--- a/LgymApi.Api/Features/MainRecords/Controllers/MainRecordsController.cs
+++ b/LgymApi.Api/Features/MainRecords/Controllers/MainRecordsController.cs
@@ -28,12 +28,12 @@ public sealed class MainRecordsController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> AddNewRecord([FromRoute] string id, [FromBody] MainRecordsFormDto form)
+    public async Task<IActionResult> AddNewRecord([FromRoute] string id, [FromBody] MainRecordsFormDto form, CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
         var exerciseId = form.ExerciseId.ToIdOrEmpty<Domain.Entities.Exercise>();
         var input = new AddMainRecordInput(userId, exerciseId, form.Weight, form.Unit, form.Date);
-        var result = await _mainRecordsService.AddNewRecordAsync(input, HttpContext.RequestAborted);
+        var result = await _mainRecordsService.AddNewRecordAsync(input, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -46,10 +46,10 @@ public sealed class MainRecordsController : ControllerBase
     [ProducesResponseType(typeof(List<MainRecordResponseDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetMainRecordsHistory([FromRoute] string id)
+    public async Task<IActionResult> GetMainRecordsHistory([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
-        var result = await _mainRecordsService.GetMainRecordsHistoryAsync(userId, HttpContext.RequestAborted);
+        var result = await _mainRecordsService.GetMainRecordsHistoryAsync(userId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -64,10 +64,10 @@ public sealed class MainRecordsController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
     // Route name is legacy; payload contains best (max) record per exercise.
-    public async Task<IActionResult> GetLastMainRecords([FromRoute] string id)
+    public async Task<IActionResult> GetLastMainRecords([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
-        var result = await _mainRecordsService.GetLastMainRecordsAsync(userId, HttpContext.RequestAborted);
+        var result = await _mainRecordsService.GetLastMainRecordsAsync(userId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -84,11 +84,11 @@ public sealed class MainRecordsController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> DeleteMainRecord([FromRoute] string id)
+    public async Task<IActionResult> DeleteMainRecord([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var currentUserId = HttpContext.GetCurrentUserId();
         var recordId = id.ToIdOrEmpty<Domain.Entities.MainRecord>();
-        var result = await _mainRecordsService.DeleteMainRecordAsync(currentUserId, recordId, HttpContext.RequestAborted);
+        var result = await _mainRecordsService.DeleteMainRecordAsync(currentUserId, recordId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -101,13 +101,13 @@ public sealed class MainRecordsController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> UpdateMainRecords([FromRoute] string id, [FromBody] MainRecordsFormDto form)
+    public async Task<IActionResult> UpdateMainRecords([FromRoute] string id, [FromBody] MainRecordsFormDto form, CancellationToken cancellationToken = default)
     {
         var routeUserId = HttpContext.ParseRouteUserIdForCurrentUser(id);
         var recordId = form.Id.ToIdOrEmpty<Domain.Entities.MainRecord>();
         var exerciseId = form.ExerciseId.ToIdOrEmpty<Domain.Entities.Exercise>();
         var input = new UpdateMainRecordInput(routeUserId, routeUserId, recordId, exerciseId, form.Weight, form.Unit, form.Date);
-        var result = await _mainRecordsService.UpdateMainRecordAsync(input, HttpContext.RequestAborted);
+        var result = await _mainRecordsService.UpdateMainRecordAsync(input, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -119,11 +119,11 @@ public sealed class MainRecordsController : ControllerBase
     [HttpPost("mainRecords/getRecordOrPossibleRecordInExercise")]
     [ProducesResponseType(typeof(PossibleRecordForExerciseDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetRecordOrPossibleRecordInExercise([FromBody] RecordOrPossibleRequestDto request)
+    public async Task<IActionResult> GetRecordOrPossibleRecordInExercise([FromBody] RecordOrPossibleRequestDto request, CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.GetCurrentUserId();
         var exerciseId = request.ExerciseId.ToIdOrEmpty<Domain.Entities.Exercise>();
-        var result = await _mainRecordsService.GetRecordOrPossibleRecordInExerciseAsync(userId, exerciseId, HttpContext.RequestAborted);
+        var result = await _mainRecordsService.GetRecordOrPossibleRecordInExerciseAsync(userId, exerciseId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();

--- a/LgymApi.Api/Features/Measurements/Controllers/MeasurementsController.cs
+++ b/LgymApi.Api/Features/Measurements/Controllers/MeasurementsController.cs
@@ -28,10 +28,10 @@ namespace LgymApi.Api.Features.Measurements.Controllers;
     [HttpPost("measurements/add")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> AddMeasurement([FromBody] MeasurementFormDto form)
+    public async Task<IActionResult> AddMeasurement([FromBody] MeasurementFormDto form, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var result = await _measurementsService.AddMeasurementAsync(user!, form.BodyPart, form.Unit, form.Value, HttpContext.RequestAborted);
+        var result = await _measurementsService.AddMeasurementAsync(user!, form.BodyPart, form.Unit, form.Value, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -45,11 +45,11 @@ namespace LgymApi.Api.Features.Measurements.Controllers;
     [ProducesResponseType(typeof(MeasurementResponseDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetMeasurementDetail([FromRoute] string id)
+    public async Task<IActionResult> GetMeasurementDetail([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         var measurementId = Id<Measurement>.TryParse(id, out var parsedId) ? parsedId : Id<Measurement>.Empty;
-        var result = await _measurementsService.GetMeasurementDetailAsync(user!, measurementId, HttpContext.RequestAborted);
+        var result = await _measurementsService.GetMeasurementDetailAsync(user!, measurementId, cancellationToken);
         
         if (result.IsFailure)
         {
@@ -64,11 +64,11 @@ namespace LgymApi.Api.Features.Measurements.Controllers;
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetMeasurementsHistory([FromRoute] string id, [FromQuery] MeasurementsHistoryRequestDto? request)
+    public async Task<IActionResult> GetMeasurementsHistory([FromRoute] string id, [FromQuery] MeasurementsHistoryRequestDto? request, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         var routeUserId = Id<UserEntity>.TryParse(id, out var parsedUserId) ? parsedUserId : Id<UserEntity>.Empty;
-        var result = await _measurementsService.GetMeasurementsHistoryAsync(user!, routeUserId, request?.BodyPart, request?.Unit, HttpContext.RequestAborted);
+        var result = await _measurementsService.GetMeasurementsHistoryAsync(user!, routeUserId, request?.BodyPart, request?.Unit, cancellationToken);
         
         if (result.IsFailure)
         {
@@ -84,11 +84,11 @@ namespace LgymApi.Api.Features.Measurements.Controllers;
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetMeasurementsList([FromRoute] string id, [FromQuery] MeasurementsHistoryRequestDto? request)
+    public async Task<IActionResult> GetMeasurementsList([FromRoute] string id, [FromQuery] MeasurementsHistoryRequestDto? request, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         var routeUserId = Id<UserEntity>.TryParse(id, out var parsedUserId) ? parsedUserId : Id<UserEntity>.Empty;
-        var result = await _measurementsService.GetMeasurementsListAsync(user!, routeUserId, request?.BodyPart, request?.Unit, HttpContext.RequestAborted);
+        var result = await _measurementsService.GetMeasurementsListAsync(user!, routeUserId, request?.BodyPart, request?.Unit, cancellationToken);
         
         if (result.IsFailure)
         {
@@ -104,11 +104,11 @@ namespace LgymApi.Api.Features.Measurements.Controllers;
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetMeasurementsTrend([FromRoute] string id, [FromQuery] MeasurementTrendRequestDto request)
+    public async Task<IActionResult> GetMeasurementsTrend([FromRoute] string id, [FromQuery] MeasurementTrendRequestDto request, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         var routeUserId = Id<UserEntity>.TryParse(id, out var parsedUserId) ? parsedUserId : Id<UserEntity>.Empty;
-        var result = await _measurementsService.GetMeasurementsTrendAsync(user!, routeUserId, request.BodyPart, request.Unit, HttpContext.RequestAborted);
+        var result = await _measurementsService.GetMeasurementsTrendAsync(user!, routeUserId, request.BodyPart, request.Unit, cancellationToken);
         
         if (result.IsFailure)
         {

--- a/LgymApi.Api/Features/Plan/Controllers/PlanController.cs
+++ b/LgymApi.Api/Features/Plan/Controllers/PlanController.cs
@@ -31,7 +31,7 @@ public sealed class PlanController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> CreatePlan([FromRoute] string id, [FromBody] PlanFormDto form)
+    public async Task<IActionResult> CreatePlan([FromRoute] string id, [FromBody] PlanFormDto form, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<UserEntity>.TryParse(id, out var routeUserId))
@@ -39,7 +39,7 @@ public sealed class PlanController : ControllerBase
             return Result<Unit, AppError>.Failure(new PlanNotFoundError(Messages.DidntFind)).ToActionResult();
         }
 
-        var result = await _planService.CreatePlanAsync(user!, routeUserId, form.Name, HttpContext.RequestAborted);
+        var result = await _planService.CreatePlanAsync(user!, routeUserId, form.Name, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -53,7 +53,7 @@ public sealed class PlanController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> UpdatePlan([FromRoute] string id, [FromBody] PlanFormDto form)
+    public async Task<IActionResult> UpdatePlan([FromRoute] string id, [FromBody] PlanFormDto form, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<UserEntity>.TryParse(id, out var routeUserId))
@@ -66,7 +66,7 @@ public sealed class PlanController : ControllerBase
             return Result<Unit, AppError>.Failure(new PlanNotFoundError(Messages.DidntFind)).ToActionResult();
         }
 
-        var result = await _planService.UpdatePlanAsync(user!, routeUserId, planId, form.Name, HttpContext.RequestAborted);
+        var result = await _planService.UpdatePlanAsync(user!, routeUserId, planId, form.Name, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -79,7 +79,7 @@ public sealed class PlanController : ControllerBase
     [ProducesResponseType(typeof(PlanFormDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetPlanConfig([FromRoute] string id)
+    public async Task<IActionResult> GetPlanConfig([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<UserEntity>.TryParse(id, out var routeUserId))
@@ -87,7 +87,7 @@ public sealed class PlanController : ControllerBase
             return Result<PlanEntity, AppError>.Failure(new PlanNotFoundError(Messages.DidntFind)).ToActionResult();
         }
 
-        var result = await _planService.GetPlanConfigAsync(user!, routeUserId, HttpContext.RequestAborted);
+        var result = await _planService.GetPlanConfigAsync(user!, routeUserId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -100,11 +100,11 @@ public sealed class PlanController : ControllerBase
     [ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(bool), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(bool), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> CheckIsUserHavePlan([FromRoute] string id)
+    public async Task<IActionResult> CheckIsUserHavePlan([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         var routeUserId = Id<UserEntity>.TryParse(id, out var parsedUserId) ? parsedUserId : Id<UserEntity>.Empty;
-        var result = await _planService.CheckIsUserHavePlanAsync(user!, routeUserId, HttpContext.RequestAborted);
+        var result = await _planService.CheckIsUserHavePlanAsync(user!, routeUserId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -117,7 +117,7 @@ public sealed class PlanController : ControllerBase
     [ProducesResponseType(typeof(List<PlanFormDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetPlansList([FromRoute] string id)
+    public async Task<IActionResult> GetPlansList([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<UserEntity>.TryParse(id, out var routeUserId))
@@ -125,7 +125,7 @@ public sealed class PlanController : ControllerBase
             return Result<List<PlanEntity>, AppError>.Failure(new PlanNotFoundError(Messages.DidntFind)).ToActionResult();
         }
 
-        var result = await _planService.GetPlansListAsync(user!, routeUserId, HttpContext.RequestAborted);
+        var result = await _planService.GetPlansListAsync(user!, routeUserId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -139,7 +139,7 @@ public sealed class PlanController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> SetNewActivePlan([FromRoute] string id, [FromBody] SetActivePlanDto form)
+    public async Task<IActionResult> SetNewActivePlan([FromRoute] string id, [FromBody] SetActivePlanDto form, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<UserEntity>.TryParse(id, out var routeUserId))
@@ -152,7 +152,7 @@ public sealed class PlanController : ControllerBase
             return Result<Unit, AppError>.Failure(new PlanNotFoundError(Messages.DidntFind)).ToActionResult();
         }
 
-        var result = await _planService.SetNewActivePlanAsync(user!, routeUserId, planId, HttpContext.RequestAborted);
+        var result = await _planService.SetNewActivePlanAsync(user!, routeUserId, planId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -165,10 +165,10 @@ public sealed class PlanController : ControllerBase
     [ProducesResponseType(typeof(PlanDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> CopyPlan([FromBody] CopyPlanDto dto)
+    public async Task<IActionResult> CopyPlan([FromBody] CopyPlanDto dto, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var result = await _planService.CopyPlanAsync(user!, dto.ShareCode, HttpContext.RequestAborted);
+        var result = await _planService.CopyPlanAsync(user!, dto.ShareCode, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -182,7 +182,7 @@ public sealed class PlanController : ControllerBase
     [ProducesResponseType(typeof(ShareCodeResponseDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GenerateShareCode([FromRoute] string id)
+    public async Task<IActionResult> GenerateShareCode([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<PlanEntity>.TryParse(id, out var planId))
@@ -190,7 +190,7 @@ public sealed class PlanController : ControllerBase
             return Result<string, AppError>.Failure(new PlanNotFoundError(Messages.DidntFind)).ToActionResult();
         }
 
-        var result = await _planService.GenerateShareCodeAsync(user!, planId, HttpContext.RequestAborted);
+        var result = await _planService.GenerateShareCodeAsync(user!, planId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -203,7 +203,7 @@ public sealed class PlanController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> DeletePlan([FromRoute] string id)
+    public async Task<IActionResult> DeletePlan([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<PlanEntity>.TryParse(id, out var planId))
@@ -211,7 +211,7 @@ public sealed class PlanController : ControllerBase
             return Result<Unit, AppError>.Failure(new PlanNotFoundError(Messages.DidntFind)).ToActionResult();
         }
 
-        var result = await _planService.DeletePlanAsync(user!, planId, HttpContext.RequestAborted);
+        var result = await _planService.DeletePlanAsync(user!, planId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();

--- a/LgymApi.Api/Features/PlanDay/Controllers/PlanDayController.cs
+++ b/LgymApi.Api/Features/PlanDay/Controllers/PlanDayController.cs
@@ -35,7 +35,7 @@ public sealed class PlanDayController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> CreatePlanDay([FromRoute] string id, [FromBody] PlanDayFormDto form)
+    public async Task<IActionResult> CreatePlanDay([FromRoute] string id, [FromBody] PlanDayFormDto form, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<PlanEntity>.TryParse(id, out var planId))
@@ -51,7 +51,7 @@ public sealed class PlanDayController : ControllerBase
                 Reps = exercise.Reps
             })
             .ToList();
-        var result = await _planDayService.CreatePlanDayAsync(user!, planId, form.Name, exercises, HttpContext.RequestAborted);
+        var result = await _planDayService.CreatePlanDayAsync(user!, planId, form.Name, exercises, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -65,7 +65,7 @@ public sealed class PlanDayController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> UpdatePlanDay([FromBody] PlanDayFormDto form)
+    public async Task<IActionResult> UpdatePlanDay([FromBody] PlanDayFormDto form, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<PlanDayEntity>.TryParse(form.Id ?? string.Empty, out var planDayId))
@@ -81,7 +81,7 @@ public sealed class PlanDayController : ControllerBase
                 Reps = exercise.Reps
             })
             .ToList();
-        var result = await _planDayService.UpdatePlanDayAsync(user!, planDayId, form.Name, exercises, HttpContext.RequestAborted);
+        var result = await _planDayService.UpdatePlanDayAsync(user!, planDayId, form.Name, exercises, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -94,7 +94,7 @@ public sealed class PlanDayController : ControllerBase
     [ProducesResponseType(typeof(PlanDayVmDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetPlanDay([FromRoute] string id)
+    public async Task<IActionResult> GetPlanDay([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<PlanDayEntity>.TryParse(id, out var planDayId))
@@ -103,7 +103,7 @@ public sealed class PlanDayController : ControllerBase
         }
 
         var cultures = HttpContext.GetCulturePreferences();
-        var result = await _planDayService.GetPlanDayAsync(user!, planDayId, cultures, HttpContext.RequestAborted);
+        var result = await _planDayService.GetPlanDayAsync(user!, planDayId, cultures, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -122,7 +122,7 @@ public sealed class PlanDayController : ControllerBase
     [ProducesResponseType(typeof(List<PlanDayVmDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetPlanDays([FromRoute] string id)
+    public async Task<IActionResult> GetPlanDays([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<PlanEntity>.TryParse(id, out var planId))
@@ -131,7 +131,7 @@ public sealed class PlanDayController : ControllerBase
         }
 
         var cultures = HttpContext.GetCulturePreferences();
-        var result = await _planDayService.GetPlanDaysAsync(user!, planId, cultures, HttpContext.RequestAborted);
+        var result = await _planDayService.GetPlanDaysAsync(user!, planId, cultures, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -150,7 +150,7 @@ public sealed class PlanDayController : ControllerBase
     [ProducesResponseType(typeof(List<PlanDayChooseDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetPlanDaysTypes([FromRoute] string id)
+    public async Task<IActionResult> GetPlanDaysTypes([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<UserEntity>.TryParse(id, out var routeUserId))
@@ -158,7 +158,7 @@ public sealed class PlanDayController : ControllerBase
             return Result<List<LgymApi.Domain.Entities.PlanDay>, AppError>.Failure(new PlanDayNotFoundError(Messages.DidntFind)).ToActionResult();
         }
 
-        var result = await _planDayService.GetPlanDaysTypesAsync(user!, routeUserId, HttpContext.RequestAborted);
+        var result = await _planDayService.GetPlanDaysTypesAsync(user!, routeUserId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -172,7 +172,7 @@ public sealed class PlanDayController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> DeletePlanDay([FromRoute] string id)
+    public async Task<IActionResult> DeletePlanDay([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<PlanDayEntity>.TryParse(id, out var planDayId))
@@ -180,7 +180,7 @@ public sealed class PlanDayController : ControllerBase
             return Result<Unit, AppError>.Failure(new PlanDayNotFoundError(Messages.DidntFind)).ToActionResult();
         }
 
-        var result = await _planDayService.DeletePlanDayAsync(user!, planDayId, HttpContext.RequestAborted);
+        var result = await _planDayService.DeletePlanDayAsync(user!, planDayId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -193,7 +193,7 @@ public sealed class PlanDayController : ControllerBase
     [ProducesResponseType(typeof(List<PlanDayBaseInfoDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetPlanDaysInfo([FromRoute] string id)
+    public async Task<IActionResult> GetPlanDaysInfo([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
         if (!Id<PlanEntity>.TryParse(id, out var planId))
@@ -201,7 +201,7 @@ public sealed class PlanDayController : ControllerBase
             return Result<PlanDaysInfoContext, AppError>.Failure(new PlanDayNotFoundError(Messages.DidntFind)).ToActionResult();
         }
 
-        var result = await _planDayService.GetPlanDaysInfoAsync(user!, planId, HttpContext.RequestAborted);
+        var result = await _planDayService.GetPlanDaysInfoAsync(user!, planId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();

--- a/LgymApi.Api/Features/Public/Controllers/PublicInvitationController.cs
+++ b/LgymApi.Api/Features/Public/Controllers/PublicInvitationController.cs
@@ -27,7 +27,7 @@ public sealed class PublicInvitationController : ControllerBase
     [HttpGet("{invitationId}")]
     [ProducesResponseType(typeof(PublicInvitationStatusDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetInvitationStatus([FromRoute] string invitationId, [FromQuery] string? code)
+    public async Task<IActionResult> GetInvitationStatus([FromRoute] string invitationId, [FromQuery] string? code, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(code))
         {
@@ -39,7 +39,7 @@ public sealed class PublicInvitationController : ControllerBase
             return NotFound();
         }
 
-        var invitation = await _trainerRelationshipRepository.FindInvitationByIdWithCodeAsync(parsedId, code, HttpContext.RequestAborted);
+        var invitation = await _trainerRelationshipRepository.FindInvitationByIdWithCodeAsync(parsedId, code, cancellationToken);
         if (invitation == null)
         {
             return NotFound();
@@ -48,7 +48,7 @@ public sealed class PublicInvitationController : ControllerBase
         bool userExists = invitation.TraineeId != null;
         if (!userExists && !string.IsNullOrWhiteSpace(invitation.InviteeEmail))
         {
-            userExists = await _userRepository.FindByEmailAsync(invitation.InviteeEmail, HttpContext.RequestAborted) != null;
+            userExists = await _userRepository.FindByEmailAsync(invitation.InviteeEmail, cancellationToken) != null;
         }
 
         return Ok(_mapper.Map<(string Status, bool UserExists), PublicInvitationStatusDto>((invitation.Status.ToString(), userExists)));

--- a/LgymApi.Api/Features/Role/Controllers/RoleController.cs
+++ b/LgymApi.Api/Features/Role/Controllers/RoleController.cs
@@ -28,9 +28,8 @@ public sealed class RoleController : ControllerBase
 
     [HttpGet]
     [ProducesResponseType(typeof(List<RoleDto>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetRoles()
+    public async Task<IActionResult> GetRoles(CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var result = await _roleService.GetRolesAsync(cancellationToken);
         
         if (result.IsFailure)
@@ -43,9 +42,8 @@ public sealed class RoleController : ControllerBase
 
     [HttpPost("paginated")]
     [ProducesResponseType(typeof(PaginatedRoleResult), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetRolesPaginated([FromBody] PaginatedRoleRequest request)
+    public async Task<IActionResult> GetRolesPaginated([FromBody] PaginatedRoleRequest request, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var filterInput = new FilterInput
         {
             Page = request.Page,
@@ -78,9 +76,8 @@ public sealed class RoleController : ControllerBase
     [HttpGet("{id}")]
     [ProducesResponseType(typeof(RoleDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetRole([FromRoute] string id)
+    public async Task<IActionResult> GetRole([FromRoute] string id, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var roleId = Id<Domain.Entities.Role>.TryParse(id, out var parsedRoleId) ? parsedRoleId : Id<Domain.Entities.Role>.Empty;
         var result = await _roleService.GetRoleAsync(roleId, cancellationToken);
         
@@ -103,9 +100,8 @@ public sealed class RoleController : ControllerBase
     [HttpPost]
     [ProducesResponseType(typeof(RoleDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> CreateRole([FromBody] UpsertRoleRequest request)
+    public async Task<IActionResult> CreateRole([FromBody] UpsertRoleRequest request, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var result = await _roleService.CreateRoleAsync(request.Name, request.Description, request.PermissionClaims, cancellationToken);
         
         if (result.IsFailure)
@@ -120,9 +116,8 @@ public sealed class RoleController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> UpdateRole([FromRoute] string id, [FromBody] UpsertRoleRequest request)
+    public async Task<IActionResult> UpdateRole([FromRoute] string id, [FromBody] UpsertRoleRequest request, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var roleId = Id<Domain.Entities.Role>.TryParse(id, out var parsedRoleId) ? parsedRoleId : Id<Domain.Entities.Role>.Empty;
         var result = await _roleService.UpdateRoleAsync(roleId, request.Name, request.Description, request.PermissionClaims, cancellationToken);
         
@@ -137,9 +132,8 @@ public sealed class RoleController : ControllerBase
     [HttpPost("{id}/delete")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> DeleteRole([FromRoute] string id)
+    public async Task<IActionResult> DeleteRole([FromRoute] string id, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var roleId = Id<Domain.Entities.Role>.TryParse(id, out var parsedRoleId) ? parsedRoleId : Id<Domain.Entities.Role>.Empty;
         var result = await _roleService.DeleteRoleAsync(roleId, cancellationToken);
         
@@ -155,9 +149,8 @@ public sealed class RoleController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> UpdateUserRoles([FromRoute] string id, [FromBody] UpdateUserRolesRequest request)
+    public async Task<IActionResult> UpdateUserRoles([FromRoute] string id, [FromBody] UpdateUserRolesRequest request, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
         var userId = Id<Domain.Entities.User>.TryParse(id, out var parsedUserId) ? parsedUserId : Id<Domain.Entities.User>.Empty;
         var result = await _roleService.UpdateUserRolesAsync(userId, request.Roles, cancellationToken);
         

--- a/LgymApi.Api/Features/Trainer/Controllers/TraineeRelationshipController.cs
+++ b/LgymApi.Api/Features/Trainer/Controllers/TraineeRelationshipController.cs
@@ -31,7 +31,7 @@ public sealed class TraineeRelationshipController : ControllerBase
 
     [HttpPost("invitations/{invitationId}/accept")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> AcceptInvitation([FromRoute] string invitationId)
+    public async Task<IActionResult> AcceptInvitation([FromRoute] string invitationId, CancellationToken cancellationToken = default)
     {
         if (!Id<TrainerInvitationEntity>.TryParse(invitationId, out var parsedInvitationId))
         {
@@ -39,7 +39,7 @@ public sealed class TraineeRelationshipController : ControllerBase
         }
 
         var trainee = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.AcceptInvitationAsync(trainee!, parsedInvitationId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.AcceptInvitationAsync(trainee!, parsedInvitationId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -50,7 +50,7 @@ public sealed class TraineeRelationshipController : ControllerBase
 
     [HttpPost("invitations/{invitationId}/reject")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> RejectInvitation([FromRoute] string invitationId)
+    public async Task<IActionResult> RejectInvitation([FromRoute] string invitationId, CancellationToken cancellationToken = default)
     {
         if (!Id<TrainerInvitationEntity>.TryParse(invitationId, out var parsedInvitationId))
         {
@@ -58,7 +58,7 @@ public sealed class TraineeRelationshipController : ControllerBase
         }
 
         var trainee = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.RejectInvitationAsync(trainee!, parsedInvitationId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.RejectInvitationAsync(trainee!, parsedInvitationId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -69,10 +69,10 @@ public sealed class TraineeRelationshipController : ControllerBase
 
     [HttpPost("trainer/detach")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> DetachFromTrainer()
+    public async Task<IActionResult> DetachFromTrainer(CancellationToken cancellationToken = default)
     {
         var trainee = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.DetachFromTrainerAsync(trainee!, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.DetachFromTrainerAsync(trainee!, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -83,10 +83,10 @@ public sealed class TraineeRelationshipController : ControllerBase
 
     [HttpGet("plan/active")]
     [ProducesResponseType(typeof(TrainerManagedPlanDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetActiveAssignedPlan()
+    public async Task<IActionResult> GetActiveAssignedPlan(CancellationToken cancellationToken = default)
     {
         var trainee = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.GetActiveAssignedPlanAsync(trainee!, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.GetActiveAssignedPlanAsync(trainee!, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();

--- a/LgymApi.Api/Features/Trainer/Controllers/TraineeReportingController.cs
+++ b/LgymApi.Api/Features/Trainer/Controllers/TraineeReportingController.cs
@@ -29,10 +29,10 @@ public sealed class TraineeReportingController : ControllerBase
 
     [HttpGet("report-requests")]
     [ProducesResponseType(typeof(List<ReportRequestDto>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetPendingRequests()
+    public async Task<IActionResult> GetPendingRequests(CancellationToken cancellationToken = default)
     {
         var trainee = HttpContext.GetCurrentUser();
-        var result = await _reportingService.GetPendingRequestsForTraineeAsync(trainee!, HttpContext.RequestAborted);
+        var result = await _reportingService.GetPendingRequestsForTraineeAsync(trainee!, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -45,7 +45,7 @@ public sealed class TraineeReportingController : ControllerBase
     [HttpPost("report-requests/{requestId}/submit")]
     [ProducesResponseType(typeof(ReportSubmissionDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> SubmitRequest([FromRoute] string requestId, [FromBody] SubmitReportRequestRequest request)
+    public async Task<IActionResult> SubmitRequest([FromRoute] string requestId, [FromBody] SubmitReportRequestRequest request, CancellationToken cancellationToken = default)
     {
         if (!Id<ReportRequest>.TryParse(requestId, out var parsedRequestId))
         {
@@ -56,7 +56,7 @@ public sealed class TraineeReportingController : ControllerBase
         var result = await _reportingService.SubmitReportRequestAsync(trainee!, parsedRequestId, new SubmitReportRequestCommand
         {
             Answers = new Dictionary<string, System.Text.Json.JsonElement>(request.Answers, StringComparer.OrdinalIgnoreCase)
-        }, HttpContext.RequestAborted);
+        }, cancellationToken);
 
         if (result.IsFailure)
         {

--- a/LgymApi.Api/Features/Trainer/Controllers/TraineeSupplementationController.cs
+++ b/LgymApi.Api/Features/Trainer/Controllers/TraineeSupplementationController.cs
@@ -29,10 +29,10 @@ public sealed class TraineeSupplementationController : ControllerBase
 
     [HttpGet("supplements/schedule")]
     [ProducesResponseType(typeof(List<SupplementScheduleEntryDto>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetSchedule([FromQuery] DateOnly? date)
+    public async Task<IActionResult> GetSchedule([FromQuery] DateOnly? date, CancellationToken cancellationToken = default)
     {
         var trainee = HttpContext.GetCurrentUser();
-        var result = await _supplementationService.GetActiveScheduleForDateAsync(trainee!, date ?? DateOnly.FromDateTime(DateTime.UtcNow), HttpContext.RequestAborted);
+        var result = await _supplementationService.GetActiveScheduleForDateAsync(trainee!, date ?? DateOnly.FromDateTime(DateTime.UtcNow), cancellationToken);
 
         if (result.IsFailure)
         {
@@ -45,7 +45,7 @@ public sealed class TraineeSupplementationController : ControllerBase
     [HttpPost("supplements/intakes/check-off")]
     [ProducesResponseType(typeof(SupplementScheduleEntryDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> CheckOffIntake([FromBody] CheckOffSupplementIntakeRequest request)
+    public async Task<IActionResult> CheckOffIntake([FromBody] CheckOffSupplementIntakeRequest request, CancellationToken cancellationToken = default)
     {
         Id<LgymApi.Domain.Entities.SupplementPlanItem>.TryParse(request.PlanItemId, out var parsedPlanItemId);
         
@@ -55,7 +55,7 @@ public sealed class TraineeSupplementationController : ControllerBase
             PlanItemId = parsedPlanItemId,
             IntakeDate = request.IntakeDate,
             TakenAt = request.TakenAt
-        }, HttpContext.RequestAborted);
+        }, cancellationToken);
 
         if (result.IsFailure)
         {

--- a/LgymApi.Api/Features/Trainer/Controllers/TrainerAuthController.cs
+++ b/LgymApi.Api/Features/Trainer/Controllers/TrainerAuthController.cs
@@ -29,7 +29,7 @@ public sealed class TrainerAuthController : ControllerBase
     [ApiIdempotency("/api/trainer/register", ApiIdempotencyScopeSource.NormalizedEmail)]
     [AllowAnonymous]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Register([FromBody] RegisterUserRequest request)
+    public async Task<IActionResult> Register([FromBody] RegisterUserRequest request, CancellationToken cancellationToken = default)
     {
         var input = new RegisterUserInput(
             request.Name,
@@ -39,7 +39,7 @@ public sealed class TrainerAuthController : ControllerBase
             IsVisibleInRanking: null,
             PreferredLanguage: null);
 
-        var result = await _userService.RegisterTrainerAsync(input, HttpContext.RequestAborted);
+        var result = await _userService.RegisterTrainerAsync(input, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -51,9 +51,9 @@ public sealed class TrainerAuthController : ControllerBase
     [HttpPost("login")]
     [AllowAnonymous]
     [ProducesResponseType(typeof(LoginResponseDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Login([FromBody] LoginRequest request)
+    public async Task<IActionResult> Login([FromBody] LoginRequest request, CancellationToken cancellationToken = default)
     {
-        var result = await _userService.LoginTrainerAsync(request.Name, request.Password, HttpContext.RequestAborted);
+        var result = await _userService.LoginTrainerAsync(request.Name, request.Password, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -65,10 +65,10 @@ public sealed class TrainerAuthController : ControllerBase
     [HttpGet("checkToken")]
     [Authorize(Policy = AuthConstants.Policies.TrainerAccess)]
     [ProducesResponseType(typeof(UserInfoDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> CheckToken()
+    public async Task<IActionResult> CheckToken(CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var result = await _userService.CheckTokenAsync(user, HttpContext.RequestAborted);
+        var result = await _userService.CheckTokenAsync(user, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();

--- a/LgymApi.Api/Features/Trainer/Controllers/TrainerRelationshipController.cs
+++ b/LgymApi.Api/Features/Trainer/Controllers/TrainerRelationshipController.cs
@@ -45,7 +45,7 @@ public sealed class TrainerRelationshipController : ControllerBase
     [HttpPost("invitations")]
     [ApiIdempotency("/api/trainer/invitations", ApiIdempotencyScopeSource.AuthenticatedUser)]
     [ProducesResponseType(typeof(TrainerInvitationDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> CreateInvitation([FromBody] CreateTrainerInvitationRequest request)
+    public async Task<IActionResult> CreateInvitation([FromBody] CreateTrainerInvitationRequest request, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(request.TraineeId, out var traineeId))
         {
@@ -53,7 +53,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.CreateInvitationAsync(trainer!, traineeId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.CreateInvitationAsync(trainer!, traineeId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -64,9 +64,8 @@ public sealed class TrainerRelationshipController : ControllerBase
 
     [HttpPost("invitations/paginated")]
     [ProducesResponseType(typeof(PaginatedTrainerInvitationResult), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetInvitationsPaginated([FromBody] PaginatedTrainerInvitationRequest request)
+    public async Task<IActionResult> GetInvitationsPaginated([FromBody] PaginatedTrainerInvitationRequest request, CancellationToken cancellationToken = default)
     {
-        var cancellationToken = HttpContext.RequestAborted;
         var filterInput = new FilterInput
         {
             Page = request.Page,
@@ -98,11 +97,11 @@ public sealed class TrainerRelationshipController : ControllerBase
 
     [HttpPost("invitations/by-email")]
     [ProducesResponseType(typeof(TrainerInvitationDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> CreateInvitationByEmail([FromBody] CreateTrainerInvitationByEmailRequest request)
+    public async Task<IActionResult> CreateInvitationByEmail([FromBody] CreateTrainerInvitationByEmailRequest request, CancellationToken cancellationToken = default)
     {
         var trainer = HttpContext.GetCurrentUser();
         var result = await _trainerRelationshipService.CreateInvitationByEmailAsync(
-            trainer!, request.Email, request.PreferredLanguage, request.PreferredTimeZone, HttpContext.RequestAborted);
+            trainer!, request.Email, request.PreferredLanguage, request.PreferredTimeZone, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -113,7 +112,7 @@ public sealed class TrainerRelationshipController : ControllerBase
 
     [HttpPost("invitations/{invitationId}/revoke")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> RevokeInvitation([FromRoute] string invitationId)
+    public async Task<IActionResult> RevokeInvitation([FromRoute] string invitationId, CancellationToken cancellationToken = default)
     {
         if (!Id<TrainerInvitationEntity>.TryParse(invitationId, out var parsedInvitationId))
         {
@@ -121,7 +120,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.RevokeInvitationAsync(trainer!, parsedInvitationId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.RevokeInvitationAsync(trainer!, parsedInvitationId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -132,7 +131,7 @@ public sealed class TrainerRelationshipController : ControllerBase
 
     [HttpGet("trainees")]
     [ProducesResponseType(typeof(TrainerDashboardTraineesResponse), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetDashboardTrainees([FromQuery] TrainerDashboardTraineesRequest request)
+    public async Task<IActionResult> GetDashboardTrainees([FromQuery] TrainerDashboardTraineesRequest request, CancellationToken cancellationToken = default)
     {
         var trainer = HttpContext.GetCurrentUser();
         var result = await _trainerRelationshipService.GetDashboardTraineesAsync(trainer!, new TrainerDashboardTraineeQuery
@@ -143,7 +142,7 @@ public sealed class TrainerRelationshipController : ControllerBase
             SortDirection = request.SortDirection,
             Page = request.Page,
             PageSize = request.PageSize
-        }, HttpContext.RequestAborted);
+        }, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -163,7 +162,7 @@ public sealed class TrainerRelationshipController : ControllerBase
     [ProducesResponseType(typeof(List<DateTime>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetTraineeTrainingDates([FromRoute] string traineeId)
+    public async Task<IActionResult> GetTraineeTrainingDates([FromRoute] string traineeId, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -171,7 +170,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.GetTraineeTrainingDatesAsync(trainer!, parsedTraineeId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.GetTraineeTrainingDatesAsync(trainer!, parsedTraineeId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -184,7 +183,7 @@ public sealed class TrainerRelationshipController : ControllerBase
     [ProducesResponseType(typeof(List<TrainingByDateDetailsDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetTraineeTrainingByDate([FromRoute] string traineeId, [FromBody] TrainingByDateRequestDto request)
+    public async Task<IActionResult> GetTraineeTrainingByDate([FromRoute] string traineeId, [FromBody] TrainingByDateRequestDto request, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -192,7 +191,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.GetTraineeTrainingByDateAsync(trainer!, parsedTraineeId, request.CreatedAt, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.GetTraineeTrainingByDateAsync(trainer!, parsedTraineeId, request.CreatedAt, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -205,7 +204,7 @@ public sealed class TrainerRelationshipController : ControllerBase
     [ProducesResponseType(typeof(List<ExerciseScoresChartDataDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetTraineeExerciseScoresChartData([FromRoute] string traineeId, [FromBody] ExerciseScoresChartRequestDto request)
+    public async Task<IActionResult> GetTraineeExerciseScoresChartData([FromRoute] string traineeId, [FromBody] ExerciseScoresChartRequestDto request, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -218,7 +217,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.GetTraineeExerciseScoresChartDataAsync(trainer!, parsedTraineeId, parsedExerciseId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.GetTraineeExerciseScoresChartDataAsync(trainer!, parsedTraineeId, parsedExerciseId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -231,7 +230,7 @@ public sealed class TrainerRelationshipController : ControllerBase
     [ProducesResponseType(typeof(List<EloRegistryBaseChartDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetTraineeEloChart([FromRoute] string traineeId)
+    public async Task<IActionResult> GetTraineeEloChart([FromRoute] string traineeId, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -239,7 +238,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.GetTraineeEloChartAsync(trainer!, parsedTraineeId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.GetTraineeEloChartAsync(trainer!, parsedTraineeId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -252,7 +251,7 @@ public sealed class TrainerRelationshipController : ControllerBase
     [ProducesResponseType(typeof(List<MainRecordResponseDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetTraineeMainRecordsHistory([FromRoute] string traineeId)
+    public async Task<IActionResult> GetTraineeMainRecordsHistory([FromRoute] string traineeId, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -260,7 +259,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.GetTraineeMainRecordsHistoryAsync(trainer!, parsedTraineeId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.GetTraineeMainRecordsHistoryAsync(trainer!, parsedTraineeId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -272,7 +271,7 @@ public sealed class TrainerRelationshipController : ControllerBase
 
     [HttpPost("trainees/{traineeId}/unlink")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> UnlinkTrainee([FromRoute] string traineeId)
+    public async Task<IActionResult> UnlinkTrainee([FromRoute] string traineeId, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -280,7 +279,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.UnlinkTraineeAsync(trainer!, parsedTraineeId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.UnlinkTraineeAsync(trainer!, parsedTraineeId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -291,7 +290,7 @@ public sealed class TrainerRelationshipController : ControllerBase
 
     [HttpGet("trainees/{traineeId}/plans")]
     [ProducesResponseType(typeof(List<TrainerManagedPlanDto>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetTraineePlans([FromRoute] string traineeId)
+    public async Task<IActionResult> GetTraineePlans([FromRoute] string traineeId, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -299,7 +298,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.GetTraineePlansAsync(trainer!, parsedTraineeId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.GetTraineePlansAsync(trainer!, parsedTraineeId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -310,7 +309,7 @@ public sealed class TrainerRelationshipController : ControllerBase
 
     [HttpPost("trainees/{traineeId}/plans")]
     [ProducesResponseType(typeof(TrainerManagedPlanDto), StatusCodes.Status201Created)]
-    public async Task<IActionResult> CreateTraineePlan([FromRoute] string traineeId, [FromBody] TrainerPlanFormRequest request)
+    public async Task<IActionResult> CreateTraineePlan([FromRoute] string traineeId, [FromBody] TrainerPlanFormRequest request, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -318,7 +317,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.CreateTraineePlanAsync(trainer!, parsedTraineeId, request.Name, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.CreateTraineePlanAsync(trainer!, parsedTraineeId, request.Name, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -329,7 +328,7 @@ public sealed class TrainerRelationshipController : ControllerBase
 
     [HttpPost("trainees/{traineeId}/plans/{planId}/update")]
     [ProducesResponseType(typeof(TrainerManagedPlanDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> UpdateTraineePlan([FromRoute] string traineeId, [FromRoute] string planId, [FromBody] TrainerPlanFormRequest request)
+    public async Task<IActionResult> UpdateTraineePlan([FromRoute] string traineeId, [FromRoute] string planId, [FromBody] TrainerPlanFormRequest request, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -342,7 +341,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.UpdateTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, request.Name, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.UpdateTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, request.Name, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -353,7 +352,7 @@ public sealed class TrainerRelationshipController : ControllerBase
 
     [HttpPost("trainees/{traineeId}/plans/{planId}/delete")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> DeleteTraineePlan([FromRoute] string traineeId, [FromRoute] string planId)
+    public async Task<IActionResult> DeleteTraineePlan([FromRoute] string traineeId, [FromRoute] string planId, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -366,7 +365,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.DeleteTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.DeleteTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -377,7 +376,7 @@ public sealed class TrainerRelationshipController : ControllerBase
 
     [HttpPost("trainees/{traineeId}/plans/{planId}/assign")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> AssignTraineePlan([FromRoute] string traineeId, [FromRoute] string planId)
+    public async Task<IActionResult> AssignTraineePlan([FromRoute] string traineeId, [FromRoute] string planId, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -390,7 +389,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.AssignTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.AssignTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -401,7 +400,7 @@ public sealed class TrainerRelationshipController : ControllerBase
 
     [HttpPost("trainees/{traineeId}/plans/unassign")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> UnassignTraineePlan([FromRoute] string traineeId)
+    public async Task<IActionResult> UnassignTraineePlan([FromRoute] string traineeId, CancellationToken cancellationToken = default)
     {
         if (!Id<UserEntity>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -409,7 +408,7 @@ public sealed class TrainerRelationshipController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _trainerRelationshipService.UnassignTraineePlanAsync(trainer!, parsedTraineeId, HttpContext.RequestAborted);
+        var result = await _trainerRelationshipService.UnassignTraineePlanAsync(trainer!, parsedTraineeId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();

--- a/LgymApi.Api/Features/Trainer/Controllers/TrainerReportingController.cs
+++ b/LgymApi.Api/Features/Trainer/Controllers/TrainerReportingController.cs
@@ -30,7 +30,7 @@ public sealed class TrainerReportingController : ControllerBase
 
     [HttpPost("report-templates")]
     [ProducesResponseType(typeof(ReportTemplateDto), StatusCodes.Status201Created)]
-    public async Task<IActionResult> CreateTemplate([FromBody] UpsertReportTemplateRequest request)
+    public async Task<IActionResult> CreateTemplate([FromBody] UpsertReportTemplateRequest request, CancellationToken cancellationToken = default)
     {
         var trainer = HttpContext.GetCurrentUser();
         var result = await _reportingService.CreateTemplateAsync(trainer!, new CreateReportTemplateCommand
@@ -38,7 +38,7 @@ public sealed class TrainerReportingController : ControllerBase
             Name = request.Name,
             Description = request.Description,
             Fields = request.Fields.Select(MapField).ToList()
-        }, HttpContext.RequestAborted);
+        }, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -50,10 +50,10 @@ public sealed class TrainerReportingController : ControllerBase
 
     [HttpGet("report-templates")]
     [ProducesResponseType(typeof(List<ReportTemplateDto>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetTemplates()
+    public async Task<IActionResult> GetTemplates(CancellationToken cancellationToken = default)
     {
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _reportingService.GetTrainerTemplatesAsync(trainer!, HttpContext.RequestAborted);
+        var result = await _reportingService.GetTrainerTemplatesAsync(trainer!, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -66,7 +66,7 @@ public sealed class TrainerReportingController : ControllerBase
     [HttpGet("report-templates/{templateId}")]
     [ProducesResponseType(typeof(ReportTemplateDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> GetTemplate([FromRoute] string templateId)
+    public async Task<IActionResult> GetTemplate([FromRoute] string templateId, CancellationToken cancellationToken = default)
     {
         if (!Id<ReportTemplate>.TryParse(templateId, out var parsedTemplateId))
         {
@@ -74,7 +74,7 @@ public sealed class TrainerReportingController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _reportingService.GetTrainerTemplateAsync(trainer!, parsedTemplateId, HttpContext.RequestAborted);
+        var result = await _reportingService.GetTrainerTemplateAsync(trainer!, parsedTemplateId, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -87,7 +87,7 @@ public sealed class TrainerReportingController : ControllerBase
     [HttpPost("report-templates/{templateId}/update")]
     [ProducesResponseType(typeof(ReportTemplateDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> UpdateTemplate([FromRoute] string templateId, [FromBody] UpsertReportTemplateRequest request)
+    public async Task<IActionResult> UpdateTemplate([FromRoute] string templateId, [FromBody] UpsertReportTemplateRequest request, CancellationToken cancellationToken = default)
     {
         if (!Id<ReportTemplate>.TryParse(templateId, out var parsedTemplateId))
         {
@@ -100,7 +100,7 @@ public sealed class TrainerReportingController : ControllerBase
             Name = request.Name,
             Description = request.Description,
             Fields = request.Fields.Select(MapField).ToList()
-        }, HttpContext.RequestAborted);
+        }, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -113,7 +113,7 @@ public sealed class TrainerReportingController : ControllerBase
     [HttpPost("report-templates/{templateId}/delete")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> DeleteTemplate([FromRoute] string templateId)
+    public async Task<IActionResult> DeleteTemplate([FromRoute] string templateId, CancellationToken cancellationToken = default)
     {
         if (!Id<ReportTemplate>.TryParse(templateId, out var parsedTemplateId))
         {
@@ -121,7 +121,7 @@ public sealed class TrainerReportingController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _reportingService.DeleteTemplateAsync(trainer!, parsedTemplateId, HttpContext.RequestAborted);
+        var result = await _reportingService.DeleteTemplateAsync(trainer!, parsedTemplateId, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -134,7 +134,7 @@ public sealed class TrainerReportingController : ControllerBase
     [HttpPost("trainees/{traineeId}/report-requests")]
     [ProducesResponseType(typeof(ReportRequestDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> CreateReportRequest([FromRoute] string traineeId, [FromBody] CreateReportRequestRequest request)
+    public async Task<IActionResult> CreateReportRequest([FromRoute] string traineeId, [FromBody] CreateReportRequestRequest request, CancellationToken cancellationToken = default)
     {
         if (!Id<LgymApi.Domain.Entities.User>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -152,7 +152,7 @@ public sealed class TrainerReportingController : ControllerBase
             TemplateId = parsedTemplateId,
             DueAt = request.DueAt,
             Note = request.Note
-        }, HttpContext.RequestAborted);
+        }, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -165,7 +165,7 @@ public sealed class TrainerReportingController : ControllerBase
     [HttpGet("trainees/{traineeId}/report-submissions")]
     [ProducesResponseType(typeof(List<ReportSubmissionDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> GetTraineeSubmissions([FromRoute] string traineeId)
+    public async Task<IActionResult> GetTraineeSubmissions([FromRoute] string traineeId, CancellationToken cancellationToken = default)
     {
         if (!Id<LgymApi.Domain.Entities.User>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -173,7 +173,7 @@ public sealed class TrainerReportingController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _reportingService.GetTraineeSubmissionsAsync(trainer!, parsedTraineeId, HttpContext.RequestAborted);
+        var result = await _reportingService.GetTraineeSubmissionsAsync(trainer!, parsedTraineeId, cancellationToken);
 
         if (result.IsFailure)
         {

--- a/LgymApi.Api/Features/Trainer/Controllers/TrainerSupplementationController.cs
+++ b/LgymApi.Api/Features/Trainer/Controllers/TrainerSupplementationController.cs
@@ -31,12 +31,12 @@ public sealed class TrainerSupplementationController : ControllerBase
 
     [HttpGet("trainees/{traineeId}/supplement-plans")]
     [ProducesResponseType(typeof(List<SupplementPlanDto>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetTraineePlans([FromRoute] string traineeId)
+    public async Task<IActionResult> GetTraineePlans([FromRoute] string traineeId, CancellationToken cancellationToken = default)
     {
         Id<LgymApi.Domain.Entities.User>.TryParse(traineeId, out var parsedTraineeId);
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _supplementationService.GetTraineePlansAsync(trainer!, parsedTraineeId, HttpContext.RequestAborted);
+        var result = await _supplementationService.GetTraineePlansAsync(trainer!, parsedTraineeId, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -48,12 +48,12 @@ public sealed class TrainerSupplementationController : ControllerBase
 
     [HttpPost("trainees/{traineeId}/supplement-plans")]
     [ProducesResponseType(typeof(SupplementPlanDto), StatusCodes.Status201Created)]
-    public async Task<IActionResult> CreateTraineePlan([FromRoute] string traineeId, [FromBody] UpsertSupplementPlanRequest request)
+    public async Task<IActionResult> CreateTraineePlan([FromRoute] string traineeId, [FromBody] UpsertSupplementPlanRequest request, CancellationToken cancellationToken = default)
     {
         Id<LgymApi.Domain.Entities.User>.TryParse(traineeId, out var parsedTraineeId);
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _supplementationService.CreateTraineePlanAsync(trainer!, parsedTraineeId, MapPlanCommand(request), HttpContext.RequestAborted);
+        var result = await _supplementationService.CreateTraineePlanAsync(trainer!, parsedTraineeId, MapPlanCommand(request), cancellationToken);
 
         if (result.IsFailure)
         {
@@ -65,7 +65,7 @@ public sealed class TrainerSupplementationController : ControllerBase
 
     [HttpPost("trainees/{traineeId}/supplement-plans/{planId}/update")]
     [ProducesResponseType(typeof(SupplementPlanDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> UpdateTraineePlan([FromRoute] string traineeId, [FromRoute] string planId, [FromBody] UpsertSupplementPlanRequest request)
+    public async Task<IActionResult> UpdateTraineePlan([FromRoute] string traineeId, [FromRoute] string planId, [FromBody] UpsertSupplementPlanRequest request, CancellationToken cancellationToken = default)
     {
         if (!Id<LgymApi.Domain.Entities.User>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -78,7 +78,7 @@ public sealed class TrainerSupplementationController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _supplementationService.UpdateTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, MapPlanCommand(request), HttpContext.RequestAborted);
+        var result = await _supplementationService.UpdateTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, MapPlanCommand(request), cancellationToken);
 
         if (result.IsFailure)
         {
@@ -90,7 +90,7 @@ public sealed class TrainerSupplementationController : ControllerBase
 
     [HttpPost("trainees/{traineeId}/supplement-plans/{planId}/delete")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> DeleteTraineePlan([FromRoute] string traineeId, [FromRoute] string planId)
+    public async Task<IActionResult> DeleteTraineePlan([FromRoute] string traineeId, [FromRoute] string planId, CancellationToken cancellationToken = default)
     {
         if (!Id<LgymApi.Domain.Entities.User>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -103,7 +103,7 @@ public sealed class TrainerSupplementationController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _supplementationService.DeleteTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, HttpContext.RequestAborted);
+        var result = await _supplementationService.DeleteTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -115,7 +115,7 @@ public sealed class TrainerSupplementationController : ControllerBase
 
     [HttpPost("trainees/{traineeId}/supplement-plans/{planId}/assign")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> AssignTraineePlan([FromRoute] string traineeId, [FromRoute] string planId)
+    public async Task<IActionResult> AssignTraineePlan([FromRoute] string traineeId, [FromRoute] string planId, CancellationToken cancellationToken = default)
     {
         if (!Id<LgymApi.Domain.Entities.User>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -128,7 +128,7 @@ public sealed class TrainerSupplementationController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _supplementationService.AssignTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, HttpContext.RequestAborted);
+        var result = await _supplementationService.AssignTraineePlanAsync(trainer!, parsedTraineeId, parsedPlanId, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -140,7 +140,7 @@ public sealed class TrainerSupplementationController : ControllerBase
 
     [HttpPost("trainees/{traineeId}/supplement-plans/unassign")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> UnassignTraineePlan([FromRoute] string traineeId)
+    public async Task<IActionResult> UnassignTraineePlan([FromRoute] string traineeId, CancellationToken cancellationToken = default)
     {
         if (!Id<LgymApi.Domain.Entities.User>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -148,7 +148,7 @@ public sealed class TrainerSupplementationController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _supplementationService.UnassignTraineePlanAsync(trainer!, parsedTraineeId, HttpContext.RequestAborted);
+        var result = await _supplementationService.UnassignTraineePlanAsync(trainer!, parsedTraineeId, cancellationToken);
 
         if (result.IsFailure)
         {
@@ -160,7 +160,7 @@ public sealed class TrainerSupplementationController : ControllerBase
 
     [HttpGet("trainees/{traineeId}/supplements/compliance")]
     [ProducesResponseType(typeof(SupplementComplianceSummaryDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetComplianceSummary([FromRoute] string traineeId, [FromQuery] DateOnly? fromDate, [FromQuery] DateOnly? toDate)
+    public async Task<IActionResult> GetComplianceSummary([FromRoute] string traineeId, [FromQuery] DateOnly? fromDate, [FromQuery] DateOnly? toDate, CancellationToken cancellationToken = default)
     {
         if (!Id<LgymApi.Domain.Entities.User>.TryParse(traineeId, out var parsedTraineeId))
         {
@@ -173,7 +173,7 @@ public sealed class TrainerSupplementationController : ControllerBase
         }
 
         var trainer = HttpContext.GetCurrentUser();
-        var result = await _supplementationService.GetComplianceSummaryAsync(trainer!, parsedTraineeId, fromDate.Value, toDate.Value, HttpContext.RequestAborted);
+        var result = await _supplementationService.GetComplianceSummaryAsync(trainer!, parsedTraineeId, fromDate.Value, toDate.Value, cancellationToken);
 
         if (result.IsFailure)
         {

--- a/LgymApi.Api/Features/Training/Controllers/TrainingController.cs
+++ b/LgymApi.Api/Features/Training/Controllers/TrainingController.cs
@@ -32,7 +32,7 @@ public sealed class TrainingController : ControllerBase
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> AddTraining([FromRoute] string id, [FromBody] TrainingFormDto form)
+    public async Task<IActionResult> AddTraining([FromRoute] string id, [FromBody] TrainingFormDto form, CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
         var gymId = form.GymId.ToIdOrEmpty<LgymApi.Domain.Entities.Gym>();
@@ -47,7 +47,7 @@ public sealed class TrainingController : ControllerBase
             }).ToList();
 
         var input = new AddTrainingInput(gymId, planDayId, form.CreatedAt, exercises);
-        var result = await _trainingService.AddTrainingAsync(userId, input, HttpContext.RequestAborted);
+        var result = await _trainingService.AddTrainingAsync(userId, input, cancellationToken);
         
         if (result.IsFailure)
         {
@@ -62,10 +62,10 @@ public sealed class TrainingController : ControllerBase
     [ProducesResponseType(typeof(LastTrainingInfoDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetLastTraining([FromRoute] string id)
+    public async Task<IActionResult> GetLastTraining([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
-        var result = await _trainingService.GetLastTrainingAsync(userId, HttpContext.RequestAborted);
+        var result = await _trainingService.GetLastTrainingAsync(userId, cancellationToken);
         
         if (result.IsFailure)
         {
@@ -79,10 +79,10 @@ public sealed class TrainingController : ControllerBase
     [ProducesResponseType(typeof(List<TrainingByDateDetailsDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetTrainingByDate([FromRoute] string id, [FromBody] TrainingByDateRequestDto request)
+    public async Task<IActionResult> GetTrainingByDate([FromRoute] string id, [FromBody] TrainingByDateRequestDto request, CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
-        var result = await _trainingService.GetTrainingByDateAsync(userId, request.CreatedAt, HttpContext.RequestAborted);
+        var result = await _trainingService.GetTrainingByDateAsync(userId, request.CreatedAt, cancellationToken);
         
         if (result.IsFailure)
         {
@@ -97,10 +97,10 @@ public sealed class TrainingController : ControllerBase
     [ProducesResponseType(typeof(List<DateTime>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetTrainingDates([FromRoute] string id)
+    public async Task<IActionResult> GetTrainingDates([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var userId = HttpContext.ParseRouteUserIdForCurrentUser(id);
-        var result = await _trainingService.GetTrainingDatesAsync(userId, HttpContext.RequestAborted);
+        var result = await _trainingService.GetTrainingDatesAsync(userId, cancellationToken);
         
         if (result.IsFailure)
         {

--- a/LgymApi.Api/Features/Tutorial/Controllers/TutorialController.cs
+++ b/LgymApi.Api/Features/Tutorial/Controllers/TutorialController.cs
@@ -25,10 +25,10 @@ public sealed class TutorialController : ControllerBase
 
     [HttpGet("active")]
     [ProducesResponseType(typeof(List<TutorialProgressDto>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetActiveTutorials()
+    public async Task<IActionResult> GetActiveTutorials(CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var result = await _tutorialService.GetActiveTutorialsAsync(user!.Id, HttpContext.RequestAborted);
+        var result = await _tutorialService.GetActiveTutorialsAsync(user!.Id, cancellationToken);
         
         if (result.IsFailure)
         {
@@ -42,10 +42,10 @@ public sealed class TutorialController : ControllerBase
     [HttpGet("{tutorialType}")]
     [ProducesResponseType(typeof(TutorialProgressDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetTutorialProgress([FromRoute] TutorialType tutorialType)
+    public async Task<IActionResult> GetTutorialProgress([FromRoute] TutorialType tutorialType, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var result = await _tutorialService.GetTutorialProgressAsync(user!.Id, tutorialType, HttpContext.RequestAborted);
+        var result = await _tutorialService.GetTutorialProgressAsync(user!.Id, tutorialType, cancellationToken);
         
         if (result.IsFailure)
         {
@@ -63,10 +63,10 @@ public sealed class TutorialController : ControllerBase
 
     [HttpPost("completeStep")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> CompleteStep([FromBody] CompleteStepRequest request)
+    public async Task<IActionResult> CompleteStep([FromBody] CompleteStepRequest request, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var result = await _tutorialService.CompleteStepAsync(user!.Id, request.TutorialType, request.Step, HttpContext.RequestAborted);
+        var result = await _tutorialService.CompleteStepAsync(user!.Id, request.TutorialType, request.Step, cancellationToken);
         
         if (result.IsFailure)
         {
@@ -78,10 +78,10 @@ public sealed class TutorialController : ControllerBase
 
     [HttpPost("complete")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> CompleteTutorial([FromBody] CompleteTutorialRequest request)
+    public async Task<IActionResult> CompleteTutorial([FromBody] CompleteTutorialRequest request, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var result = await _tutorialService.CompleteTutorialAsync(user!.Id, request.TutorialType, HttpContext.RequestAborted);
+        var result = await _tutorialService.CompleteTutorialAsync(user!.Id, request.TutorialType, cancellationToken);
         
         if (result.IsFailure)
         {

--- a/LgymApi.Api/Features/User/Controllers/UserController.cs
+++ b/LgymApi.Api/Features/User/Controllers/UserController.cs
@@ -35,7 +35,7 @@ public sealed class UserController : ControllerBase
     [ApiIdempotency("/api/register", ApiIdempotencyScopeSource.NormalizedEmail)]
     [AllowAnonymous]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Register([FromBody] RegisterUserRequest request)
+    public async Task<IActionResult> Register([FromBody] RegisterUserRequest request, CancellationToken cancellationToken = default)
     {
         var preferredLanguage = Request.Headers.TryGetValue("Accept-Language", out var langs)
             ? langs.ToString()
@@ -49,7 +49,7 @@ public sealed class UserController : ControllerBase
             request.IsVisibleInRanking,
             preferredLanguage);
 
-        var result = await _userService.RegisterAsync(input, HttpContext.RequestAborted);
+        var result = await _userService.RegisterAsync(input, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -61,9 +61,9 @@ public sealed class UserController : ControllerBase
     [HttpPost("login")]
     [AllowAnonymous]
     [ProducesResponseType(typeof(LoginResponseDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Login([FromBody] LoginRequest request)
+    public async Task<IActionResult> Login([FromBody] LoginRequest request, CancellationToken cancellationToken = default)
     {
-        var result = await _userService.LoginAsync(request.Name, request.Password, HttpContext.RequestAborted);
+        var result = await _userService.LoginAsync(request.Name, request.Password, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -75,19 +75,19 @@ public sealed class UserController : ControllerBase
 
     [HttpGet("{id}/isAdmin")]
     [ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
-    public async Task<IActionResult> IsAdmin([FromRoute] string id)
+    public async Task<IActionResult> IsAdmin([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var userId = ParseUserId(id);
-        var result = await _userService.IsAdminAsync(userId, HttpContext.RequestAborted);
+        var result = await _userService.IsAdminAsync(userId, cancellationToken);
         return Ok(result);
     }
 
     [HttpGet("checkToken")]
     [ProducesResponseType(typeof(UserInfoDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> CheckToken()
+    public async Task<IActionResult> CheckToken(CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var result = await _userService.CheckTokenAsync(user, HttpContext.RequestAborted);
+        var result = await _userService.CheckTokenAsync(user, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -99,10 +99,10 @@ public sealed class UserController : ControllerBase
 
     [HttpPost("logout")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Logout()
+    public async Task<IActionResult> Logout(CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var result = await _userService.LogoutAsync(user, HttpContext.RequestAborted);
+        var result = await _userService.LogoutAsync(user, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -113,9 +113,9 @@ public sealed class UserController : ControllerBase
 
     [HttpGet("getUsersRanking")]
     [ProducesResponseType(typeof(List<UserBaseInfoDto>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetUsersRanking()
+    public async Task<IActionResult> GetUsersRanking(CancellationToken cancellationToken = default)
     {
-        var result = await _userService.GetUsersRankingAsync(HttpContext.RequestAborted);
+        var result = await _userService.GetUsersRankingAsync(cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -127,10 +127,10 @@ public sealed class UserController : ControllerBase
 
     [HttpGet("userInfo/{id}/getUserEloPoints")]
     [ProducesResponseType(typeof(UserEloDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetUserElo([FromRoute] string id)
+    public async Task<IActionResult> GetUserElo([FromRoute] string id, CancellationToken cancellationToken = default)
     {
         var userId = ParseUserId(id);
-        var result = await _userService.GetUserEloAsync(userId, HttpContext.RequestAborted);
+        var result = await _userService.GetUserEloAsync(userId, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -148,10 +148,10 @@ public sealed class UserController : ControllerBase
 
     [HttpGet("deleteAccount")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> DeleteAccount()
+    public async Task<IActionResult> DeleteAccount(CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var result = await _userService.DeleteAccountAsync(user, HttpContext.RequestAborted);
+        var result = await _userService.DeleteAccountAsync(user, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -162,7 +162,7 @@ public sealed class UserController : ControllerBase
 
     [HttpPost("changeVisibilityInRanking")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> ChangeVisibilityInRanking([FromBody] Dictionary<string, bool> body)
+    public async Task<IActionResult> ChangeVisibilityInRanking([FromBody] Dictionary<string, bool> body, CancellationToken cancellationToken = default)
     {
         if (!body.TryGetValue("isVisibleInRanking", out var isVisible))
         {
@@ -171,7 +171,7 @@ public sealed class UserController : ControllerBase
         }
 
         var user = HttpContext.GetCurrentUser();
-        var result = await _userService.ChangeVisibilityInRankingAsync(user, isVisible, HttpContext.RequestAborted);
+        var result = await _userService.ChangeVisibilityInRankingAsync(user, isVisible, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -182,10 +182,10 @@ public sealed class UserController : ControllerBase
 
     [HttpPost("updateTimeZone")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> UpdateTimeZone([FromBody] UpdateTimeZoneRequest request)
+    public async Task<IActionResult> UpdateTimeZone([FromBody] UpdateTimeZoneRequest request, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var result = await _userService.UpdateTimeZoneAsync(user, request.PreferredTimeZone, HttpContext.RequestAborted);
+        var result = await _userService.UpdateTimeZoneAsync(user, request.PreferredTimeZone, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -197,10 +197,10 @@ public sealed class UserController : ControllerBase
      [HttpPost("forgot-password")]
      [AllowAnonymous]
      [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-     public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordRequest request)
+     public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordRequest request, CancellationToken cancellationToken = default)
      {
          var preferences = HttpContext.GetCulturePreferences();
-         await _passwordResetService.RequestPasswordResetAsync(request.Email, preferences.First(), HttpContext.RequestAborted);
+         await _passwordResetService.RequestPasswordResetAsync(request.Email, preferences.First(), cancellationToken);
          return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.ForgotPasswordRequested));
      }
 
@@ -208,9 +208,9 @@ public sealed class UserController : ControllerBase
     [AllowAnonymous]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordRequest request)
+    public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordRequest request, CancellationToken cancellationToken = default)
     {
-        var result = await _passwordResetService.ResetPasswordAsync(request.Token, request.NewPassword, HttpContext.RequestAborted);
+        var result = await _passwordResetService.ResetPasswordAsync(request.Token, request.NewPassword, cancellationToken);
         if (result.IsFailure)
         {
             return BadRequest(_mapper.Map<string, ResponseMessageDto>(Messages.PasswordResetInvalidOrExpiredToken));

--- a/LgymApi.ArchitectureTests/ControllerActionCancellationTokenGuardTests.cs
+++ b/LgymApi.ArchitectureTests/ControllerActionCancellationTokenGuardTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LgymApi.ArchitectureTests;
+
+[TestFixture]
+public sealed class ControllerActionCancellationTokenGuardTests
+{
+    [Test]
+    public void Controller_Actions_Returning_Task_Should_Have_CancellationToken_Parameter()
+    {
+        var repoRoot = ResolveRepositoryRoot();
+        var controllersRoot = Path.Combine(repoRoot, "LgymApi.Api", "Features");
+
+        Assert.That(Directory.Exists(controllersRoot), Is.True, $"Controllers root '{controllersRoot}' not found.");
+
+        var controllerFiles = Directory
+            .EnumerateFiles(controllersRoot, "*Controller.cs", SearchOption.AllDirectories)
+            .Where(path => !IsInBuildArtifacts(path))
+            .ToList();
+
+        Assert.That(controllerFiles, Is.Not.Empty, "No controller files found for CancellationToken guard test.");
+
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+        var violations = new List<Violation>();
+
+        foreach (var file in controllerFiles)
+        {
+            var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file), parseOptions, file);
+            var root = tree.GetCompilationUnitRoot();
+
+            var controllerClasses = root
+                .DescendantNodes()
+                .OfType<ClassDeclarationSyntax>()
+                .Where(cls => cls.Identifier.ValueText.EndsWith("Controller", StringComparison.Ordinal));
+
+            foreach (var controllerClass in controllerClasses)
+            {
+                foreach (var method in controllerClass.Members.OfType<MethodDeclarationSyntax>())
+                {
+                    if (!method.Modifiers.Any(m => m.Kind() == SyntaxKind.PublicKeyword))
+                    {
+                        continue;
+                    }
+
+                    if (!IsAsyncActionResultReturnType(method))
+                    {
+                        continue;
+                    }
+
+                    if (HasCancellationTokenParameter(method.ParameterList))
+                    {
+                        continue;
+                    }
+
+                    var lineSpan = tree.GetLineSpan(method.Span);
+                    violations.Add(new Violation(
+                        Path.GetRelativePath(repoRoot, file),
+                        lineSpan.StartLinePosition.Line + 1,
+                        controllerClass.Identifier.ValueText,
+                        method.Identifier.ValueText));
+                }
+            }
+        }
+
+        Assert.That(
+            violations,
+            Is.Empty,
+            "Every public controller action returning Task<IActionResult> or Task<ActionResult<T>> must declare a CancellationToken parameter." + Environment.NewLine +
+            string.Join(Environment.NewLine, violations.Select(v => v.ToString())));
+    }
+
+    private static bool IsAsyncActionResultReturnType(MethodDeclarationSyntax method)
+    {
+        var returnType = method.ReturnType.ToString();
+
+        if (returnType == "Task<IActionResult>")
+        {
+            return true;
+        }
+
+        if (returnType == "Task<ActionResult>")
+        {
+            return true;
+        }
+
+        if (returnType.StartsWith("Task<ActionResult<", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasCancellationTokenParameter(ParameterListSyntax parameterList)
+    {
+        return parameterList.Parameters.Any(parameter =>
+            parameter.Type is IdentifierNameSyntax { Identifier.ValueText: "CancellationToken" }
+            || parameter.Type is QualifiedNameSyntax { Right: IdentifierNameSyntax { Identifier.ValueText: "CancellationToken" } });
+    }
+
+    private static bool IsInBuildArtifacts(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        return normalized.Contains("/obj/", StringComparison.OrdinalIgnoreCase) || normalized.Contains("/bin/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "LgymApi.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to locate repository root.");
+    }
+
+    private sealed record Violation(string File, int Line, string Controller, string Action)
+    {
+        public override string ToString() => $"{File}:{Line} -> {Controller}.{Action} is missing CancellationToken parameter";
+    }
+}

--- a/LgymApi.ArchitectureTests/HttpContextRequestAbortedBanGuardTests.cs
+++ b/LgymApi.ArchitectureTests/HttpContextRequestAbortedBanGuardTests.cs
@@ -1,0 +1,133 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LgymApi.ArchitectureTests;
+
+[TestFixture]
+public sealed class HttpContextRequestAbortedBanGuardTests
+{
+    [Test]
+    public void Controllers_Should_Not_Use_HttpContext_RequestAborted()
+    {
+        var repoRoot = ResolveRepositoryRoot();
+        var controllersRoot = Path.Combine(repoRoot, "LgymApi.Api", "Features");
+
+        Assert.That(Directory.Exists(controllersRoot), Is.True, $"Controllers root '{controllersRoot}' not found.");
+
+        var controllerFiles = Directory
+            .EnumerateFiles(controllersRoot, "*Controller.cs", SearchOption.AllDirectories)
+            .Where(path => !IsInBuildArtifacts(path))
+            .ToList();
+
+        Assert.That(controllerFiles, Is.Not.Empty, "No controller files found for HttpContext.RequestAborted ban guard test.");
+
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+        var violations = new List<Violation>();
+
+        foreach (var file in controllerFiles)
+        {
+            var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file), parseOptions, file);
+            var root = tree.GetCompilationUnitRoot();
+
+            var controllerClasses = root
+                .DescendantNodes()
+                .OfType<ClassDeclarationSyntax>()
+                .Where(cls => cls.Identifier.ValueText.EndsWith("Controller", StringComparison.Ordinal));
+
+            foreach (var controllerClass in controllerClasses)
+            {
+                foreach (var member in controllerClass.Members)
+                {
+                    MethodDeclarationSyntax? method = member switch
+                    {
+                        MethodDeclarationSyntax m => m,
+                        _ => null
+                    };
+
+                    if (method is null)
+                    {
+                        continue;
+                    }
+
+                    if (!method.Modifiers.Any(m => m.Kind() == SyntaxKind.PublicKeyword))
+                    {
+                        continue;
+                    }
+
+                    foreach (var memberAccess in method.DescendantNodes().OfType<MemberAccessExpressionSyntax>())
+                    {
+                        if (!IsHttpContextRequestAborted(memberAccess))
+                        {
+                            continue;
+                        }
+
+                        var lineSpan = tree.GetLineSpan(memberAccess.Span);
+                        violations.Add(new Violation(
+                            Path.GetRelativePath(repoRoot, file),
+                            lineSpan.StartLinePosition.Line + 1,
+                            controllerClass.Identifier.ValueText,
+                            method.Identifier.ValueText));
+                    }
+                }
+            }
+        }
+
+        Assert.That(
+            violations,
+            Is.Empty,
+            "Controllers must not use HttpContext.RequestAborted. Use CancellationToken parameter instead." + Environment.NewLine +
+            string.Join(Environment.NewLine, violations.Select(v => v.ToString())));
+    }
+
+    private static bool IsHttpContextRequestAborted(MemberAccessExpressionSyntax memberAccess)
+    {
+        if (memberAccess.Name.Identifier.ValueText != "RequestAborted")
+        {
+            return false;
+        }
+
+        if (memberAccess.Expression is IdentifierNameSyntax { Identifier.ValueText: "HttpContext" })
+        {
+            return true;
+        }
+
+        if (memberAccess.Expression is PostfixUnaryExpressionSyntax { Operand: IdentifierNameSyntax { Identifier.ValueText: "HttpContext" }, RawKind: (int)SyntaxKind.SuppressNullableWarningExpression })
+        {
+            return true;
+        }
+
+        if (memberAccess.Expression is ConditionalAccessExpressionSyntax { Expression: IdentifierNameSyntax { Identifier.ValueText: "HttpContext" } })
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsInBuildArtifacts(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        return normalized.Contains("/obj/", StringComparison.OrdinalIgnoreCase) || normalized.Contains("/bin/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "LgymApi.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Unable to locate repository root.");
+    }
+
+    private sealed record Violation(string File, int Line, string Controller, string Action)
+    {
+        public override string ToString() => $"{File}:{Line} -> {Controller}.{Action} uses HttpContext.RequestAborted instead of CancellationToken parameter";
+    }
+}


### PR DESCRIPTION
## Summary

- Add architecture tests enforcing consistent cancellation handling in API controllers
  - `ControllerActionCancellationTokenGuardTests`: requires `CancellationToken` parameter on all async `Task<IActionResult>` actions
  - `HttpContextRequestAbortedBanGuardTests`: bans direct `HttpContext.RequestAborted` usage in controllers
- Update all 25 controllers (~100+ action methods) to use `CancellationToken` parameter instead of `HttpContext.RequestAborted`

## Changes

**New test files:**
- `LgymApi.ArchitectureTests/ControllerActionCancellationTokenGuardTests.cs`
- `LgymApi.ArchitectureTests/HttpContextRequestAbortedBanGuardTests.cs`

**Updated controllers (25 files):**
- AdminUser, AppConfig, EloRegistry, Exercise, ExerciseScores, Gym, InAppNotification, MainRecords, Measurements, Plan, PlanDay, Public, Role, Trainer (TraineeRelationship, TraineeReporting, TraineeSupplementation, TrainerAuth, TrainerRelationship, TrainerReporting, TrainerSupplementation), Training, Tutorial, User

## Verification

- All 42 architecture tests pass
- `dotnet test LgymApi.ArchitectureTests/LgymApi.ArchitectureTests.csproj -c Release --no-build` ✅