### PR TITLE
feat: Google OAuth sign-in and account linking (#302)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageVersion Include="Gridify" Version="2.19.0" />
+    <PackageVersion Include="Google.Apis.Auth" Version="1.73.0" />
     <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.23" />
     <PackageVersion Include="Hangfire.PostgreSql" Version="1.21.1" />
     <PackageVersion Include="MailKit" Version="4.16.0" />

--- a/LgymApi.Api/Features/Account/Contracts/AccountDtos.cs
+++ b/LgymApi.Api/Features/Account/Contracts/AccountDtos.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+using LgymApi.Api.Interfaces;
+
+namespace LgymApi.Api.Features.Account.Contracts;
+
+public sealed class LinkGoogleRequest : IDto
+{
+    [JsonPropertyName("idToken")]
+    public string IdToken { get; set; } = string.Empty;
+}
+
+public sealed class ExternalLoginDto : IResultDto
+{
+    [JsonPropertyName("provider")]
+    public string Provider { get; set; } = string.Empty;
+
+    [JsonPropertyName("providerEmail")]
+    public string? ProviderEmail { get; set; }
+}

--- a/LgymApi.Api/Features/Account/Controllers/AccountController.cs
+++ b/LgymApi.Api/Features/Account/Controllers/AccountController.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Serialization;
+using LgymApi.Api.Extensions;
+using LgymApi.Api.Features.Account.Contracts;
+using LgymApi.Api.Middleware;
+using LgymApi.Api.Features.Common.Contracts;
+using LgymApi.Application.ExternalAuth;
+using LgymApi.Application.Mapping.Core;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LgymApi.Api.Features.Account.Controllers;
+
+[ApiController]
+[Route("api/account")]
+[Authorize]
+public sealed class AccountController : ControllerBase
+{
+    private readonly IAccountLinkingService _accountLinkingService;
+    private readonly IMapper _mapper;
+
+    public AccountController(IAccountLinkingService accountLinkingService, IMapper mapper)
+    {
+        _accountLinkingService = accountLinkingService;
+        _mapper = mapper;
+    }
+
+    [HttpPost("link-google")]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> LinkGoogle([FromBody] LinkGoogleRequest request, CancellationToken cancellationToken = default)
+    {
+        // validation (FluentValidation will run automatically when configured)
+        var userId = HttpContext.GetCurrentUserId();
+
+        var result = await _accountLinkingService.LinkGoogleAsync(userId, request.IdToken, cancellationToken);
+        if (result.IsFailure)
+        {
+            return result.ToActionResult();
+        }
+
+        return Ok(_mapper.Map<string, ResponseMessageDto>(LgymApi.Resources.Messages.Updated));
+    }
+
+    [HttpGet("external-logins")]
+    [ProducesResponseType(typeof(ExternalLoginDto[]), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetExternalLogins(CancellationToken cancellationToken = default)
+    {
+        var userId = HttpContext.GetCurrentUserId();
+        var result = await _accountLinkingService.GetExternalLoginsAsync(userId, cancellationToken);
+        if (result.IsFailure)
+        {
+            return result.ToActionResult();
+        }
+
+        var mapped = _mapper.MapList<LgymApi.Application.ExternalAuth.ExternalLoginInfo, ExternalLoginDto>(result.Value);
+        return Ok(mapped);
+    }
+}

--- a/LgymApi.Api/Features/Account/Controllers/AccountController.cs
+++ b/LgymApi.Api/Features/Account/Controllers/AccountController.cs
@@ -1,12 +1,8 @@
-using System.Text.Json.Serialization;
 using LgymApi.Api.Extensions;
 using LgymApi.Api.Features.Account.Contracts;
-using LgymApi.Api.Middleware;
 using LgymApi.Api.Features.Common.Contracts;
 using LgymApi.Application.ExternalAuth;
 using LgymApi.Application.Mapping.Core;
-using LgymApi.Domain.ValueObjects;
-using LgymApi.Domain.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -32,7 +28,7 @@ public sealed class AccountController : ControllerBase
     public async Task<IActionResult> LinkGoogle([FromBody] LinkGoogleRequest request, CancellationToken cancellationToken = default)
     {
         // validation (FluentValidation will run automatically when configured)
-        var userId = HttpContext.GetCurrentUserId();
+        var userId = LgymApi.Api.Middleware.HttpContextExtensions.GetCurrentUserId(HttpContext);
 
         var result = await _accountLinkingService.LinkGoogleAsync(userId, request.IdToken, cancellationToken);
         if (result.IsFailure)
@@ -47,7 +43,7 @@ public sealed class AccountController : ControllerBase
     [ProducesResponseType(typeof(ExternalLoginDto[]), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetExternalLogins(CancellationToken cancellationToken = default)
     {
-        var userId = HttpContext.GetCurrentUserId();
+        var userId = LgymApi.Api.Middleware.HttpContextExtensions.GetCurrentUserId(HttpContext);
         var result = await _accountLinkingService.GetExternalLoginsAsync(userId, cancellationToken);
         if (result.IsFailure)
         {

--- a/LgymApi.Api/Features/Account/Validation/LinkGoogleRequestValidator.cs
+++ b/LgymApi.Api/Features/Account/Validation/LinkGoogleRequestValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using LgymApi.Api.Features.Account.Contracts;
+using LgymApi.Resources;
+
+namespace LgymApi.Api.Features.Account.Validation;
+
+public sealed class LinkGoogleRequestValidator : AbstractValidator<LinkGoogleRequest>
+{
+    public LinkGoogleRequestValidator()
+    {
+        RuleFor(x => x.IdToken)
+            .NotEmpty()
+            .WithMessage(Messages.GoogleIdTokenRequired);
+    }
+}

--- a/LgymApi.Api/Features/Auth/Contracts/AuthDtos.cs
+++ b/LgymApi.Api/Features/Auth/Contracts/AuthDtos.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+using LgymApi.Api.Interfaces;
+
+namespace LgymApi.Api.Features.Auth.Contracts;
+
+public sealed class GoogleSignInRequest : IDto
+{
+    [JsonPropertyName("idToken")]
+    public string IdToken { get; set; } = string.Empty;
+}

--- a/LgymApi.Api/Features/Auth/Controllers/AuthController.cs
+++ b/LgymApi.Api/Features/Auth/Controllers/AuthController.cs
@@ -1,0 +1,41 @@
+using LgymApi.Api.Extensions;
+using LgymApi.Api.Features.Auth.Contracts;
+using LgymApi.Api.Features.User.Contracts;
+using LgymApi.Api.Middleware;
+using LgymApi.Application.ExternalAuth;
+using LgymApi.Application.Features.User.Models;
+using LgymApi.Application.Mapping.Core;
+using LgymApi.Resources;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LgymApi.Api.Features.Auth.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public sealed class AuthController : ControllerBase
+{
+    private readonly IExternalAuthService _externalAuthService;
+    private readonly IMapper _mapper;
+
+    public AuthController(IExternalAuthService externalAuthService, IMapper mapper)
+    {
+        _externalAuthService = externalAuthService;
+        _mapper = mapper;
+    }
+
+    [HttpPost("google")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(LoginResponseDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Google([FromBody] GoogleSignInRequest request, CancellationToken cancellationToken = default)
+    {
+        var result = await _externalAuthService.GoogleSignInAsync(request.IdToken, cancellationToken);
+        if (result.IsFailure)
+        {
+            return result.ToActionResult();
+        }
+
+        var mapped = _mapper.Map<LoginResult, LoginResponseDto>(result.Value);
+        return Ok(mapped);
+    }
+}

--- a/LgymApi.Api/Features/Auth/Controllers/AuthController.cs
+++ b/LgymApi.Api/Features/Auth/Controllers/AuthController.cs
@@ -1,11 +1,7 @@
 using LgymApi.Api.Extensions;
 using LgymApi.Api.Features.Auth.Contracts;
-using LgymApi.Api.Features.User.Contracts;
-using LgymApi.Api.Middleware;
 using LgymApi.Application.ExternalAuth;
-using LgymApi.Application.Features.User.Models;
 using LgymApi.Application.Mapping.Core;
-using LgymApi.Resources;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -26,7 +22,7 @@ public sealed class AuthController : ControllerBase
 
     [HttpPost("google")]
     [AllowAnonymous]
-    [ProducesResponseType(typeof(LoginResponseDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(LgymApi.Api.Features.User.Contracts.LoginResponseDto), StatusCodes.Status200OK)]
     public async Task<IActionResult> Google([FromBody] GoogleSignInRequest request, CancellationToken cancellationToken = default)
     {
         var result = await _externalAuthService.GoogleSignInAsync(request.IdToken, cancellationToken);
@@ -35,7 +31,7 @@ public sealed class AuthController : ControllerBase
             return result.ToActionResult();
         }
 
-        var mapped = _mapper.Map<LoginResult, LoginResponseDto>(result.Value);
+        var mapped = _mapper.Map<LgymApi.Application.Features.User.Models.LoginResult, LgymApi.Api.Features.User.Contracts.LoginResponseDto>(result.Value);
         return Ok(mapped);
     }
 }

--- a/LgymApi.Api/Features/Auth/Validation/GoogleSignInRequestValidator.cs
+++ b/LgymApi.Api/Features/Auth/Validation/GoogleSignInRequestValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using LgymApi.Api.Features.Auth.Contracts;
+using LgymApi.Resources;
+
+namespace LgymApi.Api.Features.Auth.Validation;
+
+public sealed class GoogleSignInRequestValidator : AbstractValidator<GoogleSignInRequest>
+{
+    public GoogleSignInRequestValidator()
+    {
+        RuleFor(x => x.IdToken)
+            .NotEmpty()
+            .WithMessage(Messages.GoogleIdTokenRequired);
+    }
+}

--- a/LgymApi.Api/Mapping/Profiles/AccountProfile.cs
+++ b/LgymApi.Api/Mapping/Profiles/AccountProfile.cs
@@ -1,0 +1,17 @@
+using LgymApi.Api.Features.Account.Contracts;
+using LgymApi.Application.ExternalAuth;
+using LgymApi.Application.Mapping.Core;
+
+namespace LgymApi.Api.Mapping.Profiles;
+
+public sealed class AccountProfile : IMappingProfile
+{
+    public void Configure(MappingConfiguration configuration)
+    {
+        configuration.CreateMap<ExternalLoginInfo, ExternalLoginDto>((source, _) => new ExternalLoginDto
+        {
+            Provider = source.Provider,
+            ProviderEmail = source.ProviderEmail
+        });
+    }
+}

--- a/LgymApi.Api/appsettings.json
+++ b/LgymApi.Api/appsettings.json
@@ -5,6 +5,9 @@
   "Jwt": {
     "SigningKey": "YOUR_JWT_SIGNING_KEY_HERE"
   },
+  "GoogleAuth": {
+    "ClientId": "YOUR_GOOGLE_CLIENT_ID_HERE"
+  },
   "Cors": {
     "AllowedOrigins": []
   },

--- a/LgymApi.Application/ExternalAuth/AccountLinkingService.cs
+++ b/LgymApi.Application/ExternalAuth/AccountLinkingService.cs
@@ -1,0 +1,86 @@
+using LgymApi.Application.Common.Errors;
+using LgymApi.Application.Common.Results;
+using LgymApi.Application.Repositories;
+using LgymApi.Application.Services;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.Security;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.Resources;
+
+namespace LgymApi.Application.ExternalAuth;
+
+public sealed class AccountLinkingService : IAccountLinkingService
+{
+    private readonly IGoogleTokenValidator _googleTokenValidator;
+    private readonly IUserRepository _userRepository;
+    private readonly IUserExternalLoginRepository _userExternalLoginRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public AccountLinkingService(
+        IGoogleTokenValidator googleTokenValidator,
+        IUserRepository userRepository,
+        IUserExternalLoginRepository userExternalLoginRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _googleTokenValidator = googleTokenValidator;
+        _userRepository = userRepository;
+        _userExternalLoginRepository = userExternalLoginRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<Unit, AppError>> LinkGoogleAsync(Id<User> userId, string idToken, CancellationToken cancellationToken)
+    {
+        var token = await _googleTokenValidator.ValidateAsync(idToken, cancellationToken);
+        if (token == null || !token.EmailVerified)
+        {
+            return Result<Unit, AppError>.Failure(new InvalidUserError(Messages.InvalidToken));
+        }
+
+        var user = await _userRepository.FindByIdAsync(userId, cancellationToken);
+        if (user == null)
+        {
+            return Result<Unit, AppError>.Failure(new UserNotFoundError(Messages.DidntFind));
+        }
+
+        var existingLogin = await _userExternalLoginRepository.FindByProviderAsync(
+            AuthConstants.ExternalProviders.Google,
+            token.Subject,
+            cancellationToken);
+
+        if (existingLogin != null)
+        {
+            return Result<Unit, AppError>.Failure(new ConflictError(Messages.GoogleAccountAlreadyLinked));
+        }
+
+        await _userExternalLoginRepository.AddAsync(new UserExternalLogin
+        {
+            Id = Id<UserExternalLogin>.New(),
+            UserId = userId,
+            Provider = AuthConstants.ExternalProviders.Google,
+            ProviderKey = token.Subject,
+            ProviderEmail = token.Email
+        }, cancellationToken);
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return Result<Unit, AppError>.Success(Unit.Value);
+    }
+
+    public async Task<Result<IReadOnlyList<ExternalLoginInfo>, AppError>> GetExternalLoginsAsync(Id<User> userId, CancellationToken cancellationToken)
+    {
+        var user = await _userRepository.FindByIdAsync(userId, cancellationToken);
+        if (user == null)
+        {
+            return Result<IReadOnlyList<ExternalLoginInfo>, AppError>.Failure(new UserNotFoundError(Messages.DidntFind));
+        }
+
+        var externalLogins = await _userExternalLoginRepository.GetByUserIdAsync(userId, cancellationToken);
+        var result = externalLogins
+            .OrderBy(x => x.Provider, StringComparer.Ordinal)
+            .Select(x => new ExternalLoginInfo(x.Provider, x.ProviderEmail))
+            .ToList()
+            .AsReadOnly();
+
+        return Result<IReadOnlyList<ExternalLoginInfo>, AppError>.Success(result);
+    }
+}

--- a/LgymApi.Application/ExternalAuth/AccountLinkingService.cs
+++ b/LgymApi.Application/ExternalAuth/AccountLinkingService.cs
@@ -31,15 +31,30 @@ public sealed class AccountLinkingService : IAccountLinkingService
     public async Task<Result<Unit, AppError>> LinkGoogleAsync(Id<User> userId, string idToken, CancellationToken cancellationToken)
     {
         var token = await _googleTokenValidator.ValidateAsync(idToken, cancellationToken);
-        if (token == null || !token.EmailVerified)
+        if (token == null)
         {
-            return Result<Unit, AppError>.Failure(new InvalidUserError(Messages.InvalidToken));
+            return Result<Unit, AppError>.Failure(new InvalidUserError(Messages.GoogleTokenInvalid));
+        }
+
+        if (!token.EmailVerified)
+        {
+            return Result<Unit, AppError>.Failure(new InvalidUserError(Messages.GoogleEmailNotVerified));
         }
 
         var user = await _userRepository.FindByIdAsync(userId, cancellationToken);
         if (user == null)
         {
             return Result<Unit, AppError>.Failure(new UserNotFoundError(Messages.DidntFind));
+        }
+
+        var existingUserLogin = await _userExternalLoginRepository.FindByUserAndProviderAsync(
+            userId,
+            AuthConstants.ExternalProviders.Google,
+            cancellationToken);
+
+        if (existingUserLogin != null)
+        {
+            return Result<Unit, AppError>.Failure(new ConflictError(Messages.GoogleAccountAlreadyLinked));
         }
 
         var existingLogin = await _userExternalLoginRepository.FindByProviderAsync(

--- a/LgymApi.Application/ExternalAuth/AccountLinkingService.cs
+++ b/LgymApi.Application/ExternalAuth/AccountLinkingService.cs
@@ -76,7 +76,14 @@ public sealed class AccountLinkingService : IAccountLinkingService
             ProviderEmail = token.Email
         }, cancellationToken);
 
-        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex.GetType().Name == "DbUpdateException")
+        {
+            return Result<Unit, AppError>.Failure(new ConflictError(Messages.GoogleAccountAlreadyLinked));
+        }
 
         return Result<Unit, AppError>.Success(Unit.Value);
     }

--- a/LgymApi.Application/ExternalAuth/ExternalAuthService.cs
+++ b/LgymApi.Application/ExternalAuth/ExternalAuthService.cs
@@ -1,0 +1,87 @@
+using LgymApi.Application.Common.Errors;
+using LgymApi.Application.Common.Results;
+using LgymApi.Application.Features.User.Models;
+using LgymApi.Application.Repositories;
+using LgymApi.Application.Services;
+using LgymApi.Domain.Security;
+using LgymApi.Resources;
+
+namespace LgymApi.Application.ExternalAuth;
+
+public sealed class ExternalAuthService : IExternalAuthService
+{
+    private readonly IGoogleTokenValidator _googleTokenValidator;
+    private readonly IGoogleUserRegistrar _googleUserRegistrar;
+    private readonly ILoginResultBuilder _loginResultBuilder;
+    private readonly IUserExternalLoginRepository _userExternalLoginRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public ExternalAuthService(
+        IGoogleTokenValidator googleTokenValidator,
+        IUserExternalLoginRepository userExternalLoginRepository,
+        IGoogleUserRegistrar googleUserRegistrar,
+        ILoginResultBuilder loginResultBuilder,
+        IUnitOfWork unitOfWork)
+    {
+        _googleTokenValidator = googleTokenValidator;
+        _userExternalLoginRepository = userExternalLoginRepository;
+        _googleUserRegistrar = googleUserRegistrar;
+        _loginResultBuilder = loginResultBuilder;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<LoginResult, AppError>> GoogleSignInAsync(string idToken, CancellationToken cancellationToken)
+    {
+        var payload = await _googleTokenValidator.ValidateAsync(idToken, cancellationToken);
+        if (payload == null)
+        {
+            return Result<LoginResult, AppError>.Failure(new UserUnauthorizedError(Messages.GoogleTokenInvalid));
+        }
+
+        if (!payload.EmailVerified)
+        {
+            return Result<LoginResult, AppError>.Failure(new UserUnauthorizedError(Messages.GoogleEmailNotVerified));
+        }
+
+        var existingExternalLogin = await _userExternalLoginRepository.FindByProviderAsync(
+            AuthConstants.ExternalProviders.Google,
+            payload.Subject,
+            cancellationToken);
+
+        if (existingExternalLogin != null)
+        {
+            var existingUser = existingExternalLogin.User;
+            if (existingUser == null || existingUser.IsDeleted)
+            {
+                return Result<LoginResult, AppError>.Failure(new UserUnauthorizedError(Messages.Unauthorized));
+            }
+
+            if (existingUser.IsBlocked)
+            {
+                return Result<LoginResult, AppError>.Failure(new ForbiddenError(Messages.AccountBlocked));
+            }
+
+            var existingResult = await _loginResultBuilder.BuildAsync(existingUser, existingUser.PreferredTimeZone, cancellationToken);
+            if (existingResult.IsSuccess)
+            {
+                await _unitOfWork.SaveChangesAsync(cancellationToken);
+            }
+
+            return existingResult;
+        }
+
+        var createdUserResult = await _googleUserRegistrar.RegisterAsync(payload, cancellationToken);
+        if (!createdUserResult.IsSuccess)
+        {
+            return Result<LoginResult, AppError>.Failure(createdUserResult.Error!);
+        }
+
+        var createdResult = await _loginResultBuilder.BuildAsync(createdUserResult.Value!, createdUserResult.Value!.PreferredTimeZone, cancellationToken);
+        if (createdResult.IsSuccess)
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+        }
+
+        return createdResult;
+    }
+}

--- a/LgymApi.Application/ExternalAuth/ExternalLoginInfo.cs
+++ b/LgymApi.Application/ExternalAuth/ExternalLoginInfo.cs
@@ -1,0 +1,3 @@
+namespace LgymApi.Application.ExternalAuth;
+
+public sealed record ExternalLoginInfo(string Provider, string? ProviderEmail);

--- a/LgymApi.Application/ExternalAuth/GoogleSignInInput.cs
+++ b/LgymApi.Application/ExternalAuth/GoogleSignInInput.cs
@@ -1,0 +1,6 @@
+namespace LgymApi.Application.ExternalAuth;
+
+public sealed class GoogleSignInInput
+{
+    public string IdToken { get; init; } = string.Empty;
+}

--- a/LgymApi.Application/ExternalAuth/GoogleSignInInput.cs
+++ b/LgymApi.Application/ExternalAuth/GoogleSignInInput.cs
@@ -1,6 +1,0 @@
-namespace LgymApi.Application.ExternalAuth;
-
-public sealed class GoogleSignInInput
-{
-    public string IdToken { get; init; } = string.Empty;
-}

--- a/LgymApi.Application/ExternalAuth/GoogleUserRegistrar.cs
+++ b/LgymApi.Application/ExternalAuth/GoogleUserRegistrar.cs
@@ -1,0 +1,113 @@
+using LgymApi.Application.Common.Errors;
+using LgymApi.Application.Common.Results;
+using LgymApi.Application.Options;
+using LgymApi.Application.Repositories;
+using LgymApi.Application.Services;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.Security;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.Resources;
+
+namespace LgymApi.Application.ExternalAuth;
+
+public sealed class GoogleUserRegistrar : IGoogleUserRegistrar
+{
+    private const string DefaultProfileRank = "Junior 1";
+
+    private readonly AppDefaultsOptions _appDefaultsOptions;
+    private readonly IUserExternalLoginRepository _userExternalLoginRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly IRoleRepository _roleRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public GoogleUserRegistrar(
+        IUserRepository userRepository,
+        IUserExternalLoginRepository userExternalLoginRepository,
+        IRoleRepository roleRepository,
+        IUnitOfWork unitOfWork,
+        AppDefaultsOptions appDefaultsOptions)
+    {
+        _userRepository = userRepository;
+        _userExternalLoginRepository = userExternalLoginRepository;
+        _roleRepository = roleRepository;
+        _unitOfWork = unitOfWork;
+        _appDefaultsOptions = appDefaultsOptions;
+    }
+
+    public async Task<Result<User, AppError>> RegisterAsync(GoogleTokenPayload payload, CancellationToken cancellationToken)
+    {
+        var normalizedEmail = new Email(payload.Email);
+        var localUser = await _userRepository.FindByEmailAsync(normalizedEmail, cancellationToken);
+        if (localUser != null)
+        {
+            return Result<User, AppError>.Failure(new ConflictError(Messages.GoogleEmailConflict));
+        }
+
+        var userRole = await _roleRepository.GetByNamesAsync([AuthConstants.Roles.User], cancellationToken);
+        if (userRole.Count != 1)
+        {
+            return Result<User, AppError>.Failure(new InternalServerError(Messages.DefaultRoleMissing));
+        }
+
+        var user = new User
+        {
+            Id = Id<User>.New(),
+            Name = await GenerateUniqueUserNameAsync(normalizedEmail.Value, cancellationToken),
+            Email = normalizedEmail,
+            IsVisibleInRanking = true,
+            ProfileRank = DefaultProfileRank,
+            PreferredLanguage = _appDefaultsOptions.PreferredLanguage,
+            PreferredTimeZone = _appDefaultsOptions.PreferredTimeZone
+        };
+
+        var externalLogin = new UserExternalLogin
+        {
+            Id = Id<UserExternalLogin>.New(),
+            UserId = user.Id,
+            Provider = AuthConstants.ExternalProviders.Google,
+            ProviderKey = payload.Subject,
+            ProviderEmail = normalizedEmail.Value
+        };
+
+        await _userRepository.AddAsync(user, cancellationToken);
+        await _userExternalLoginRepository.AddAsync(externalLogin, cancellationToken);
+        await _roleRepository.AddUserRolesAsync(user.Id, [userRole[0].Id], cancellationToken);
+
+        try
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex.GetType().Name == "DbUpdateException")
+        {
+            return Result<User, AppError>.Failure(new ConflictError(Messages.GoogleEmailConflict));
+        }
+
+        var createdUser = await _userRepository.FindByIdIncludingDeletedAsync(user.Id, cancellationToken);
+        return createdUser == null
+            ? Result<User, AppError>.Failure(new InternalServerError(Messages.Unauthorized))
+            : Result<User, AppError>.Success(createdUser);
+    }
+
+    private async Task<string> GenerateUniqueUserNameAsync(string email, CancellationToken cancellationToken)
+    {
+        var atIndex = email.IndexOf('@');
+        var baseName = atIndex > 0 ? email[..atIndex] : email;
+        var candidateBase = string.Concat(baseName.Where(char.IsLetterOrDigit));
+
+        if (string.IsNullOrWhiteSpace(candidateBase))
+        {
+            candidateBase = "user";
+        }
+
+        var candidate = candidateBase;
+        var suffix = 1;
+
+        while (await _userRepository.FindByNameAsync(candidate, cancellationToken) != null)
+        {
+            suffix++;
+            candidate = $"{candidateBase}{suffix}";
+        }
+
+        return candidate;
+    }
+}

--- a/LgymApi.Application/ExternalAuth/GoogleUserRegistrar.cs
+++ b/LgymApi.Application/ExternalAuth/GoogleUserRegistrar.cs
@@ -82,9 +82,9 @@ public sealed class GoogleUserRegistrar : IGoogleUserRegistrar
             return Result<User, AppError>.Failure(new ConflictError(Messages.GoogleEmailConflict));
         }
 
-        var createdUser = await _userRepository.FindByIdIncludingDeletedAsync(user.Id, cancellationToken);
+        var createdUser = await _userRepository.FindByIdWithRolesAsync(user.Id, cancellationToken);
         return createdUser == null
-            ? Result<User, AppError>.Failure(new InternalServerError(Messages.Unauthorized))
+            ? Result<User, AppError>.Failure(new InternalServerError(Messages.UserLoadFailed))
             : Result<User, AppError>.Success(createdUser);
     }
 

--- a/LgymApi.Application/ExternalAuth/IAccountLinkingService.cs
+++ b/LgymApi.Application/ExternalAuth/IAccountLinkingService.cs
@@ -1,0 +1,12 @@
+using LgymApi.Application.Common.Errors;
+using LgymApi.Application.Common.Results;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.Application.ExternalAuth;
+
+public interface IAccountLinkingService
+{
+    Task<Result<Unit, AppError>> LinkGoogleAsync(Id<User> userId, string idToken, CancellationToken cancellationToken);
+    Task<Result<IReadOnlyList<ExternalLoginInfo>, AppError>> GetExternalLoginsAsync(Id<User> userId, CancellationToken cancellationToken);
+}

--- a/LgymApi.Application/ExternalAuth/IExternalAuthService.cs
+++ b/LgymApi.Application/ExternalAuth/IExternalAuthService.cs
@@ -1,0 +1,10 @@
+using LgymApi.Application.Common.Errors;
+using LgymApi.Application.Common.Results;
+using LgymApi.Application.Features.User.Models;
+
+namespace LgymApi.Application.ExternalAuth;
+
+public interface IExternalAuthService
+{
+    Task<Result<LoginResult, AppError>> GoogleSignInAsync(string idToken, CancellationToken cancellationToken);
+}

--- a/LgymApi.Application/ExternalAuth/IGoogleUserRegistrar.cs
+++ b/LgymApi.Application/ExternalAuth/IGoogleUserRegistrar.cs
@@ -1,0 +1,11 @@
+using LgymApi.Application.Common.Errors;
+using LgymApi.Application.Common.Results;
+using LgymApi.Application.Services;
+using LgymApi.Domain.Entities;
+
+namespace LgymApi.Application.ExternalAuth;
+
+public interface IGoogleUserRegistrar
+{
+    Task<Result<User, AppError>> RegisterAsync(GoogleTokenPayload payload, CancellationToken cancellationToken);
+}

--- a/LgymApi.Application/ExternalAuth/ILoginResultBuilder.cs
+++ b/LgymApi.Application/ExternalAuth/ILoginResultBuilder.cs
@@ -1,0 +1,11 @@
+using LgymApi.Application.Common.Errors;
+using LgymApi.Application.Common.Results;
+using LgymApi.Application.Features.User.Models;
+using LgymApi.Domain.Entities;
+
+namespace LgymApi.Application.ExternalAuth;
+
+public interface ILoginResultBuilder
+{
+    Task<Result<LoginResult, AppError>> BuildAsync(User user, string preferredTimeZone, CancellationToken cancellationToken);
+}

--- a/LgymApi.Application/ExternalAuth/LoginResultBuilder.cs
+++ b/LgymApi.Application/ExternalAuth/LoginResultBuilder.cs
@@ -6,6 +6,7 @@ using LgymApi.Application.Repositories;
 using LgymApi.Application.Services;
 using LgymApi.Domain.Entities;
 using LgymApi.Domain.ValueObjects;
+using LgymApi.Resources;
 
 namespace LgymApi.Application.ExternalAuth;
 
@@ -15,15 +16,18 @@ public sealed class LoginResultBuilder : ILoginResultBuilder
     private readonly IRankService _rankService;
     private readonly ITokenService _tokenService;
     private readonly ITutorialService _tutorialService;
+    private readonly IUserRepository _userRepository;
     private readonly IUserSessionStore _userSessionStore;
 
     public LoginResultBuilder(
+        IUserRepository userRepository,
         IUserSessionStore userSessionStore,
         ITokenService tokenService,
         IEloRegistryRepository eloRepository,
         IRankService rankService,
         ITutorialService tutorialService)
     {
+        _userRepository = userRepository;
         _userSessionStore = userSessionStore;
         _tokenService = tokenService;
         _eloRepository = eloRepository;
@@ -33,8 +37,14 @@ public sealed class LoginResultBuilder : ILoginResultBuilder
 
     public async Task<Result<LoginResult, AppError>> BuildAsync(User user, string preferredTimeZone, CancellationToken cancellationToken)
     {
-        var roles = user.UserRoles.Select(ur => ur.Role.Name).OrderBy(name => name).ToList();
-        var permissionClaims = user.UserRoles
+        var userWithRoles = await _userRepository.FindByIdWithRolesAsync(user.Id, cancellationToken);
+        if (userWithRoles == null)
+        {
+            return Result<LoginResult, AppError>.Failure(new InternalServerError(Messages.UserLoadFailed));
+        }
+
+        var roles = userWithRoles.UserRoles.Select(ur => ur.Role.Name).OrderBy(name => name).ToList();
+        var permissionClaims = userWithRoles.UserRoles
             .SelectMany(ur => ur.Role.RoleClaims)
             .Where(rc => rc.ClaimType == LgymApi.Domain.Security.AuthConstants.PermissionClaimType)
             .Select(rc => rc.ClaimValue)
@@ -42,12 +52,12 @@ public sealed class LoginResultBuilder : ILoginResultBuilder
             .OrderBy(value => value)
             .ToList();
 
-        var session = await _userSessionStore.CreateSessionAsync(user.Id, DateTimeOffset.UtcNow.AddDays(30), cancellationToken);
+        var session = await _userSessionStore.CreateSessionAsync(userWithRoles.Id, DateTimeOffset.UtcNow.AddDays(30), cancellationToken);
 
-        var token = _tokenService.CreateToken(user.Id, session.Id, session.Jti, roles, permissionClaims);
-        var elo = await _eloRepository.GetLatestEloAsync(user.Id, cancellationToken) ?? 1000;
-        var nextRank = _rankService.GetNextRank(user.ProfileRank);
-        var hasActiveTutorials = await _tutorialService.HasActiveTutorialsAsync(user.Id, cancellationToken);
+        var token = _tokenService.CreateToken(userWithRoles.Id, session.Id, session.Jti, roles, permissionClaims);
+        var elo = await _eloRepository.GetLatestEloAsync(userWithRoles.Id, cancellationToken) ?? 1000;
+        var nextRank = _rankService.GetNextRank(userWithRoles.ProfileRank);
+        var hasActiveTutorials = await _tutorialService.HasActiveTutorialsAsync(userWithRoles.Id, cancellationToken);
 
         return Result<LoginResult, AppError>.Success(new LoginResult
         {
@@ -55,18 +65,18 @@ public sealed class LoginResultBuilder : ILoginResultBuilder
             PermissionClaims = permissionClaims,
             User = new UserInfoResult
             {
-                Name = user.Name,
-                Id = user.Id,
-                Email = user.Email,
-                Avatar = user.Avatar,
-                ProfileRank = user.ProfileRank,
-                PreferredTimeZone = string.IsNullOrWhiteSpace(user.PreferredTimeZone) ? preferredTimeZone : user.PreferredTimeZone,
-                CreatedAt = user.CreatedAt.UtcDateTime,
-                UpdatedAt = user.UpdatedAt.UtcDateTime,
+                Name = userWithRoles.Name,
+                Id = userWithRoles.Id,
+                Email = userWithRoles.Email,
+                Avatar = userWithRoles.Avatar,
+                ProfileRank = userWithRoles.ProfileRank,
+                PreferredTimeZone = string.IsNullOrWhiteSpace(userWithRoles.PreferredTimeZone) ? preferredTimeZone : userWithRoles.PreferredTimeZone,
+                CreatedAt = userWithRoles.CreatedAt.UtcDateTime,
+                UpdatedAt = userWithRoles.UpdatedAt.UtcDateTime,
                 Elo = elo,
                 NextRank = nextRank == null ? null : new RankInfo { Name = nextRank.Name, NeedElo = nextRank.NeedElo },
-                IsDeleted = user.IsDeleted,
-                IsVisibleInRanking = user.IsVisibleInRanking,
+                IsDeleted = userWithRoles.IsDeleted,
+                IsVisibleInRanking = userWithRoles.IsVisibleInRanking,
                 Roles = roles,
                 PermissionClaims = permissionClaims,
                 HasActiveTutorials = hasActiveTutorials

--- a/LgymApi.Application/ExternalAuth/LoginResultBuilder.cs
+++ b/LgymApi.Application/ExternalAuth/LoginResultBuilder.cs
@@ -1,0 +1,76 @@
+using LgymApi.Application.Common.Errors;
+using LgymApi.Application.Common.Results;
+using LgymApi.Application.Features.Tutorial;
+using LgymApi.Application.Features.User.Models;
+using LgymApi.Application.Repositories;
+using LgymApi.Application.Services;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.Application.ExternalAuth;
+
+public sealed class LoginResultBuilder : ILoginResultBuilder
+{
+    private readonly IEloRegistryRepository _eloRepository;
+    private readonly IRankService _rankService;
+    private readonly ITokenService _tokenService;
+    private readonly ITutorialService _tutorialService;
+    private readonly IUserSessionStore _userSessionStore;
+
+    public LoginResultBuilder(
+        IUserSessionStore userSessionStore,
+        ITokenService tokenService,
+        IEloRegistryRepository eloRepository,
+        IRankService rankService,
+        ITutorialService tutorialService)
+    {
+        _userSessionStore = userSessionStore;
+        _tokenService = tokenService;
+        _eloRepository = eloRepository;
+        _rankService = rankService;
+        _tutorialService = tutorialService;
+    }
+
+    public async Task<Result<LoginResult, AppError>> BuildAsync(User user, string preferredTimeZone, CancellationToken cancellationToken)
+    {
+        var roles = user.UserRoles.Select(ur => ur.Role.Name).OrderBy(name => name).ToList();
+        var permissionClaims = user.UserRoles
+            .SelectMany(ur => ur.Role.RoleClaims)
+            .Where(rc => rc.ClaimType == LgymApi.Domain.Security.AuthConstants.PermissionClaimType)
+            .Select(rc => rc.ClaimValue)
+            .Distinct()
+            .OrderBy(value => value)
+            .ToList();
+
+        var session = await _userSessionStore.CreateSessionAsync(user.Id, DateTimeOffset.UtcNow.AddDays(30), cancellationToken);
+
+        var token = _tokenService.CreateToken(user.Id, session.Id, session.Jti, roles, permissionClaims);
+        var elo = await _eloRepository.GetLatestEloAsync(user.Id, cancellationToken) ?? 1000;
+        var nextRank = _rankService.GetNextRank(user.ProfileRank);
+        var hasActiveTutorials = await _tutorialService.HasActiveTutorialsAsync(user.Id, cancellationToken);
+
+        return Result<LoginResult, AppError>.Success(new LoginResult
+        {
+            Token = token,
+            PermissionClaims = permissionClaims,
+            User = new UserInfoResult
+            {
+                Name = user.Name,
+                Id = user.Id,
+                Email = user.Email,
+                Avatar = user.Avatar,
+                ProfileRank = user.ProfileRank,
+                PreferredTimeZone = string.IsNullOrWhiteSpace(user.PreferredTimeZone) ? preferredTimeZone : user.PreferredTimeZone,
+                CreatedAt = user.CreatedAt.UtcDateTime,
+                UpdatedAt = user.UpdatedAt.UtcDateTime,
+                Elo = elo,
+                NextRank = nextRank == null ? null : new RankInfo { Name = nextRank.Name, NeedElo = nextRank.NeedElo },
+                IsDeleted = user.IsDeleted,
+                IsVisibleInRanking = user.IsVisibleInRanking,
+                Roles = roles,
+                PermissionClaims = permissionClaims,
+                HasActiveTutorials = hasActiveTutorials
+            }
+        });
+    }
+}

--- a/LgymApi.Application/Repositories/IUserExternalLoginRepository.cs
+++ b/LgymApi.Application/Repositories/IUserExternalLoginRepository.cs
@@ -7,5 +7,6 @@ public interface IUserExternalLoginRepository
 {
     Task AddAsync(UserExternalLogin externalLogin, CancellationToken cancellationToken = default);
     Task<UserExternalLogin?> FindByProviderAsync(string provider, string providerKey, CancellationToken cancellationToken = default);
+    Task<UserExternalLogin?> FindByUserAndProviderAsync(Id<User> userId, string provider, CancellationToken cancellationToken = default);
     Task<List<UserExternalLogin>> GetByUserIdAsync(Id<User> userId, CancellationToken cancellationToken = default);
 }

--- a/LgymApi.Application/Repositories/IUserExternalLoginRepository.cs
+++ b/LgymApi.Application/Repositories/IUserExternalLoginRepository.cs
@@ -1,0 +1,11 @@
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.Application.Repositories;
+
+public interface IUserExternalLoginRepository
+{
+    Task AddAsync(UserExternalLogin externalLogin, CancellationToken cancellationToken = default);
+    Task<UserExternalLogin?> FindByProviderAsync(string provider, string providerKey, CancellationToken cancellationToken = default);
+    Task<List<UserExternalLogin>> GetByUserIdAsync(Id<User> userId, CancellationToken cancellationToken = default);
+}

--- a/LgymApi.Application/Repositories/IUserRepository.cs
+++ b/LgymApi.Application/Repositories/IUserRepository.cs
@@ -11,6 +11,7 @@ public interface IUserRepository
 {
     Task<User?> FindByIdAsync(Id<User> id, CancellationToken cancellationToken = default);
     Task<User?> FindByIdIncludingDeletedAsync(Id<User> id, CancellationToken cancellationToken = default);
+    Task<User?> FindByIdWithRolesAsync(Id<User> id, CancellationToken cancellationToken = default);
     Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default);
     Task<User?> FindByEmailAsync(Email email, CancellationToken cancellationToken = default);
     Task<User?> FindByNameOrEmailAsync(string name, string email, CancellationToken cancellationToken = default);

--- a/LgymApi.Application/ServiceCollectionExtensions.cs
+++ b/LgymApi.Application/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using LgymApi.Application.Features.Training;
 using LgymApi.Application.Features.TrainerRelationships;
 using LgymApi.Application.Features.User;
 using LgymApi.Application.Features.Tutorial;
+using LgymApi.Application.ExternalAuth;
 using LgymApi.Application.Services;
 using LgymApi.Application.Units;
 using LgymApi.Domain.Enums;
@@ -49,6 +50,10 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPlanDayServiceDependencies, PlanDayServiceDependencies>();
         services.AddScoped<IPlanDayService, PlanDayService>();
         services.AddScoped<IRankService, RankService>();
+        services.AddScoped<IAccountLinkingService, AccountLinkingService>();
+        services.AddScoped<IExternalAuthService, ExternalAuthService>();
+        services.AddScoped<IGoogleUserRegistrar, GoogleUserRegistrar>();
+        services.AddScoped<ILoginResultBuilder, LoginResultBuilder>();
         services.AddScoped<IReportingService, ReportingService>();
         services.AddScoped<IRoleService, RoleService>();
         services.AddScoped<ISupplementationService, SupplementationService>();

--- a/LgymApi.Application/Services/GoogleTokenPayload.cs
+++ b/LgymApi.Application/Services/GoogleTokenPayload.cs
@@ -1,0 +1,3 @@
+namespace LgymApi.Application.Services;
+
+public sealed record GoogleTokenPayload(string Subject, string Email, bool EmailVerified, string? Name, string? Picture);

--- a/LgymApi.Application/Services/IGoogleTokenValidator.cs
+++ b/LgymApi.Application/Services/IGoogleTokenValidator.cs
@@ -1,0 +1,6 @@
+namespace LgymApi.Application.Services;
+
+public interface IGoogleTokenValidator
+{
+    Task<GoogleTokenPayload?> ValidateAsync(string idToken, CancellationToken ct);
+}

--- a/LgymApi.DataSeeder/Program.cs
+++ b/LgymApi.DataSeeder/Program.cs
@@ -108,6 +108,7 @@ public static class Program
         services.AddScoped<IEntitySeeder, UserTutorialProgressSeeder>();
         services.AddScoped<IEntitySeeder, UserTutorialStepProgressSeeder>();
         services.AddScoped<IEntitySeeder, UserSessionSeeder>();
+        services.AddScoped<IEntitySeeder, UserExternalLoginSeeder>();
         services.AddScoped<SeedOrchestrator>();
         return services.BuildServiceProvider();
     }

--- a/LgymApi.DataSeeder/Seeders/UserExternalLoginSeeder.cs
+++ b/LgymApi.DataSeeder/Seeders/UserExternalLoginSeeder.cs
@@ -1,0 +1,14 @@
+using LgymApi.Infrastructure.Data;
+
+namespace LgymApi.DataSeeder.Seeders;
+
+public sealed class UserExternalLoginSeeder : IEntitySeeder
+{
+    public int Order => 111;
+
+    public Task SeedAsync(AppDbContext context, SeedContext seedContext, CancellationToken cancellationToken)
+    {
+        SeedOperationConsole.Skip("user external logins");
+        return Task.CompletedTask;
+    }
+}

--- a/LgymApi.Domain/Entities/User.cs
+++ b/LgymApi.Domain/Entities/User.cs
@@ -28,6 +28,7 @@ public sealed class User : EntityBase<User>
     public ICollection<Measurement> Measurements { get; set; } = new List<Measurement>();
     public ICollection<MainRecord> MainRecords { get; set; } = new List<MainRecord>();
     public ICollection<EloRegistry> EloRegistries { get; set; } = new List<EloRegistry>();
+    public ICollection<UserExternalLogin> ExternalLogins { get; set; } = new List<UserExternalLogin>();
     public ICollection<Gym> Gyms { get; set; } = new List<Gym>();
     public ICollection<UserRole> UserRoles { get; set; } = new List<UserRole>();
 }

--- a/LgymApi.Domain/Entities/UserExternalLogin.cs
+++ b/LgymApi.Domain/Entities/UserExternalLogin.cs
@@ -1,0 +1,13 @@
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.Domain.Entities;
+
+public sealed class UserExternalLogin : EntityBase<UserExternalLogin>
+{
+    public Id<User> UserId { get; set; }
+    public string Provider { get; set; } = string.Empty;
+    public string ProviderKey { get; set; } = string.Empty;
+    public string? ProviderEmail { get; set; }
+
+    public User? User { get; set; }
+}

--- a/LgymApi.Domain/Security/AuthConstants.cs
+++ b/LgymApi.Domain/Security/AuthConstants.cs
@@ -49,4 +49,9 @@ public static class AuthConstants
     {
         public const string JwtSigningKey = "Jwt:SigningKey";
     }
+
+    public static class ExternalProviders
+    {
+        public const string Google = "Google";
+    }
 }

--- a/LgymApi.Infrastructure/Data/AppDbContext.cs
+++ b/LgymApi.Infrastructure/Data/AppDbContext.cs
@@ -54,6 +54,7 @@ public sealed class AppDbContext : DbContext
     public DbSet<PasswordResetToken> PasswordResetTokens => Set<PasswordResetToken>();
     public DbSet<InAppNotification> InAppNotifications => Set<InAppNotification>();
     public DbSet<UserSession> UserSessions => Set<UserSession>();
+    public DbSet<UserExternalLogin> UserExternalLogins => Set<UserExternalLogin>();
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
@@ -590,6 +591,24 @@ public sealed class AppDbContext : DbContext
             entity.HasOne<User>()
                 .WithMany()
                 .HasForeignKey(e => e.UserId);
+        });
+
+        modelBuilder.Entity<UserExternalLogin>(entity =>
+        {
+            entity.ToTable("UserExternalLogins");
+            entity.Property(e => e.Provider).HasMaxLength(50).IsRequired();
+            entity.Property(e => e.ProviderKey).HasMaxLength(255).IsRequired();
+            entity.Property(e => e.ProviderEmail).HasMaxLength(256);
+            entity.HasIndex(e => new { e.Provider, e.ProviderKey })
+                .IsUnique()
+                .HasFilter("\"IsDeleted\" = FALSE");
+            entity.HasIndex(e => new { e.UserId, e.Provider })
+                .IsUnique()
+                .HasFilter("\"IsDeleted\" = FALSE");
+            entity.HasOne(e => e.User)
+                .WithMany(u => u.ExternalLogins)
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         RoleSeedDataConfiguration.Apply(modelBuilder);

--- a/LgymApi.Infrastructure/LgymApi.Infrastructure.csproj
+++ b/LgymApi.Infrastructure/LgymApi.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Gridify" />
+    <PackageReference Include="Google.Apis.Auth" />
     <PackageReference Include="Hangfire.AspNetCore" />
     <PackageReference Include="Hangfire.PostgreSql" />
     <PackageReference Include="MailKit" />

--- a/LgymApi.Infrastructure/Migrations/20260423173321_AddUserExternalLogin.Designer.cs
+++ b/LgymApi.Infrastructure/Migrations/20260423173321_AddUserExternalLogin.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LgymApi.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LgymApi.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260423173321_AddUserExternalLogin")]
+    partial class AddUserExternalLogin
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LgymApi.Infrastructure/Migrations/20260423173321_AddUserExternalLogin.cs
+++ b/LgymApi.Infrastructure/Migrations/20260423173321_AddUserExternalLogin.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LgymApi.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserExternalLogin : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserExternalLogins",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Provider = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    ProviderKey = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    ProviderEmail = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserExternalLogins", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserExternalLogins_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserExternalLogins_Provider_ProviderKey",
+                table: "UserExternalLogins",
+                columns: new[] { "Provider", "ProviderKey" },
+                unique: true,
+                filter: "\"IsDeleted\" = FALSE");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserExternalLogins_UserId_Provider",
+                table: "UserExternalLogins",
+                columns: new[] { "UserId", "Provider" },
+                unique: true,
+                filter: "\"IsDeleted\" = FALSE");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserExternalLogins");
+        }
+    }
+}

--- a/LgymApi.Infrastructure/Repositories/UserExternalLoginRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/UserExternalLoginRepository.cs
@@ -31,6 +31,13 @@ public sealed class UserExternalLoginRepository : IUserExternalLoginRepository
             .FirstOrDefaultAsync(x => x.Provider == provider && x.ProviderKey == providerKey && !x.IsDeleted, cancellationToken);
     }
 
+    public Task<UserExternalLogin?> FindByUserAndProviderAsync(Id<User> userId, string provider, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.UserExternalLogins
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.UserId == userId && x.Provider == provider && !x.IsDeleted, cancellationToken);
+    }
+
     public Task<List<UserExternalLogin>> GetByUserIdAsync(Id<User> userId, CancellationToken cancellationToken = default)
     {
         return _dbContext.UserExternalLogins

--- a/LgymApi.Infrastructure/Repositories/UserExternalLoginRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/UserExternalLoginRepository.cs
@@ -25,9 +25,6 @@ public sealed class UserExternalLoginRepository : IUserExternalLoginRepository
         return _dbContext.UserExternalLogins
             .AsNoTracking()
             .Include(x => x.User)
-            .ThenInclude(u => u.UserRoles)
-            .ThenInclude(ur => ur.Role)
-            .ThenInclude(r => r.RoleClaims)
             .FirstOrDefaultAsync(x => x.Provider == provider && x.ProviderKey == providerKey && !x.IsDeleted, cancellationToken);
     }
 

