### PR TITLE
refactor: extract constants and typed visibility request (#276)

### DIFF
--- a/LgymApi.Api/Constants/ConfigKeys.cs
+++ b/LgymApi.Api/Constants/ConfigKeys.cs
@@ -1,0 +1,9 @@
+namespace LgymApi.Api.Constants;
+
+using LgymApi.Domain.Security;
+
+public static class ConfigKeys
+{
+    public static readonly string JwtSigningKey = AuthConstants.ConfigKeys.JwtSigningKey;
+    public const string CorsAllowedOrigins = "Cors:AllowedOrigins";
+}

--- a/LgymApi.Api/Features/AdminUser/Controllers/AdminUserController.cs
+++ b/LgymApi.Api/Features/AdminUser/Controllers/AdminUserController.cs
@@ -179,7 +179,7 @@ public sealed class AdminUserController : ControllerBase
 
     private Id<Domain.Entities.User> GetAdminUserId()
     {
-        var userIdClaim = HttpContext.User.FindFirst("userId")?.Value;
+        var userIdClaim = HttpContext.User.FindFirst(AuthConstants.ClaimNames.UserId)?.Value;
         return Id<Domain.Entities.User>.TryParse(userIdClaim, out var userId) ? userId : Id<Domain.Entities.User>.Empty;
     }
 

--- a/LgymApi.Api/Features/User/Contracts/ChangeVisibilityInRankingDto.cs
+++ b/LgymApi.Api/Features/User/Contracts/ChangeVisibilityInRankingDto.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+using LgymApi.Api.Interfaces;
+
+namespace LgymApi.Api.Features.User.Contracts;
+
+public sealed class ChangeVisibilityInRankingRequest : IDto
+{
+    [JsonPropertyName("isVisibleInRanking")]
+    public bool? IsVisibleInRanking { get; set; }
+}

--- a/LgymApi.Api/Features/User/Controllers/UserController.cs
+++ b/LgymApi.Api/Features/User/Controllers/UserController.cs
@@ -9,6 +9,7 @@ using LgymApi.Application.Features.PasswordReset;
 using LgymApi.Application.Features.User;
 using LgymApi.Application.Features.User.Models;
 using LgymApi.Application.Mapping.Core;
+using LgymApi.Domain.Security;
 using LgymApi.Domain.ValueObjects;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -103,7 +104,7 @@ public sealed class UserController : ControllerBase
     public async Task<IActionResult> Logout(CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var rawSessionId = HttpContext.User.FindFirst("sid")?.Value;
+        var rawSessionId = HttpContext.User.FindFirst(AuthConstants.ClaimNames.SessionId)?.Value;
         var sessionId = Id<UserSessionEntity>.TryParse(rawSessionId, out var parsedSessionId)
             ? parsedSessionId
             : (Id<UserSessionEntity>?)null;
@@ -168,16 +169,10 @@ public sealed class UserController : ControllerBase
 
     [HttpPost("changeVisibilityInRanking")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> ChangeVisibilityInRanking([FromBody] Dictionary<string, bool> body, CancellationToken cancellationToken = default)
+    public async Task<IActionResult> ChangeVisibilityInRanking([FromBody] ChangeVisibilityInRankingRequest request, CancellationToken cancellationToken = default)
     {
-        if (!body.TryGetValue("isVisibleInRanking", out var isVisible))
-        {
-            var routeValidationFailure = Result<Unit, AppError>.Failure(new InvalidUserError(Messages.DidntFind));
-            return routeValidationFailure.ToActionResult();
-        }
-
         var user = HttpContext.GetCurrentUser();
-        var result = await _userService.ChangeVisibilityInRankingAsync(user, isVisible, cancellationToken);
+        var result = await _userService.ChangeVisibilityInRankingAsync(user, request.IsVisibleInRanking.Value, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();

--- a/LgymApi.Api/Features/User/Validation/ChangeVisibilityInRankingRequestValidator.cs
+++ b/LgymApi.Api/Features/User/Validation/ChangeVisibilityInRankingRequestValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using LgymApi.Api.Features.User.Contracts;
+using LgymApi.Resources;
+
+namespace LgymApi.Api.Features.User.Validation;
+
+public class ChangeVisibilityInRankingRequestValidator : AbstractValidator<ChangeVisibilityInRankingRequest>
+{
+    public ChangeVisibilityInRankingRequestValidator()
+    {
+        RuleFor(x => x.IsVisibleInRanking)
+            .NotNull()
+            .WithMessage(Messages.FieldRequired);
+    }
+}

--- a/LgymApi.Api/Hubs/NotificationHub.cs
+++ b/LgymApi.Api/Hubs/NotificationHub.cs
@@ -1,4 +1,5 @@
 using LgymApi.Domain.Entities;
+using LgymApi.Domain.Security;
 using LgymApi.Domain.ValueObjects;
 using LgymApi.Application.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -21,7 +22,7 @@ public sealed class NotificationHub : Hub
 
     public override async Task OnConnectedAsync()
     {
-        var sidClaim = Context.User?.FindFirst("sid")?.Value;
+        var sidClaim = Context.User?.FindFirst(AuthConstants.ClaimNames.SessionId)?.Value;
         if (sidClaim == null || !Id<UserSession>.TryParse(sidClaim, out var sessionId))
         {
             Context.Abort();
@@ -34,7 +35,7 @@ public sealed class NotificationHub : Hub
             return;
         }
 
-        var userId = Context.User?.FindFirst("userId")?.Value;
+        var userId = Context.User?.FindFirst(AuthConstants.ClaimNames.UserId)?.Value;
         if (userId == null || !Id<User>.TryParse(userId, out var userIdParsed))
         {
             Context.Abort();

--- a/LgymApi.Api/Hubs/NotificationHubUserIdProvider.cs
+++ b/LgymApi.Api/Hubs/NotificationHubUserIdProvider.cs
@@ -1,3 +1,4 @@
+using LgymApi.Domain.Security;
 using Microsoft.AspNetCore.SignalR;
 
 namespace LgymApi.Api.Hubs;
@@ -5,5 +6,5 @@ namespace LgymApi.Api.Hubs;
 public sealed class NotificationHubUserIdProvider : IUserIdProvider
 {
     public string? GetUserId(HubConnectionContext connection)
-        => connection.User?.FindFirst("userId")?.Value;
+        => connection.User?.FindFirst(AuthConstants.ClaimNames.UserId)?.Value;
 }

--- a/LgymApi.Api/Middleware/UserContextMiddleware.cs
+++ b/LgymApi.Api/Middleware/UserContextMiddleware.cs
@@ -1,6 +1,7 @@
 using LgymApi.Application.Repositories;
 using LgymApi.Application.Services;
 using LgymApi.Domain.Entities;
+using LgymApi.Domain.Security;
 using LgymApi.Domain.ValueObjects;
 using Microsoft.AspNetCore.Authorization;
 
@@ -24,7 +25,7 @@ public sealed class UserContextMiddleware
             return;
         }
 
-        var sidClaim = context.User.FindFirst("sid")?.Value;
+        var sidClaim = context.User.FindFirst(AuthConstants.ClaimNames.SessionId)?.Value;
         if (string.IsNullOrWhiteSpace(sidClaim) || !Id<UserSession>.TryParse(sidClaim, out var sessionId))
         {
             context.Response.StatusCode = StatusCodes.Status401Unauthorized;
@@ -39,7 +40,7 @@ public sealed class UserContextMiddleware
             return;
         }
 
-        var userIdClaim = context.User.FindFirst("userId")?.Value;
+        var userIdClaim = context.User.FindFirst(AuthConstants.ClaimNames.UserId)?.Value;
         if (string.IsNullOrWhiteSpace(userIdClaim) || !Id<User>.TryParse(userIdClaim, out var userId))
         {
             context.Response.StatusCode = StatusCodes.Status401Unauthorized;

--- a/LgymApi.Api/Program.cs
+++ b/LgymApi.Api/Program.cs
@@ -18,6 +18,7 @@ using LgymApi.Api.Configuration;
 using Microsoft.AspNetCore.Localization;
 using LgymApi.Api.Middleware;
 using LgymApi.Domain.Security;
+using LgymApi.Api.Constants;
 using Hangfire;
 using LgymApi.Api.Serialization;
 using LgymApi.BackgroundWorker.Common.Serialization;
@@ -54,7 +55,7 @@ builder.Services.AddSwaggerGen(options =>
     options.UseInlineDefinitionsForEnums();
     options.SchemaFilter<EnumAsStringSchemaFilter>();
 });
-var configuredCorsOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>();
+var configuredCorsOrigins = builder.Configuration.GetSection(ConfigKeys.CorsAllowedOrigins).Get<string[]>();
 var corsAllowedOrigins = CorsOriginResolver.ResolveAllowedOrigins(configuredCorsOrigins, builder.Environment.IsDevelopment());
 
 builder.Services.AddCors(options =>
@@ -67,7 +68,7 @@ builder.Services.AddCors(options =>
             return;
         }
 
-        throw new InvalidOperationException("No CORS allowed origins are configured. Configure 'Cors:AllowedOrigins' or disable CORS explicitly.");
+         throw new InvalidOperationException($"No CORS allowed origins are configured. Configure '{ConfigKeys.CorsAllowedOrigins}' or disable CORS explicitly.");
     });
 });
 builder.Services.AddHttpContextAccessor();
@@ -90,10 +91,10 @@ builder.Services.AddSignalR();
 builder.Services.AddSingleton<IUserIdProvider, LgymApi.Api.Hubs.NotificationHubUserIdProvider>();
 builder.Services.AddScoped<IInAppNotificationPushPublisher, LgymApi.Api.Features.InAppNotification.SignalRNotificationPushPublisher>();
 
-var jwtSigningKey = builder.Configuration["Jwt:SigningKey"];
+var jwtSigningKey = builder.Configuration[ConfigKeys.JwtSigningKey];
 if (string.IsNullOrWhiteSpace(jwtSigningKey) || jwtSigningKey.Length < 32)
 {
-    throw new InvalidOperationException("Jwt:SigningKey is not configured or is too short. Set a strong key value.");
+    throw new InvalidOperationException($"{ConfigKeys.JwtSigningKey} is not configured or is too short. Set a strong key value.");
 }
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
@@ -194,7 +195,7 @@ if (!builder.Environment.IsEnvironment(TestingEnvironment))
                 });
             }
 
-            var userId = context.User.FindFirst("userId")?.Value;
+            var userId = context.User.FindFirst(AuthConstants.ClaimNames.UserId)?.Value;
             var key = string.IsNullOrWhiteSpace(userId)
                 ? context.Connection.RemoteIpAddress?.ToString() ?? "unknown"
                 : userId;

--- a/LgymApi.Domain/Security/AuthConstants.cs
+++ b/LgymApi.Domain/Security/AuthConstants.cs
@@ -38,4 +38,15 @@ public static class AuthConstants
         public const string ManageGlobalExercises = "policy.exercises.global.manage";
         public const string TrainerAccess = "policy.trainer.access";
     }
+
+    public static class ClaimNames
+    {
+        public const string UserId = "userId";
+        public const string SessionId = "sid";
+    }
+
+    public static class ConfigKeys
+    {
+        public const string JwtSigningKey = "Jwt:SigningKey";
+    }
 }

--- a/LgymApi.Infrastructure/Services/TokenService.cs
+++ b/LgymApi.Infrastructure/Services/TokenService.cs
@@ -21,10 +21,10 @@ public sealed class TokenService : ITokenService
 
     public string CreateToken(Id<User> userId, Id<UserSession> sessionId, string jti, IReadOnlyCollection<string> roles, IReadOnlyCollection<string> permissionClaims)
     {
-        var signingKey = _configuration["Jwt:SigningKey"];
+        var signingKey = _configuration[AuthConstants.ConfigKeys.JwtSigningKey];
         if (string.IsNullOrWhiteSpace(signingKey) || signingKey.Length < 32)
         {
-            throw new InvalidOperationException("Jwt:SigningKey is not configured or is too short. Set a strong key value.");
+            throw new InvalidOperationException($"{AuthConstants.ConfigKeys.JwtSigningKey} is not configured or is too short. Set a strong key value.");
         }
 
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
@@ -34,8 +34,8 @@ public sealed class TokenService : ITokenService
         var claims = new List<Claim>
         {
             new(JwtRegisteredClaimNames.Sub, userIdString),
-            new("userId", userIdString),
-            new("sid", sessionId.ToString()),
+            new(AuthConstants.ClaimNames.UserId, userIdString),
+            new(AuthConstants.ClaimNames.SessionId, sessionId.ToString()),
             new(JwtRegisteredClaimNames.Jti, jti)
         };
 

--- a/LgymApi.IntegrationTests/RankingTests.cs
+++ b/LgymApi.IntegrationTests/RankingTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using FluentAssertions;
+using LgymApi.Api.Features.User.Contracts;
 using LgymApi.Domain.Entities;
 using LgymApi.Domain.ValueObjects;
 
@@ -102,7 +103,7 @@ public sealed class RankingTests : IntegrationTestBase
         var user = await SeedUserAsync(name: "visibilityuser", email: "vis@example.com", isVisibleInRanking: true);
         SetAuthorizationHeader(user.Id);
 
-        var request = new Dictionary<string, bool> { { "isVisibleInRanking", false } };
+        var request = new ChangeVisibilityInRankingRequest { IsVisibleInRanking = false };
         var response = await Client.PostAsJsonAsync("/api/changeVisibilityInRanking", request);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -121,7 +122,7 @@ public sealed class RankingTests : IntegrationTestBase
         var user = await SeedUserAsync(name: "hiddenuser", email: "hid@example.com", isVisibleInRanking: false);
         SetAuthorizationHeader(user.Id);
 
-        var request = new Dictionary<string, bool> { { "isVisibleInRanking", true } };
+        var request = new ChangeVisibilityInRankingRequest { IsVisibleInRanking = true };
         var response = await Client.PostAsJsonAsync("/api/changeVisibilityInRanking", request);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -143,7 +144,7 @@ public sealed class RankingTests : IntegrationTestBase
         var user = await SeedUserAsync(name: "badrequest", email: "bad@example.com");
         SetAuthorizationHeader(user.Id);
 
-        var request = new Dictionary<string, string> { { "wrongField", "value" } };
+        var request = new ChangeVisibilityInRankingRequest { IsVisibleInRanking = null };
         var response = await Client.PostAsJsonAsync("/api/changeVisibilityInRanking", request);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);