--- a/LgymApi.Infrastructure/Repositories/UserExternalLoginRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/UserExternalLoginRepository.cs
@@ -1,0 +1,42 @@
+using LgymApi.Application.Repositories;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace LgymApi.Infrastructure.Repositories;
+
+public sealed class UserExternalLoginRepository : IUserExternalLoginRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public UserExternalLoginRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task AddAsync(UserExternalLogin externalLogin, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.UserExternalLogins.AddAsync(externalLogin, cancellationToken).AsTask();
+    }
+
+    public Task<UserExternalLogin?> FindByProviderAsync(string provider, string providerKey, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.UserExternalLogins
+            .AsNoTracking()
+            .Include(x => x.User)
+            .ThenInclude(u => u.UserRoles)
+            .ThenInclude(ur => ur.Role)
+            .ThenInclude(r => r.RoleClaims)
+            .FirstOrDefaultAsync(x => x.Provider == provider && x.ProviderKey == providerKey && !x.IsDeleted, cancellationToken);
+    }
+
+    public Task<List<UserExternalLogin>> GetByUserIdAsync(Id<User> userId, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.UserExternalLogins
+            .AsNoTracking()
+            .Where(x => x.UserId == userId && !x.IsDeleted)
+            .OrderBy(x => x.Provider)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/LgymApi.Infrastructure/Repositories/UserExternalLoginRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/UserExternalLoginRepository.cs
@@ -25,21 +25,21 @@ public sealed class UserExternalLoginRepository : IUserExternalLoginRepository
         return _dbContext.UserExternalLogins
             .AsNoTracking()
             .Include(x => x.User)
-            .FirstOrDefaultAsync(x => x.Provider == provider && x.ProviderKey == providerKey && !x.IsDeleted, cancellationToken);
+            .FirstOrDefaultAsync(x => x.Provider == provider && x.ProviderKey == providerKey, cancellationToken);
     }
 
     public Task<UserExternalLogin?> FindByUserAndProviderAsync(Id<User> userId, string provider, CancellationToken cancellationToken = default)
     {
         return _dbContext.UserExternalLogins
             .AsNoTracking()
-            .FirstOrDefaultAsync(x => x.UserId == userId && x.Provider == provider && !x.IsDeleted, cancellationToken);
+            .FirstOrDefaultAsync(x => x.UserId == userId && x.Provider == provider, cancellationToken);
     }
 
     public Task<List<UserExternalLogin>> GetByUserIdAsync(Id<User> userId, CancellationToken cancellationToken = default)
     {
         return _dbContext.UserExternalLogins
             .AsNoTracking()
-            .Where(x => x.UserId == userId && !x.IsDeleted)
+            .Where(x => x.UserId == userId)
             .OrderBy(x => x.Provider)
             .ToListAsync(cancellationToken);
     }

--- a/LgymApi.Infrastructure/Repositories/UserRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/UserRepository.cs
@@ -41,6 +41,9 @@ public sealed class UserRepository : IUserRepository
     {
         return _dbContext.Users
             .IgnoreQueryFilters()
+            .Include(u => u.UserRoles)
+            .ThenInclude(ur => ur.Role)
+            .ThenInclude(r => r.RoleClaims)
             .FirstOrDefaultAsync(u => u.Id == id, cancellationToken);
     }
 

--- a/LgymApi.Infrastructure/Repositories/UserRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/UserRepository.cs
@@ -41,6 +41,13 @@ public sealed class UserRepository : IUserRepository
     {
         return _dbContext.Users
             .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.Id == id, cancellationToken);
+    }
+
+    public Task<User?> FindByIdWithRolesAsync(Id<User> id, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.Users
+            .IgnoreQueryFilters()
             .Include(u => u.UserRoles)
             .ThenInclude(ur => ur.Role)
             .ThenInclude(r => r.RoleClaims)

--- a/LgymApi.Infrastructure/Repositories/UserRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/UserRepository.cs
@@ -47,7 +47,6 @@ public sealed class UserRepository : IUserRepository
     public Task<User?> FindByIdWithRolesAsync(Id<User> id, CancellationToken cancellationToken = default)
     {
         return _dbContext.Users
-            .IgnoreQueryFilters()
             .Include(u => u.UserRoles)
             .ThenInclude(ur => ur.Role)
             .ThenInclude(r => r.RoleClaims)

--- a/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
+++ b/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
@@ -79,6 +79,7 @@ public static class ServiceCollectionExtensions
         }
 
         services.AddScoped<ITokenService, TokenService>();
+        services.AddScoped<IGoogleTokenValidator, GoogleTokenValidator>();
         services.AddScoped<ILegacyPasswordService, LegacyPasswordService>();
         services.AddScoped<IUserSessionStore, UserSessionStore>();
         services.AddScoped<IEmailTemplateComposer, TrainerInvitationEmailTemplateComposer>();
@@ -98,6 +99,7 @@ public static class ServiceCollectionExtensions
                 : sp.GetRequiredService<SmtpEmailSender>();
         });
         services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IUserExternalLoginRepository, UserExternalLoginRepository>();
         services.AddScoped<IPasswordResetTokenRepository, PasswordResetTokenRepository>();
         services.AddScoped<IRoleRepository, RoleRepository>();
         services.AddScoped<ITrainerRelationshipRepository, TrainerRelationshipRepository>();