--- a/LgymApi.IntegrationTests/UserSessionIntegrationTests.cs
+++ b/LgymApi.IntegrationTests/UserSessionIntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using FluentAssertions;
 using LgymApi.Domain.Entities;
+using LgymApi.Domain.Security;
 using LgymApi.Domain.ValueObjects;
 using LgymApi.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
@@ -224,7 +225,7 @@ public sealed class UserSessionIntegrationTests : IntegrationTestBase
     private SessionClaims ReadSessionClaims(string token)
     {
         var jwt = new JwtSecurityTokenHandler().ReadJwtToken(token);
-        var sid = jwt.Claims.Single(c => c.Type == "sid").Value;
+        var sid = jwt.Claims.Single(c => c.Type == AuthConstants.ClaimNames.SessionId).Value;
         var jti = jwt.Claims.Single(c => c.Type == JwtRegisteredClaimNames.Jti).Value;
         Id<UserSession>.TryParse(sid, out var sessionId).Should().BeTrue();
 

--- a/LgymApi.UnitTests/AdminUserControllerTests.cs
+++ b/LgymApi.UnitTests/AdminUserControllerTests.cs
@@ -11,6 +11,7 @@ using LgymApi.Application.Mapping;
 using LgymApi.Application.Mapping.Core;
 using LgymApi.Application.Pagination;
 using LgymApi.Domain.Entities;
+using LgymApi.Domain.Security;
 using LgymApi.Domain.ValueObjects;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -94,7 +95,7 @@ public sealed class AdminUserControllerTests
                 {
                     User = new ClaimsPrincipal(new ClaimsIdentity(
                     [
-                        new Claim("userId", Id<User>.New().ToString())
+                        new Claim(AuthConstants.ClaimNames.UserId, Id<User>.New().ToString())
                     ],
                     "TestAuth"))
                 }

--- a/LgymApi.UnitTests/ChangeVisibilityInRankingRequestValidatorTests.cs
+++ b/LgymApi.UnitTests/ChangeVisibilityInRankingRequestValidatorTests.cs
@@ -1,0 +1,41 @@
+using LgymApi.Api.Features.User.Contracts;
+using LgymApi.Api.Features.User.Validation;
+
+namespace LgymApi.UnitTests;
+
+[TestFixture]
+public sealed class ChangeVisibilityInRankingRequestValidatorTests
+{
+    [Test]
+    public void Validate_Fails_WhenIsVisibleInRankingIsNull()
+    {
+        var validator = new ChangeVisibilityInRankingRequestValidator();
+        var request = new ChangeVisibilityInRankingRequest { IsVisibleInRanking = null };
+
+        var result = validator.Validate(request);
+
+        Assert.That(result.IsValid, Is.False);
+    }
+
+    [Test]
+    public void Validate_Passes_WhenIsVisibleInRankingIsTrue()
+    {
+        var validator = new ChangeVisibilityInRankingRequestValidator();
+        var request = new ChangeVisibilityInRankingRequest { IsVisibleInRanking = true };
+
+        var result = validator.Validate(request);
+
+        Assert.That(result.IsValid, Is.True);
+    }
+
+    [Test]
+    public void Validate_Passes_WhenIsVisibleInRankingIsFalse()
+    {
+        var validator = new ChangeVisibilityInRankingRequestValidator();
+        var request = new ChangeVisibilityInRankingRequest { IsVisibleInRanking = false };
+
+        var result = validator.Validate(request);
+
+        Assert.That(result.IsValid, Is.True);
+    }
+}

--- a/LgymApi.UnitTests/InAppNotifications/NotificationHubTests.cs
+++ b/LgymApi.UnitTests/InAppNotifications/NotificationHubTests.cs
@@ -1,6 +1,7 @@
 using LgymApi.Api.Hubs;
 using LgymApi.Application.Services;
 using LgymApi.Domain.Entities;
+using LgymApi.Domain.Security;
 using LgymApi.Domain.ValueObjects;
 using LgymApi.UnitTests.Fakes;
 using Microsoft.AspNetCore.Http.Features;
@@ -99,12 +100,12 @@ public sealed class NotificationHubTests
 
             if (userId != null)
             {
-                claims.Add(new Claim("userId", userId));
+                claims.Add(new Claim(AuthConstants.ClaimNames.UserId, userId));
             }
 
             if (sessionId != null)
             {
-                claims.Add(new Claim("sid", sessionId));
+                claims.Add(new Claim(AuthConstants.ClaimNames.SessionId, sessionId));
             }
 
             User = claims.Count > 0

--- a/LgymApi.UnitTests/InAppNotifications/NotificationHubUserIdProviderTests.cs
+++ b/LgymApi.UnitTests/InAppNotifications/NotificationHubUserIdProviderTests.cs
@@ -1,4 +1,5 @@
 using LgymApi.Api.Hubs;
+using LgymApi.Domain.Security;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -12,7 +13,7 @@ public sealed class NotificationHubUserIdProviderTests
     [Test]
     public void GetUserId_WithUserIdClaim_ReturnsClaimValue()
     {
-        var connection = CreateConnection(new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("userId", "user-123") }, "Test")));
+        var connection = CreateConnection(new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(AuthConstants.ClaimNames.UserId, "user-123") }, "Test")));
 
         var result = new NotificationHubUserIdProvider().GetUserId(connection);
 