--- a/LgymApi.Infrastructure/Services/GoogleTokenValidator.cs
+++ b/LgymApi.Infrastructure/Services/GoogleTokenValidator.cs
@@ -1,0 +1,52 @@
+using Google.Apis.Auth;
+using LgymApi.Application.Services;
+using Microsoft.Extensions.Configuration;
+
+namespace LgymApi.Infrastructure.Services;
+
+public sealed class GoogleTokenValidator : IGoogleTokenValidator
+{
+    private readonly IConfiguration _configuration;
+
+    public GoogleTokenValidator(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public async Task<GoogleTokenPayload?> ValidateAsync(string idToken, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var clientId = _configuration["GoogleAuth:ClientId"];
+        if (string.IsNullOrWhiteSpace(clientId))
+        {
+            return null;
+        }
+
+        try
+        {
+            var payload = await GoogleJsonWebSignature.ValidateAsync(
+                idToken,
+                new GoogleJsonWebSignature.ValidationSettings
+                {
+                    Audience = [clientId]
+                });
+
+            if (string.IsNullOrWhiteSpace(payload.Subject) || string.IsNullOrWhiteSpace(payload.Email))
+            {
+                return null;
+            }
+
+            return new GoogleTokenPayload(
+                payload.Subject,
+                payload.Email,
+                payload.EmailVerified,
+                payload.Name,
+                payload.Picture);
+        }
+        catch (InvalidJwtException)
+        {
+            return null;
+        }
+    }
+}

--- a/LgymApi.Infrastructure/Services/GoogleTokenValidator.cs
+++ b/LgymApi.Infrastructure/Services/GoogleTokenValidator.cs
@@ -20,7 +20,7 @@ public sealed class GoogleTokenValidator : IGoogleTokenValidator
         var clientId = _configuration["GoogleAuth:ClientId"];
         if (string.IsNullOrWhiteSpace(clientId))
         {
-            return null;
+            throw new InvalidOperationException("GoogleAuth:ClientId configuration is missing.");
         }
 
         try

--- a/LgymApi.IntegrationTests/GoogleAuthTests.cs
+++ b/LgymApi.IntegrationTests/GoogleAuthTests.cs
@@ -7,7 +7,6 @@ using LgymApi.Domain.Security;
 using LgymApi.Domain.ValueObjects;
 using LgymApi.Infrastructure.Data;
 using LgymApi.TestUtils;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/LgymApi.IntegrationTests/GoogleAuthTests.cs
+++ b/LgymApi.IntegrationTests/GoogleAuthTests.cs
@@ -1,0 +1,365 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.IO;
+using FluentAssertions;
+using LgymApi.Application.Services;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.Security;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.Infrastructure.Data;
+using LgymApi.TestUtils;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute;
+
+namespace LgymApi.IntegrationTests;
+
+[TestFixture]
+public sealed class GoogleAuthTests : IntegrationTestBase
+{
+    private IGoogleTokenValidator _googleTokenValidator = null!;
+    private CustomWebApplicationFactory _baseFactory = null!;
+    private HttpClient _client = null!;
+    private Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program> _factory = null!;
+
+    [SetUp]
+    public void SetUpGoogleAuthHost()
+    {
+        _googleTokenValidator = Substitute.For<IGoogleTokenValidator>();
+
+        _baseFactory = new CustomWebApplicationFactory();
+        _factory = _baseFactory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IGoogleTokenValidator>();
+                services.AddSingleton(_googleTokenValidator);
+            });
+        });
+
+        _client = _factory.CreateClient();
+    }
+
+    [TearDown]
+    public void TearDownGoogleAuthHost()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        _baseFactory.Dispose();
+    }
+
+    [Test]
+    public async Task POST_AuthGoogle_ValidToken_NewUser_Returns200_AndCreatesUser()
+    {
+        const string email = "google-new@example.com";
+        const string subject = "google-sub-new";
+
+        _googleTokenValidator.ValidateAsync("valid-token", Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload(subject, email, true, "Google New", null));
+
+        var response = await _client.PostAsJsonAsync("/api/auth/google", new { idToken = "valid-token" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<LoginResponseDto>();
+        body.Should().NotBeNull();
+        body!.Token.Should().NotBeNullOrWhiteSpace();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var user = await db.Users.FirstOrDefaultAsync(x => x.Email.Value == email);
+        user.Should().NotBeNull();
+
+        var externalLogin = await db.UserExternalLogins.FirstOrDefaultAsync(x => x.UserId == user!.Id && x.Provider == AuthConstants.ExternalProviders.Google);
+        externalLogin.Should().NotBeNull();
+        externalLogin!.ProviderEmail.Should().Be(email);
+    }
+
+    [Test]
+    public async Task POST_AuthGoogle_ValidToken_ExistingLinkedUser_Returns200()
+    {
+        const string email = "google-linked@example.com";
+        const string subject = "google-sub-linked";
+
+        var user = await SeedUserAsync(name: "linkeduser", email: email);
+        await SeedGoogleExternalLoginAsync(user.Id, subject, email);
+
+        _googleTokenValidator.ValidateAsync("valid-token", Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload(subject, email, true, "Google Linked", null));
+
+        var response = await _client.PostAsJsonAsync("/api/auth/google", new { idToken = "valid-token" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<LoginResponseDto>();
+        body.Should().NotBeNull();
+        body!.Token.Should().NotBeNullOrWhiteSpace();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        (await db.Users.CountAsync(x => x.Email.Value == email)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task POST_AuthGoogle_EmailCollision_NoLink_Returns409()
+    {
+        const string email = "collision@example.com";
+
+        await SeedUserAsync(name: "localuser", email: email);
+
+        _googleTokenValidator.ValidateAsync("valid-token", Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload("google-sub-collision", email, true, "Google Collision", null));
+
+        var response = await _client.PostAsJsonAsync("/api/auth/google", new { idToken = "valid-token" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Test]
+    public async Task POST_AuthGoogle_InvalidToken_Returns401()
+    {
+        _googleTokenValidator.ValidateAsync("invalid-token", Arg.Any<CancellationToken>())
+            .Returns((GoogleTokenPayload?)null);
+
+        var response = await _client.PostAsJsonAsync("/api/auth/google", new { idToken = "invalid-token" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task POST_AuthGoogle_UnverifiedEmail_Returns401()
+    {
+        _googleTokenValidator.ValidateAsync("valid-token", Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload("google-sub-unverified", "unverified@example.com", false, "Google Unverified", null));
+
+        var response = await _client.PostAsJsonAsync("/api/auth/google", new { idToken = "valid-token" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task POST_AuthGoogle_MissingIdToken_Returns400()
+    {
+        var response = await _client.PostAsJsonAsync("/api/auth/google", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task POST_LinkGoogle_Authenticated_Success_Returns200()
+    {
+        const string email = "link-success@example.com";
+        const string subject = "google-sub-link-success";
+
+        var user = await SeedUserAsync(name: "linkuser", email: email);
+        SetAuthorizationHeader(user.Id);
+
+        _googleTokenValidator.ValidateAsync("valid-token", Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload(subject, email, true, "Google Link", null));
+
+        var response = await _client.PostAsJsonAsync("/api/account/link-google", new { idToken = "valid-token" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var externalLogin = await db.UserExternalLogins.FirstOrDefaultAsync(x => x.UserId == user.Id && x.Provider == AuthConstants.ExternalProviders.Google);
+        externalLogin.Should().NotBeNull();
+        externalLogin!.ProviderEmail.Should().Be(email);
+    }
+
+    [Test]
+    public async Task POST_LinkGoogle_Unauthenticated_Returns401()
+    {
+        _googleTokenValidator.ValidateAsync("valid-token", Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload("google-sub-unauth", "unauth@example.com", true, "Google Unauth", null));
+
+        var response = await _client.PostAsJsonAsync("/api/account/link-google", new { idToken = "valid-token" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task POST_LinkGoogle_AlreadyLinkedGoogleAccount_Returns409()
+    {
+        const string email = "linked-other@example.com";
+        const string subject = "google-sub-conflict";
+
+        var otherUser = await SeedUserAsync(name: "otheruser", email: email);
+        await SeedGoogleExternalLoginAsync(otherUser.Id, subject, email);
+
+        var currentUser = await SeedUserAsync(name: "currentuser", email: "current@example.com");
+        SetAuthorizationHeader(currentUser.Id);
+
+        _googleTokenValidator.ValidateAsync("valid-token", Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload(subject, "current@example.com", true, "Google Conflict", null));
+
+        var response = await _client.PostAsJsonAsync("/api/account/link-google", new { idToken = "valid-token" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Test]
+    public async Task GET_ExternalLogins_Authenticated_ReturnsProviders()
+    {
+        const string email = "external-list@example.com";
+
+        var user = await SeedUserAsync(name: "listuser", email: email);
+        await SeedGoogleExternalLoginAsync(user.Id, "google-sub-list", email);
+        SetAuthorizationHeader(user.Id);
+
+        var response = await _client.GetAsync("/api/account/external-logins");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<List<ExternalLoginDto>>();
+        body.Should().NotBeNull();
+        body.Should().ContainSingle();
+        body![0].Provider.Should().Be(AuthConstants.ExternalProviders.Google);
+        body[0].ProviderEmail.Should().Be(email);
+    }
+
+    [Test]
+    public async Task GET_ExternalLogins_Unauthenticated_Returns401()
+    {
+        var response = await _client.GetAsync("/api/account/external-logins");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task SeedGoogleExternalLoginAsync(Id<User> userId, string subject, string email)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        db.UserExternalLogins.Add(new UserExternalLogin
+        {
+            Id = Id<UserExternalLogin>.New(),
+            UserId = userId,
+            Provider = AuthConstants.ExternalProviders.Google,
+            ProviderKey = subject,
+            ProviderEmail = email,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            IsDeleted = false
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    private new async Task<User> SeedUserAsync(
+        string name = "testuser",
+        string email = "test@example.com",
+        string password = "password123",
+        bool isAdmin = false,
+        bool isVisibleInRanking = true,
+        bool isTester = false,
+        bool isDeleted = false,
+        int elo = 1000)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var user = await TestDataFactory.SeedUserAsync(
+            db,
+            name,
+            email,
+            password,
+            isAdmin,
+            isVisibleInRanking,
+            isTester,
+            isDeleted,
+            elo);
+        await db.SaveChangesAsync();
+        return user;
+    }
+
+    private new void SetAuthorizationHeader(Id<User> userId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var sessionId = Id<UserSession>.New();
+        var jti = Id<UserSession>.New().ToString();
+        db.UserSessions.Add(new UserSession
+        {
+            Id = sessionId,
+            UserId = userId,
+            Jti = jti,
+            ExpiresAtUtc = DateTimeOffset.UtcNow.AddDays(1),
+            RevokedAtUtc = null
+        });
+        db.SaveChanges();
+
+        var token = GenerateJwt(userId, sessionId, jti);
+        _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+    }
+
+    private new string GenerateJwt(Id<User> userId, Id<UserSession> sessionId, string jti)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var roles = db.UserRoles
+            .Where(ur => ur.UserId == userId)
+            .Select(ur => ur.Role.Name)
+            .Distinct()
+            .ToList();
+
+        var permissionClaims = db.UserRoles
+            .Where(ur => ur.UserId == userId)
+            .SelectMany(ur => ur.Role.RoleClaims)
+            .Where(rc => rc.ClaimType == AuthConstants.PermissionClaimType)
+            .Select(rc => rc.ClaimValue)
+            .Distinct()
+            .ToList();
+
+        var key = new Microsoft.IdentityModel.Tokens.SymmetricSecurityKey(System.Text.Encoding.UTF8.GetBytes(CustomWebApplicationFactory.TestJwtSigningKey));
+        var credentials = new Microsoft.IdentityModel.Tokens.SigningCredentials(key, Microsoft.IdentityModel.Tokens.SecurityAlgorithms.HmacSha256);
+
+        var claims = new List<System.Security.Claims.Claim>
+        {
+            new(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub, userId.ToString()),
+            new("userId", userId.ToString()),
+            new("sid", sessionId.ToString()),
+            new(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Jti, jti)
+        };
+
+        foreach (var role in roles)
+        {
+            claims.Add(new System.Security.Claims.Claim(System.Security.Claims.ClaimTypes.Role, role));
+        }
+
+        foreach (var permission in permissionClaims)
+        {
+            claims.Add(new System.Security.Claims.Claim(AuthConstants.PermissionClaimType, permission));
+        }
+
+        var token = new System.IdentityModel.Tokens.Jwt.JwtSecurityToken(
+            claims: claims,
+            expires: DateTime.UtcNow.AddDays(1),
+            signingCredentials: credentials);
+
+        return new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private sealed class LoginResponseDto
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("token")]
+        public string Token { get; set; } = string.Empty;
+    }
+
+    private sealed class ExternalLoginDto
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("provider")]
+        public string Provider { get; set; } = string.Empty;
+
+        [System.Text.Json.Serialization.JsonPropertyName("providerEmail")]
+        public string? ProviderEmail { get; set; }
+    }
+
+}

--- a/LgymApi.IntegrationTests/GoogleAuthTests.cs
+++ b/LgymApi.IntegrationTests/GoogleAuthTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.IO;
 using FluentAssertions;
 using LgymApi.Application.Services;
 using LgymApi.Domain.Entities;

--- a/LgymApi.Resources/Resources/Messages.resx
+++ b/LgymApi.Resources/Resources/Messages.resx
@@ -36,6 +36,12 @@
   <data name="InvalidToken" xml:space="preserve">
     <value>Invalid JWT token.</value>
   </data>
+  <data name="GoogleAccountAlreadyLinked" xml:space="preserve">
+    <value>This Google account is already linked to another user.</value>
+  </data>
+  <data name="GoogleIdTokenRequired" xml:space="preserve">
+    <value>Google ID token is required.</value>
+  </data>
   <data name="ExpiredToken" xml:space="preserve">
     <value>Token has expired.</value>
   </data>
@@ -257,6 +263,15 @@
   </data>
   <data name="AccountBlocked" xml:space="preserve">
     <value>Your account has been blocked.</value>
+  </data>
+  <data name="GoogleTokenInvalid" xml:space="preserve">
+    <value>Google sign-in token is invalid.</value>
+  </data>
+  <data name="GoogleEmailNotVerified" xml:space="preserve">
+    <value>Your Google account email address is not verified.</value>
+  </data>
+  <data name="GoogleEmailConflict" xml:space="preserve">
+    <value>An account with this email already exists. Sign in with your password and link Google manually.</value>
   </data>
   <data name="CannotBlockSelf" xml:space="preserve">
     <value>You cannot block yourself.</value>

--- a/LgymApi.Resources/Resources/Messages.resx
+++ b/LgymApi.Resources/Resources/Messages.resx
@@ -37,7 +37,7 @@
     <value>Invalid JWT token.</value>
   </data>
   <data name="GoogleAccountAlreadyLinked" xml:space="preserve">
-    <value>This Google account is already linked to another user.</value>
+    <value>This Google account is already linked.</value>
   </data>
   <data name="GoogleIdTokenRequired" xml:space="preserve">
     <value>Google ID token is required.</value>

--- a/LgymApi.Resources/Resources/Messages.resx
+++ b/LgymApi.Resources/Resources/Messages.resx
@@ -273,6 +273,9 @@
   <data name="GoogleEmailConflict" xml:space="preserve">
     <value>An account with this email already exists. Sign in with your password and link Google manually.</value>
   </data>
+  <data name="UserLoadFailed" xml:space="preserve">
+    <value>Failed to load the created user.</value>
+  </data>
   <data name="CannotBlockSelf" xml:space="preserve">
     <value>You cannot block yourself.</value>
   </data>

--- a/LgymApi.UnitTests/AppConfigServiceTests.cs
+++ b/LgymApi.UnitTests/AppConfigServiceTests.cs
@@ -371,6 +371,7 @@ public sealed class AppConfigServiceTests
     {
         public Task<User?> FindByIdAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByIdIncludingDeletedAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<User?> FindByIdWithRolesAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByEmailAsync(Email email, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameOrEmailAsync(string name, string email, CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -444,6 +445,7 @@ public sealed class AppConfigServiceTests
         }
 
         public Task<User?> FindByIdIncludingDeletedAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<User?> FindByIdWithRolesAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByEmailAsync(Email email, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameOrEmailAsync(string name, string email, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/LgymApi.UnitTests/EloRegistryServiceTests.cs
+++ b/LgymApi.UnitTests/EloRegistryServiceTests.cs
@@ -31,6 +31,7 @@ public sealed class EloRegistryServiceTests
     {
         public Task<User?> FindByIdAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByIdIncludingDeletedAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<User?> FindByIdWithRolesAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByEmailAsync(Email email, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameOrEmailAsync(string name, string email, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/LgymApi.UnitTests/ExerciseScoresServiceTests.cs
+++ b/LgymApi.UnitTests/ExerciseScoresServiceTests.cs
@@ -46,6 +46,7 @@ public sealed class ExerciseScoresServiceTests
     {
         public Task<User?> FindByIdAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByIdIncludingDeletedAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<User?> FindByIdWithRolesAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByEmailAsync(Email email, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameOrEmailAsync(string name, string email, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/LgymApi.UnitTests/ExerciseServiceTests.cs
+++ b/LgymApi.UnitTests/ExerciseServiceTests.cs
@@ -184,6 +184,7 @@ public sealed class ExerciseServiceTests
     {
         public Task<User?> FindByIdAsync(Id<LgymApi.Domain.Entities.User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByIdIncludingDeletedAsync(Id<LgymApi.Domain.Entities.User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<User?> FindByIdWithRolesAsync(Id<LgymApi.Domain.Entities.User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByEmailAsync(Email email, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameOrEmailAsync(string name, string email, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/LgymApi.UnitTests/ExternalAuth/AccountLinkingServiceTests.cs
+++ b/LgymApi.UnitTests/ExternalAuth/AccountLinkingServiceTests.cs
@@ -6,6 +6,7 @@ using LgymApi.Application.Services;
 using LgymApi.Domain.Entities;
 using LgymApi.Domain.Security;
 using LgymApi.Domain.ValueObjects;
+using LgymApi.Resources;
 using LgymApi.TestUtils;
 using LgymApi.TestUtils.Fakes;
 using NSubstitute;
@@ -46,6 +47,7 @@ public sealed class AccountLinkingServiceTests
 
         result.IsFailure.Should().BeTrue();
         result.Error.Should().BeOfType<InvalidUserError>();
+        result.Error!.Message.Should().Be(Messages.GoogleTokenInvalid);
         _unitOfWork.SaveChangesCalls.Should().Be(0);
     }
 
@@ -59,6 +61,37 @@ public sealed class AccountLinkingServiceTests
 
         result.IsFailure.Should().BeTrue();
         result.Error.Should().BeOfType<InvalidUserError>();
+        result.Error!.Message.Should().Be(Messages.GoogleEmailNotVerified);
+        _unitOfWork.SaveChangesCalls.Should().Be(0);
+    }
+
+    [Test]
+    public async Task LinkGoogle_AlreadyLinkedForCurrentUser_ReturnsConflict()
+    {
+        var user = CreateUser();
+        var existingLogin = new UserExternalLogin
+        {
+            Id = Id<UserExternalLogin>.New(),
+            UserId = user.Id,
+            Provider = AuthConstants.ExternalProviders.Google,
+            ProviderKey = "sub-existing",
+            ProviderEmail = "test@example.com"
+        };
+
+        _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload("sub123", "test@example.com", true, "Test User", null));
+        _userRepository.FindByIdAsync(user.Id, Arg.Any<CancellationToken>())
+            .Returns(user);
+        _userExternalLoginRepository.FindByUserAndProviderAsync(user.Id, AuthConstants.ExternalProviders.Google, Arg.Any<CancellationToken>())
+            .Returns(existingLogin);
+
+        var result = await _service.LinkGoogleAsync(user.Id, "token", CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<ConflictError>();
+        result.Error!.Message.Should().Be(Messages.GoogleAccountAlreadyLinked);
+        await _userExternalLoginRepository.DidNotReceiveWithAnyArgs().FindByProviderAsync(default!, default!, default);
+        await _userExternalLoginRepository.DidNotReceiveWithAnyArgs().AddAsync(default!, default);
         _unitOfWork.SaveChangesCalls.Should().Be(0);
     }
 
@@ -80,6 +113,8 @@ public sealed class AccountLinkingServiceTests
             .Returns(new GoogleTokenPayload("sub123", "test@example.com", true, "Test User", null));
         _userRepository.FindByIdAsync(Arg.Any<Id<User>>(), Arg.Any<CancellationToken>())
             .Returns(user);
+        _userExternalLoginRepository.FindByUserAndProviderAsync(user.Id, AuthConstants.ExternalProviders.Google, Arg.Any<CancellationToken>())
+            .Returns((UserExternalLogin?)null);
         _userExternalLoginRepository.FindByProviderAsync(AuthConstants.ExternalProviders.Google, "sub123", Arg.Any<CancellationToken>())
             .Returns(existingLogin);
 
@@ -101,6 +136,8 @@ public sealed class AccountLinkingServiceTests
             .Returns(payload);
         _userRepository.FindByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
+        _userExternalLoginRepository.FindByUserAndProviderAsync(user.Id, AuthConstants.ExternalProviders.Google, Arg.Any<CancellationToken>())
+            .Returns((UserExternalLogin?)null);
         _userExternalLoginRepository.FindByProviderAsync(AuthConstants.ExternalProviders.Google, payload.Subject, Arg.Any<CancellationToken>())
             .Returns((UserExternalLogin?)null);
 

--- a/LgymApi.UnitTests/ExternalAuth/AccountLinkingServiceTests.cs
+++ b/LgymApi.UnitTests/ExternalAuth/AccountLinkingServiceTests.cs
@@ -38,7 +38,7 @@ public sealed class AccountLinkingServiceTests
     }
 
     [Test]
-    public async Task LinkGoogle_InvalidToken_ReturnsUnauthorized()
+    public async Task LinkGoogle_InvalidToken_ReturnsInvalidUserError()
     {
         _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<GoogleTokenPayload?>(null));
@@ -52,7 +52,7 @@ public sealed class AccountLinkingServiceTests
     }
 
     [Test]
-    public async Task LinkGoogle_UnverifiedEmail_ReturnsUnauthorized()
+    public async Task LinkGoogle_UnverifiedEmail_ReturnsInvalidUserError()
     {
         _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new GoogleTokenPayload("sub123", "test@example.com", false, "Test User", null));

--- a/LgymApi.UnitTests/ExternalAuth/AccountLinkingServiceTests.cs
+++ b/LgymApi.UnitTests/ExternalAuth/AccountLinkingServiceTests.cs
@@ -99,14 +99,15 @@ public sealed class AccountLinkingServiceTests
     public async Task LinkGoogle_AlreadyLinkedToAnotherUser_ReturnsConflict()
     {
         var user = CreateUser();
+        var anotherUser = CreateUser();
         var existingLogin = new UserExternalLogin
         {
             Id = Id<UserExternalLogin>.New(),
-            UserId = user.Id,
+            UserId = anotherUser.Id,
             Provider = AuthConstants.ExternalProviders.Google,
             ProviderKey = "sub123",
             ProviderEmail = "linked@example.com",
-            User = user
+            User = anotherUser
         };
 
         _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())

--- a/LgymApi.UnitTests/ExternalAuth/AccountLinkingServiceTests.cs
+++ b/LgymApi.UnitTests/ExternalAuth/AccountLinkingServiceTests.cs
@@ -1,0 +1,172 @@
+using FluentAssertions;
+using LgymApi.Application.Common.Errors;
+using LgymApi.Application.ExternalAuth;
+using LgymApi.Application.Repositories;
+using LgymApi.Application.Services;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.Security;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.TestUtils;
+using LgymApi.TestUtils.Fakes;
+using NSubstitute;
+
+namespace LgymApi.UnitTests;
+
+[TestFixture]
+public sealed class AccountLinkingServiceTests
+{
+    private IGoogleTokenValidator _googleTokenValidator = null!;
+    private IUserRepository _userRepository = null!;
+    private IUserExternalLoginRepository _userExternalLoginRepository = null!;
+    private FakeUnitOfWork _unitOfWork = null!;
+    private AccountLinkingService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _googleTokenValidator = Substitute.For<IGoogleTokenValidator>();
+        _userRepository = Substitute.For<IUserRepository>();
+        _userExternalLoginRepository = Substitute.For<IUserExternalLoginRepository>();
+        _unitOfWork = new FakeUnitOfWork();
+
+        _service = new AccountLinkingService(
+            _googleTokenValidator,
+            _userRepository,
+            _userExternalLoginRepository,
+            _unitOfWork);
+    }
+
+    [Test]
+    public async Task LinkGoogle_InvalidToken_ReturnsUnauthorized()
+    {
+        _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<GoogleTokenPayload?>(null));
+
+        var result = await _service.LinkGoogleAsync(Id<User>.New(), "token", CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<InvalidUserError>();
+        _unitOfWork.SaveChangesCalls.Should().Be(0);
+    }
+
+    [Test]
+    public async Task LinkGoogle_UnverifiedEmail_ReturnsUnauthorized()
+    {
+        _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload("sub123", "test@example.com", false, "Test User", null));
+
+        var result = await _service.LinkGoogleAsync(Id<User>.New(), "token", CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<InvalidUserError>();
+        _unitOfWork.SaveChangesCalls.Should().Be(0);
+    }
+
+    [Test]
+    public async Task LinkGoogle_AlreadyLinkedToAnotherUser_ReturnsConflict()
+    {
+        var user = CreateUser();
+        var existingLogin = new UserExternalLogin
+        {
+            Id = Id<UserExternalLogin>.New(),
+            UserId = user.Id,
+            Provider = AuthConstants.ExternalProviders.Google,
+            ProviderKey = "sub123",
+            ProviderEmail = "linked@example.com",
+            User = user
+        };
+
+        _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload("sub123", "test@example.com", true, "Test User", null));
+        _userRepository.FindByIdAsync(Arg.Any<Id<User>>(), Arg.Any<CancellationToken>())
+            .Returns(user);
+        _userExternalLoginRepository.FindByProviderAsync(AuthConstants.ExternalProviders.Google, "sub123", Arg.Any<CancellationToken>())
+            .Returns(existingLogin);
+
+        var result = await _service.LinkGoogleAsync(user.Id, "token", CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<ConflictError>();
+        await _userExternalLoginRepository.DidNotReceiveWithAnyArgs().AddAsync(default!, default);
+        _unitOfWork.SaveChangesCalls.Should().Be(0);
+    }
+
+    [Test]
+    public async Task LinkGoogle_Success_AddsExternalLoginAndSaves()
+    {
+        var user = CreateUser();
+        GoogleTokenPayload? payload = new GoogleTokenPayload("sub123", "test@example.com", true, "Test User", null);
+
+        _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(payload);
+        _userRepository.FindByIdAsync(user.Id, Arg.Any<CancellationToken>())
+            .Returns(user);
+        _userExternalLoginRepository.FindByProviderAsync(AuthConstants.ExternalProviders.Google, payload.Subject, Arg.Any<CancellationToken>())
+            .Returns((UserExternalLogin?)null);
+
+        var result = await _service.LinkGoogleAsync(user.Id, "token", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        await _userExternalLoginRepository.Received(1).AddAsync(
+            Arg.Is<UserExternalLogin>(x =>
+                x.UserId == user.Id &&
+                x.Provider == AuthConstants.ExternalProviders.Google &&
+                x.ProviderKey == payload.Subject &&
+                x.ProviderEmail == payload.Email),
+            Arg.Any<CancellationToken>());
+        _unitOfWork.SaveChangesCalls.Should().Be(1);
+    }
+
+    [Test]
+    public async Task GetExternalLogins_ReturnsAllForUser()
+    {
+        var user = CreateUser();
+        var logins = new List<UserExternalLogin>
+        {
+            new()
+            {
+                Id = Id<UserExternalLogin>.New(),
+                UserId = user.Id,
+                Provider = "facebook",
+                ProviderEmail = "fb@example.com",
+                ProviderKey = "fb-1"
+            },
+            new()
+            {
+                Id = Id<UserExternalLogin>.New(),
+                UserId = user.Id,
+                Provider = AuthConstants.ExternalProviders.Google,
+                ProviderEmail = "google@example.com",
+                ProviderKey = "google-1"
+            }
+        };
+
+        _userRepository.FindByIdAsync(user.Id, Arg.Any<CancellationToken>())
+            .Returns(user);
+        _userExternalLoginRepository.GetByUserIdAsync(user.Id, Arg.Any<CancellationToken>())
+            .Returns(logins);
+
+        var result = await _service.GetExternalLoginsAsync(user.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+        result.Value[0].Should().BeEquivalentTo(new ExternalLoginInfo(AuthConstants.ExternalProviders.Google, "google@example.com"));
+        result.Value[1].Should().BeEquivalentTo(new ExternalLoginInfo("facebook", "fb@example.com"));
+    }
+
+    private static User CreateUser()
+    {
+        return new User
+        {
+            Id = Id<User>.New(),
+            Name = "Test User",
+            Email = new Email("test@example.com"),
+            ProfileRank = "Rookie",
+            PreferredTimeZone = "UTC",
+            IsDeleted = false,
+            IsBlocked = false,
+            LegacyHash = string.Empty,
+            LegacySalt = string.Empty
+        };
+    }
+}

--- a/LgymApi.UnitTests/ExternalAuth/ExternalAuthServiceTests.cs
+++ b/LgymApi.UnitTests/ExternalAuth/ExternalAuthServiceTests.cs
@@ -1,0 +1,205 @@
+using FluentAssertions;
+using LgymApi.Application.Common.Errors;
+using LgymApi.Application.Common.Results;
+using LgymApi.Application.ExternalAuth;
+using LgymApi.Application.Features.User.Models;
+using LgymApi.Application.Repositories;
+using LgymApi.Application.Services;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.Security;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.TestUtils.Fakes;
+using NSubstitute;
+
+namespace LgymApi.UnitTests;
+
+[TestFixture]
+public sealed class ExternalAuthServiceTests
+{
+    private IGoogleTokenValidator _googleTokenValidator = null!;
+    private IUserExternalLoginRepository _userExternalLoginRepository = null!;
+    private IGoogleUserRegistrar _googleUserRegistrar = null!;
+    private ILoginResultBuilder _loginResultBuilder = null!;
+    private FakeUnitOfWork _unitOfWork = null!;
+    private ExternalAuthService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _googleTokenValidator = Substitute.For<IGoogleTokenValidator>();
+        _userExternalLoginRepository = Substitute.For<IUserExternalLoginRepository>();
+        _googleUserRegistrar = Substitute.For<IGoogleUserRegistrar>();
+        _loginResultBuilder = Substitute.For<ILoginResultBuilder>();
+        _unitOfWork = new FakeUnitOfWork();
+
+        _service = new ExternalAuthService(
+            _googleTokenValidator,
+            _userExternalLoginRepository,
+            _googleUserRegistrar,
+            _loginResultBuilder,
+            _unitOfWork);
+    }
+
+    [Test]
+    public async Task GoogleSignIn_InvalidToken_ReturnsUnauthorized()
+    {
+        _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<GoogleTokenPayload?>(null));
+
+        var result = await _service.GoogleSignInAsync("invalid-token", CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<UserUnauthorizedError>();
+        _unitOfWork.SaveChangesCalls.Should().Be(0);
+    }
+
+    [Test]
+    public async Task GoogleSignIn_UnverifiedEmail_ReturnsUnauthorized()
+    {
+        _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload("sub123", "test@example.com", false, "Test User", null));
+
+        var result = await _service.GoogleSignInAsync("token", CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<UserUnauthorizedError>();
+        _userExternalLoginRepository.DidNotReceiveWithAnyArgs().FindByProviderAsync(default!, default!, default);
+        _unitOfWork.SaveChangesCalls.Should().Be(0);
+    }
+
+    [Test]
+    public async Task GoogleSignIn_ExistingLink_ReturnsLoginResult()
+    {
+        var existingUser = CreateUser(preferredTimeZone: "Europe/Warsaw");
+        var externalLogin = new UserExternalLogin
+        {
+            Id = Id<UserExternalLogin>.New(),
+            UserId = existingUser.Id,
+            Provider = AuthConstants.ExternalProviders.Google,
+            ProviderKey = "sub123",
+            ProviderEmail = "test@example.com",
+            User = existingUser
+        };
+
+        _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload("sub123", "test@example.com", true, "Test User", null));
+        _userExternalLoginRepository.FindByProviderAsync(AuthConstants.ExternalProviders.Google, "sub123", Arg.Any<CancellationToken>())
+            .Returns(externalLogin);
+        _loginResultBuilder.BuildAsync(existingUser, existingUser.PreferredTimeZone, Arg.Any<CancellationToken>())
+            .Returns(Result.Success<LoginResult, AppError>(CreateLoginResult()));
+
+        var result = await _service.GoogleSignInAsync("token", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Token.Should().Be("jwt-token");
+        _unitOfWork.SaveChangesCalls.Should().Be(1);
+    }
+
+    [Test]
+    public async Task GoogleSignIn_ExistingLink_BlockedUser_ReturnsError()
+    {
+        var blockedUser = CreateUser();
+        blockedUser.IsBlocked = true;
+        var externalLogin = new UserExternalLogin
+        {
+            Id = Id<UserExternalLogin>.New(),
+            UserId = blockedUser.Id,
+            Provider = AuthConstants.ExternalProviders.Google,
+            ProviderKey = "sub123",
+            ProviderEmail = "test@example.com",
+            User = blockedUser
+        };
+
+        _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload("sub123", "test@example.com", true, "Test User", null));
+        _userExternalLoginRepository.FindByProviderAsync(AuthConstants.ExternalProviders.Google, "sub123", Arg.Any<CancellationToken>())
+            .Returns(externalLogin);
+
+        var result = await _service.GoogleSignInAsync("token", CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<ForbiddenError>();
+        _loginResultBuilder.DidNotReceiveWithAnyArgs().BuildAsync(default!, default!, default);
+        _unitOfWork.SaveChangesCalls.Should().Be(0);
+    }
+
+    [Test]
+    public async Task GoogleSignIn_NewUser_NoConflict_CreatesAndReturnsLoginResult()
+    {
+        var createdUser = CreateUser(preferredTimeZone: "UTC");
+
+        _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload("sub123", "test@example.com", true, "Test User", null));
+        _userExternalLoginRepository.FindByProviderAsync(AuthConstants.ExternalProviders.Google, "sub123", Arg.Any<CancellationToken>())
+            .Returns((UserExternalLogin?)null);
+        _googleUserRegistrar.RegisterAsync(Arg.Any<GoogleTokenPayload>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success<User, AppError>(createdUser));
+        _loginResultBuilder.BuildAsync(createdUser, createdUser.PreferredTimeZone, Arg.Any<CancellationToken>())
+            .Returns(Result.Success<LoginResult, AppError>(CreateLoginResult()));
+
+        var result = await _service.GoogleSignInAsync("token", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Token.Should().Be("jwt-token");
+        _unitOfWork.SaveChangesCalls.Should().Be(1);
+    }
+
+    [Test]
+    public async Task GoogleSignIn_EmailCollision_NoLink_ReturnsConflict()
+    {
+        _googleTokenValidator.ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GoogleTokenPayload("sub123", "test@example.com", true, "Test User", null));
+        _userExternalLoginRepository.FindByProviderAsync(AuthConstants.ExternalProviders.Google, "sub123", Arg.Any<CancellationToken>())
+            .Returns((UserExternalLogin?)null);
+        _googleUserRegistrar.RegisterAsync(Arg.Any<GoogleTokenPayload>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Failure<User, AppError>(new ConflictError("email conflict")));
+
+        var result = await _service.GoogleSignInAsync("token", CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<ConflictError>();
+        _loginResultBuilder.DidNotReceiveWithAnyArgs().BuildAsync(default!, default!, default);
+        _unitOfWork.SaveChangesCalls.Should().Be(0);
+    }
+
+    private static User CreateUser(string preferredTimeZone = "UTC")
+    {
+        return new User
+        {
+            Id = Id<User>.New(),
+            Name = "Test User",
+            Email = new Email("test@example.com"),
+            ProfileRank = "Rookie",
+            PreferredTimeZone = preferredTimeZone,
+            IsDeleted = false,
+            IsBlocked = false,
+            LegacyHash = string.Empty,
+            LegacySalt = string.Empty
+        };
+    }
+
+    private static LoginResult CreateLoginResult()
+    {
+        return new LoginResult
+        {
+            Token = "jwt-token",
+            User = new UserInfoResult
+            {
+                Id = Id<User>.New(),
+                Name = "Test User",
+                Email = "test@example.com",
+                ProfileRank = "Rookie",
+                PreferredTimeZone = "UTC",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                Elo = 1000,
+                IsDeleted = false,
+                IsVisibleInRanking = true,
+                Roles = new List<string>(),
+                PermissionClaims = new List<string>(),
+                HasActiveTutorials = false
+            },
+            PermissionClaims = new List<string>()
+        };
+    }
+}

--- a/LgymApi.UnitTests/ExternalAuth/ExternalAuthServiceTests.cs
+++ b/LgymApi.UnitTests/ExternalAuth/ExternalAuthServiceTests.cs
@@ -63,7 +63,7 @@ public sealed class ExternalAuthServiceTests
 
         result.IsFailure.Should().BeTrue();
         result.Error.Should().BeOfType<UserUnauthorizedError>();
-        _userExternalLoginRepository.DidNotReceiveWithAnyArgs().FindByProviderAsync(default!, default!, default);
+        await _userExternalLoginRepository.DidNotReceiveWithAnyArgs().FindByProviderAsync(default!, default!, default);
         _unitOfWork.SaveChangesCalls.Should().Be(0);
     }
 
@@ -119,7 +119,7 @@ public sealed class ExternalAuthServiceTests
 
         result.IsFailure.Should().BeTrue();
         result.Error.Should().BeOfType<ForbiddenError>();
-        _loginResultBuilder.DidNotReceiveWithAnyArgs().BuildAsync(default!, default!, default);
+        await _loginResultBuilder.DidNotReceiveWithAnyArgs().BuildAsync(default!, default!, default);
         _unitOfWork.SaveChangesCalls.Should().Be(0);
     }
 
@@ -158,7 +158,7 @@ public sealed class ExternalAuthServiceTests
 
         result.IsFailure.Should().BeTrue();
         result.Error.Should().BeOfType<ConflictError>();
-        _loginResultBuilder.DidNotReceiveWithAnyArgs().BuildAsync(default!, default!, default);
+        await _loginResultBuilder.DidNotReceiveWithAnyArgs().BuildAsync(default!, default!, default);
         _unitOfWork.SaveChangesCalls.Should().Be(0);
     }
 

--- a/LgymApi.UnitTests/MainRecordsServiceTests.cs
+++ b/LgymApi.UnitTests/MainRecordsServiceTests.cs
@@ -104,6 +104,7 @@ public sealed class MainRecordsServiceTests
     {
         public Task<User?> FindByIdAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByIdIncludingDeletedAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<User?> FindByIdWithRolesAsync(Id<User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByEmailAsync(Email email, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameOrEmailAsync(string name, string email, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/LgymApi.UnitTests/PasswordResetServiceTests.cs
+++ b/LgymApi.UnitTests/PasswordResetServiceTests.cs
@@ -357,6 +357,9 @@ public sealed class PasswordResetServiceTests
         public Task<User?> FindByIdIncludingDeletedAsync(Id<User> id, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
+        public Task<User?> FindByIdWithRolesAsync(Id<User> id, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
         public Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 

--- a/LgymApi.UnitTests/RoleServiceTests.cs
+++ b/LgymApi.UnitTests/RoleServiceTests.cs
@@ -218,6 +218,9 @@ public sealed class RoleServiceTests
          public Task<User?> FindByIdIncludingDeletedAsync(Id<LgymApi.Domain.Entities.User> id, CancellationToken cancellationToken = default)
              => Task.FromResult(Users.FirstOrDefault(u => u.Id == id));
 
+         public Task<User?> FindByIdWithRolesAsync(Id<LgymApi.Domain.Entities.User> id, CancellationToken cancellationToken = default)
+             => Task.FromResult(Users.FirstOrDefault(u => u.Id == id));
+
         public Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default)
             => Task.FromResult(Users.FirstOrDefault(u => u.Name == name));
 

--- a/LgymApi.UnitTests/SendInvitationEmailHandlerTests.cs
+++ b/LgymApi.UnitTests/SendInvitationEmailHandlerTests.cs
@@ -665,6 +665,7 @@ public sealed class SendInvitationEmailHandlerTests
         }
 
         public Task<User?> FindByIdIncludingDeletedAsync(Id<LgymApi.Domain.Entities.User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<User?> FindByIdWithRolesAsync(Id<LgymApi.Domain.Entities.User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByEmailAsync(Email email, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameOrEmailAsync(string name, string email, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/LgymApi.UnitTests/SendRegistrationEmailHandlerTests.cs
+++ b/LgymApi.UnitTests/SendRegistrationEmailHandlerTests.cs
@@ -333,6 +333,7 @@ public sealed class SendRegistrationEmailHandlerTests
         }
 
         public Task<User?> FindByIdIncludingDeletedAsync(Id<LgymApi.Domain.Entities.User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<User?> FindByIdWithRolesAsync(Id<LgymApi.Domain.Entities.User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByEmailAsync(Email email, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameOrEmailAsync(string name, string email, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/LgymApi.UnitTests/ServiceTransactionBehaviorTests.cs
+++ b/LgymApi.UnitTests/ServiceTransactionBehaviorTests.cs
@@ -454,6 +454,7 @@ public sealed class ServiceTransactionBehaviorTests
 
         public Task<User?> FindByIdAsync(Id<LgymApi.Domain.Entities.User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByIdIncludingDeletedAsync(Id<LgymApi.Domain.Entities.User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<User?> FindByIdWithRolesAsync(Id<LgymApi.Domain.Entities.User> id, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByEmailAsync(Email email, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<User?> FindByNameOrEmailAsync(string name, string email, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/LgymApi.UnitTests/UserContextMiddlewareBlockedTests.cs
+++ b/LgymApi.UnitTests/UserContextMiddlewareBlockedTests.cs
@@ -98,6 +98,8 @@ public sealed class UserContextMiddlewareBlockedTests
             => Task.FromResult(Users.FirstOrDefault(u => u.Id == id && !u.IsDeleted));
         public Task<User?> FindByIdIncludingDeletedAsync(Id<User> id, CancellationToken cancellationToken = default)
             => Task.FromResult(Users.FirstOrDefault(u => u.Id == id));
+        public Task<User?> FindByIdWithRolesAsync(Id<User> id, CancellationToken cancellationToken = default)
+            => Task.FromResult(Users.FirstOrDefault(u => u.Id == id));
         public Task<User?> FindByNameAsync(string name, CancellationToken cancellationToken = default)
             => Task.FromResult(Users.FirstOrDefault(u => u.Name == name));
         public Task<User?> FindByEmailAsync(Email email, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

- Adds Google OAuth sign-in flow: validates Google ID token, auto-registers new users, and returns a JWT
- Adds Google account linking for existing users via POST /api/account/link-google
- Introduces UserExternalLogin entity, EF migration, repository, and full service layer with unit + integration tests

## Changes

### Domain
- UserExternalLogin entity and ExternalProviders constant

### Infrastructure
- GoogleTokenValidator service (validates Google ID tokens via Google API)
- EF migration AddUserExternalLogin
- UserExternalLoginRepository

### Application
- ExternalAuthService - Google sign-in with auto-registration
- AccountLinkingService - links Google account to existing user
- GoogleUserRegistrar, LoginResultBuilder - supporting services

### API
- POST /api/auth/google-sign-in - sign in / register via Google
- POST /api/account/link-google - link Google account (requires auth)
- FluentValidation validators for both endpoints

### Tests
- Unit tests: ExternalAuthServiceTests, AccountLinkingServiceTests
- Integration tests: GoogleAuthTests

## Related Issue
Closes #302