--- a/LgymApi.UnitTests/TokenServiceTests.cs
+++ b/LgymApi.UnitTests/TokenServiceTests.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using LgymApi.Domain.Entities;
+using LgymApi.Domain.Security;
 using LgymApi.Domain.ValueObjects;
 using LgymApi.Infrastructure.Services;
 using Microsoft.Extensions.Configuration;
@@ -25,7 +26,7 @@ public sealed class TokenServiceTests
     {
         var settings = new Dictionary<string, string?>
         {
-            ["Jwt:SigningKey"] = "unit-test-signing-key-at-least-32-chars"
+            [AuthConstants.ConfigKeys.JwtSigningKey] = "unit-test-signing-key-at-least-32-chars"
         };
         var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
         var service = new TokenService(configuration);
@@ -42,8 +43,8 @@ public sealed class TokenServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(jwt.Claims.Any(c => c.Type == "sub" && c.Value == userId.ToString()), Is.True, "Missing 'sub' claim");
-            Assert.That(jwt.Claims.Any(c => c.Type == "userId" && c.Value == userId.ToString()), Is.True, "Missing 'userId' claim");
-            Assert.That(jwt.Claims.Any(c => c.Type == "sid" && c.Value == sessionId.ToString()), Is.True, "Missing 'sid' claim");
+            Assert.That(jwt.Claims.Any(c => c.Type == AuthConstants.ClaimNames.UserId && c.Value == userId.ToString()), Is.True, "Missing 'userId' claim");
+            Assert.That(jwt.Claims.Any(c => c.Type == AuthConstants.ClaimNames.SessionId && c.Value == sessionId.ToString()), Is.True, "Missing 'sid' claim");
             Assert.That(jwt.Claims.Any(c => c.Type == JwtRegisteredClaimNames.Jti && c.Value == jti), Is.True, "Missing 'jti' claim");
             Assert.That(jwt.Claims.Any(c => c.Type == ClaimTypes.Role && c.Value == "User"), Is.True, "Missing 'User' role claim");
             Assert.That(jwt.Claims.Any(c => c.Type == "permission" && c.Value == "admin:access"), Is.True, "Missing 'admin:access' permission claim");

--- a/LgymApi.UnitTests/UserContextMiddlewareBlockedTests.cs
+++ b/LgymApi.UnitTests/UserContextMiddlewareBlockedTests.cs
@@ -5,6 +5,7 @@ using LgymApi.Application.Pagination;
 using LgymApi.Application.Repositories;
 using LgymApi.Application.Services;
 using LgymApi.Domain.Entities;
+using LgymApi.Domain.Security;
 using LgymApi.Domain.ValueObjects;
 using LgymApi.UnitTests.Fakes;
 using Microsoft.AspNetCore.Http;
@@ -84,8 +85,8 @@ public sealed class UserContextMiddlewareBlockedTests
         var context = new DefaultHttpContext();
         context.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
         {
-            new Claim("userId", userId.ToString()),
-            new Claim("sid", sessionId.ToString())
+            new Claim(AuthConstants.ClaimNames.UserId, userId.ToString()),
+            new Claim(AuthConstants.ClaimNames.SessionId, sessionId.ToString())
         }));
         context.Response.Body = new System.IO.MemoryStream();
         context.SetEndpoint(new Endpoint(

--- a/LgymApi.UnitTests/UserControllerTests.cs
+++ b/LgymApi.UnitTests/UserControllerTests.cs
@@ -91,18 +91,6 @@ public sealed class UserControllerTests
         Assert.That(((ResponseMessageDto)objectResult.Value!).Message, Is.EqualTo(message));
     }
 
-    [Test]
-    public async Task ChangeVisibilityInRanking_WhenFlagMissing_ReturnsBadRequest()
-    {
-        var controller = CreateController(new StubUserService());
-        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
-
-        var action = await controller.ChangeVisibilityInRanking(new Dictionary<string, bool>());
-
-        Assert.That(action, Is.TypeOf<ObjectResult>());
-        Assert.That(((ObjectResult)action).StatusCode, Is.EqualTo(400));
-    }
-
     private static UserController CreateController(IUserService userService)
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## Summary
- extract typed claim/config constants and replace raw auth/config literals across API and infrastructure code
- migrate ChangeVisibilityInRanking from Dictionary<string, bool> to a typed request DTO plus FluentValidation coverage
- update unit, integration, and architecture-safe test coverage for the refactor

## Verification
- dotnet build LgymApi.sln --configuration Release
- dotnet test LgymApi.UnitTests/LgymApi.UnitTests.csproj --configuration Release --no-build
- dotnet test LgymApi.ArchitectureTests/LgymApi.ArchitectureTests.csproj --configuration Release --no-build
- dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --configuration Release --no-build
- dotnet test LgymApi.DataSeeder.Tests/LgymApi.DataSeeder.Tests.csproj --configuration Release --no-build

## Issues
- Parent: #273
- Closes #276