### PR TITLE
Add Docker image build with external database config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+LGYM_API_IMAGE=lgym-api:local
+LGYM_API_PORT=18080
+ASPNETCORE_ENVIRONMENT=Development
+LGYM_CONFIG_FILE=./appsettings.container.example.json
+
+# For a PostgreSQL server running on the Docker host machine, use host.docker.internal.
+# Change Port/Database/Username/Password to match your local non-Docker database.
+LGYM_POSTGRES_CONNECTION_STRING=Host=host.docker.internal;Port=5432;Database=LGYM-APP;Username=postgres;Password=YOUR_PASSWORD_HERE;TimeZone=Europe/Warsaw
+
+# Must be at least 32 characters because the API validates the JWT signing key length.
+LGYM_JWT_SIGNING_KEY=CHANGE_ME_TO_AT_LEAST_32_CHARACTERS_LONG

--- a/.github/workflows/api-image.yml
+++ b/.github/workflows/api-image.yml
@@ -2,15 +2,9 @@ name: API Image
 
 on:
   workflow_dispatch:
-    inputs:
-      image_tag:
-        description: "Docker image tag to publish"
-        required: false
-        default: latest
-        type: string
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: api-image-${{ github.workflow }}-${{ github.ref }}
@@ -26,13 +20,37 @@ jobs:
       DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME || vars.DOCKERHUB_NAMESPACE }}
       DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
       DOCKERHUB_IMAGE_NAME: ${{ vars.DOCKERHUB_IMAGE_NAME || 'lgym-api' }}
-      IMAGE_TAG: ${{ inputs.image_tag || 'latest' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Validate publish ref
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: test "$GITHUB_REF_NAME" = "$DEFAULT_BRANCH"
+
+      - name: Determine next image version
+        id: version
+        run: |
+          latest_tag=$(git tag --list 'v*.*.*' --sort=-version:refname | head -n1)
+
+          if [ -z "$latest_tag" ]; then
+            next_tag='v0.1.0'
+          else
+            version=${latest_tag#v}
+            IFS=. read -r major minor patch <<< "$version"
+            next_tag="v${major}.${minor}.$((patch + 1))"
+          fi
+
+          echo "image_tag=$next_tag" >> "$GITHUB_OUTPUT"
 
       - name: Validate Docker Hub variables
+        env:
+          IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
         run: |
           test -n "$DOCKERHUB_USERNAME"
           test -n "$DOCKERHUB_NAMESPACE"
@@ -55,7 +73,8 @@ jobs:
         with:
           images: docker.io/${{ env.DOCKERHUB_NAMESPACE }}/${{ env.DOCKERHUB_IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=${{ steps.version.outputs.image_tag }}
+            type=raw,value=latest
             type=sha,format=short,prefix=sha-
 
       - name: Build and push API image
@@ -67,11 +86,23 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Create release tag
+        env:
+          IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag "$IMAGE_TAG"
+          git push origin "$IMAGE_TAG"
+
       - name: Publish workflow summary
         env:
+          IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
           IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           echo '## API image publish' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo "Version bump: $IMAGE_TAG" >> "$GITHUB_STEP_SUMMARY"
           echo '' >> "$GITHUB_STEP_SUMMARY"
           echo 'Published Docker Hub image references:' >> "$GITHUB_STEP_SUMMARY"
           echo "$IMAGE_TAGS" | tr ',' '\n' | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/api-image.yml
+++ b/.github/workflows/api-image.yml
@@ -1,18 +1,12 @@
 name: API Image
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches: [main]
-    tags:
-      - "v*.*.*"
   workflow_dispatch:
     inputs:
       image_tag:
-        description: "Optional extra Docker image tag to publish"
+        description: "Docker image tag to publish"
         required: false
+        default: latest
         type: string
 
 permissions:
@@ -26,64 +20,24 @@ env:
   DOCKERFILE: Dockerfile
 
 jobs:
-  pr-build:
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Generate image metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: lgym-api
-          tags: |
-            type=sha,format=short,prefix=sha-
-
-      - name: Build API image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ env.DOCKERFILE }}
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Publish workflow summary
-        env:
-          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
-        run: |
-          echo '## API image build (pull request)' >> "$GITHUB_STEP_SUMMARY"
-          echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo 'Build completed with `push: false` using root `Dockerfile`.' >> "$GITHUB_STEP_SUMMARY"
-          echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo 'Build-validated image references:' >> "$GITHUB_STEP_SUMMARY"
-          echo "$IMAGE_TAGS" | tr ',' '\n' | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
-
   publish:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME || vars.DOCKERHUB_NAMESPACE }}
       DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
       DOCKERHUB_IMAGE_NAME: ${{ vars.DOCKERHUB_IMAGE_NAME || 'lgym-api' }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      IMAGE_TAG: ${{ inputs.image_tag || 'latest' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate Docker Hub configuration
+      - name: Validate Docker Hub variables
         run: |
-          test -n "$DOCKERHUB_USERNAME" || { echo 'Missing GitHub variable DOCKERHUB_USERNAME or DOCKERHUB_NAMESPACE.'; exit 1; }
-          test -n "$DOCKERHUB_NAMESPACE" || { echo 'Missing GitHub variable DOCKERHUB_NAMESPACE.'; exit 1; }
-          test -n "$DOCKERHUB_IMAGE_NAME" || { echo 'Missing GitHub variable DOCKERHUB_IMAGE_NAME.'; exit 1; }
-          test -n "$DOCKERHUB_TOKEN" || { echo 'Missing GitHub secret DOCKERHUB_TOKEN.'; exit 1; }
+          test -n "$DOCKERHUB_USERNAME"
+          test -n "$DOCKERHUB_NAMESPACE"
+          test -n "$DOCKERHUB_IMAGE_NAME"
+          test -n "$IMAGE_TAG"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -101,11 +55,8 @@ jobs:
         with:
           images: docker.io/${{ env.DOCKERHUB_NAMESPACE }}/${{ env.DOCKERHUB_IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=ref,event=branch
-            type=ref,event=tag
+            type=raw,value=${{ env.IMAGE_TAG }}
             type=sha,format=short,prefix=sha-
-            type=raw,value=${{ inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.image_tag != '' }}
 
       - name: Build and push API image
         uses: docker/build-push-action@v6

--- a/.github/workflows/api-image.yml
+++ b/.github/workflows/api-image.yml
@@ -6,17 +6,24 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Optional extra Docker image tag to publish"
+        required: false
+        type: string
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: api-image-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/lgym-api
+  DOCKERFILE: Dockerfile
 
 jobs:
   pr-build:
@@ -34,7 +41,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: lgym-api
           tags: |
             type=sha,format=short,prefix=sha-
 
@@ -42,7 +49,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: LgymApi.Api/Dockerfile
+          file: ${{ env.DOCKERFILE }}
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -53,43 +60,58 @@ jobs:
         run: |
           echo '## API image build (pull request)' >> "$GITHUB_STEP_SUMMARY"
           echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo 'Build completed with `push: false` using `LgymApi.Api/Dockerfile`.' >> "$GITHUB_STEP_SUMMARY"
+          echo 'Build completed with `push: false` using root `Dockerfile`.' >> "$GITHUB_STEP_SUMMARY"
           echo '' >> "$GITHUB_STEP_SUMMARY"
           echo 'Build-validated image references:' >> "$GITHUB_STEP_SUMMARY"
           echo "$IMAGE_TAGS" | tr ',' '\n' | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
 
-  publish-main:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  publish:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME || vars.DOCKERHUB_NAMESPACE }}
+      DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
+      DOCKERHUB_IMAGE_NAME: ${{ vars.DOCKERHUB_IMAGE_NAME || 'lgym-api' }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate Docker Hub configuration
+        run: |
+          test -n "$DOCKERHUB_USERNAME" || { echo 'Missing GitHub variable DOCKERHUB_USERNAME or DOCKERHUB_NAMESPACE.'; exit 1; }
+          test -n "$DOCKERHUB_NAMESPACE" || { echo 'Missing GitHub variable DOCKERHUB_NAMESPACE.'; exit 1; }
+          test -n "$DOCKERHUB_IMAGE_NAME" || { echo 'Missing GitHub variable DOCKERHUB_IMAGE_NAME.'; exit 1; }
+          test -n "$DOCKERHUB_TOKEN" || { echo 'Missing GitHub secret DOCKERHUB_TOKEN.'; exit 1; }
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
+      - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.io
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Generate image metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: docker.io/${{ env.DOCKERHUB_NAMESPACE }}/${{ env.DOCKERHUB_IMAGE_NAME }}
           tags: |
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch
+            type=ref,event=tag
             type=sha,format=short,prefix=sha-
+            type=raw,value=${{ inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.image_tag != '' }}
 
       - name: Build and push API image
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: LgymApi.Api/Dockerfile
+          file: ${{ env.DOCKERFILE }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -98,7 +120,7 @@ jobs:
         env:
           IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          echo '## API image publish (main)' >> "$GITHUB_STEP_SUMMARY"
+          echo '## API image publish' >> "$GITHUB_STEP_SUMMARY"
           echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo 'Published image references:' >> "$GITHUB_STEP_SUMMARY"
+          echo 'Published Docker Hub image references:' >> "$GITHUB_STEP_SUMMARY"
           echo "$IMAGE_TAGS" | tr ',' '\n' | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -116,12 +116,14 @@ appsettings.Production.json
 appsettings.Local.json
 appsettings.*.json
 !appsettings.json
+!appsettings.container.example.json
 
 # .env files
 .env
 .env.local
 .env.development
 .env.production
+!.env.example
 
 # OS files
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1
+
+ARG DOTNET_VERSION=10.0
+
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
+WORKDIR /src
+
+COPY Directory.Build.props Directory.Packages.props ./
+COPY LgymApi.Api/*.csproj LgymApi.Api/
+COPY LgymApi.Application/*.csproj LgymApi.Application/
+COPY LgymApi.BackgroundWorker/*.csproj LgymApi.BackgroundWorker/
+COPY LgymApi.BackgroundWorker.Common/*.csproj LgymApi.BackgroundWorker.Common/
+COPY LgymApi.Domain/*.csproj LgymApi.Domain/
+COPY LgymApi.Infrastructure/*.csproj LgymApi.Infrastructure/
+COPY LgymApi.Resources/*.csproj LgymApi.Resources/
+COPY LgymApi.Resources.Generator/*.csproj LgymApi.Resources.Generator/
+
+RUN dotnet restore "LgymApi.Api/LgymApi.Api.csproj"
+
+COPY . .
+
+RUN dotnet publish "LgymApi.Api/LgymApi.Api.csproj" \
+    --configuration Release \
+    --no-restore \
+    --output /app/publish \
+    /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION} AS runtime
+WORKDIR /app
+
+ENV ASPNETCORE_URLS=http://+:8080 \
+    ASPNETCORE_HTTP_PORTS=8080 \
+    DOTNET_EnableDiagnostics=0
+
+RUN addgroup --system --gid 10001 lgym \
+    && adduser --system --uid 10001 --ingroup lgym --home /app --no-create-home lgym \
+    && mkdir -p /run/config \
+    && chown -R lgym:lgym /app /run/config
+
+COPY --from=build --chown=lgym:lgym /app/publish/ ./
+
+USER lgym
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "LgymApi.Api.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,11 @@ ENV ASPNETCORE_URLS=http://+:8080 \
     ASPNETCORE_HTTP_PORTS=8080 \
     DOTNET_EnableDiagnostics=0
 
-RUN addgroup --system --gid 10001 lgym \
-    && adduser --system --uid 10001 --ingroup lgym --home /app --no-create-home lgym \
-    && mkdir -p /run/config \
-    && chown -R lgym:lgym /app /run/config
+RUN mkdir -p /run/config
 
-COPY --from=build --chown=lgym:lgym /app/publish/ ./
+COPY --from=build /app/publish/ ./
 
-USER lgym
+USER $APP_UID
 EXPOSE 8080
 
 ENTRYPOINT ["dotnet", "LgymApi.Api.dll"]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,37 @@ Avoid launch profile assumptions when testing the image.
 docker build -t lgym-api:test .
 ```
 
+### Publish the image from GitHub Actions
+
+The `.github/workflows/api-image.yml` workflow builds the image on pull requests and publishes it to Docker Hub on:
+
+- push to `main`
+- push of tags matching `v*.*.*`
+- manual `workflow_dispatch`
+
+Configure these GitHub repository variables:
+
+- `DOCKERHUB_NAMESPACE` - Docker Hub namespace, usually your username or organization
+- `DOCKERHUB_IMAGE_NAME` - image name, for example `lgym-api`; optional because the workflow defaults to `lgym-api`
+- `DOCKERHUB_USERNAME` - Docker Hub login username; optional if it is the same as `DOCKERHUB_NAMESPACE`
+
+Configure this GitHub repository secret:
+
+- `DOCKERHUB_TOKEN` - Docker Hub access token or password used by the workflow login step
+
+Published tags include:
+
+- `latest` for `main`
+- branch/tag refs from GitHub metadata
+- `sha-<short-sha>` for traceability
+- optional custom tag from manual workflow input `image_tag`
+
+Example image reference:
+
+```bash
+docker pull docker.io/<DOCKERHUB_NAMESPACE>/<DOCKERHUB_IMAGE_NAME>:latest
+```
+
 ### Local development with an external PostgreSQL database
 
 For a local PostgreSQL instance that is not running in Docker, copy the example environment file and update the database password/port/name:

--- a/README.md
+++ b/README.md
@@ -60,11 +60,9 @@ docker build -t lgym-api:test .
 
 ### Publish the image from GitHub Actions
 
-The `.github/workflows/api-image.yml` workflow builds the image on pull requests and publishes it to Docker Hub on:
-
-- push to `main`
-- push of tags matching `v*.*.*`
-- manual `workflow_dispatch`
+The `.github/workflows/api-image.yml` workflow publishes the image only through manual `workflow_dispatch` from the repository default branch.
+Each successful run automatically bumps the next patch semver image version based on existing Git tags matching `v*.*.*`.
+If no matching tag exists yet, the first published version is `v0.1.0`.
 
 Configure these GitHub repository variables:
 
@@ -78,10 +76,11 @@ Configure this GitHub repository secret:
 
 Published tags include:
 
-- `latest` for `main`
-- branch/tag refs from GitHub metadata
+- the auto-generated semver tag, for example `v1.2.4`
+- `latest`
 - `sha-<short-sha>` for traceability
-- optional custom tag from manual workflow input `image_tag`
+
+After publishing the image, the workflow also creates and pushes the matching Git tag so the next run can derive the next version deterministically.
 
 Example image reference:
 

--- a/README.md
+++ b/README.md
@@ -47,22 +47,53 @@ Do not bake secrets or site-specific values into the image.
 - Publish the API on container port `8080` and map that port to a host port
 - Set `ConnectionStrings__Postgres` from the runtime environment
 - Set `Jwt__SigningKey` only if the mounted config does not already provide it
+- Keep PostgreSQL outside this image; for a database running on the Docker host, use `host.docker.internal` from inside the container
 
 The process runs from `/app` inside the container, so the mounted config and any relative paths must assume `/app` as the content root.
 Avoid launch profile assumptions when testing the image.
 
-### Local development
+### Build the image
+
+```bash
+docker build -t lgym-api:test .
+```
+
+### Local development with an external PostgreSQL database
+
+For a local PostgreSQL instance that is not running in Docker, copy the example environment file and update the database password/port/name:
+
+```bash
+cp .env.example .env
+# edit .env
+```
+
+Then start only the API container:
+
+```bash
+docker compose -f docker-compose.external-db.yml up --build -d
+```
+
+The compose file does not start PostgreSQL. It connects the API container to the host machine through `host.docker.internal`, with a Linux-compatible `host-gateway` mapping.
+
+Smoke check:
+
+```bash
+curl --fail http://localhost:18080/health/live
+```
+
+### Manual local run
 
 Use the same image for local runs and point it at an external config file:
 
 ```bash
 docker run -d --rm --name lgym-api-dev \
   -p 18080:8080 \
+  --add-host=host.docker.internal:host-gateway \
   -e ASPNETCORE_ENVIRONMENT=Development \
   -e LGYM_APP_CONFIG_PATH=/run/config/appsettings.container.json \
-  -e ConnectionStrings__Postgres='Host=host.docker.internal;Port=5433;Database=LGYM-APP;Username=postgres;Password=REPLACE_ME;TimeZone=Europe/Warsaw' \
+  -e ConnectionStrings__Postgres='Host=host.docker.internal;Port=5432;Database=LGYM-APP;Username=postgres;Password=REPLACE_ME;TimeZone=Europe/Warsaw' \
   -e Jwt__SigningKey='REPLACE_ME_MIN_32_CHARS' \
-  -v "$(pwd)/appsettings.container.json:/run/config/appsettings.container.json:ro" \
+  -v "$(pwd)/appsettings.container.example.json:/run/config/appsettings.container.json:ro" \
   lgym-api:test
 ```
 

--- a/appsettings.container.example.json
+++ b/appsettings.container.example.json
@@ -1,0 +1,16 @@
+{
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173"
+    ]
+  },
+  "GoogleAuth": {
+    "ClientId": "YOUR_GOOGLE_CLIENT_ID_HERE"
+  },
+  "Email": {
+    "Enabled": false
+  }
+}

--- a/docker-compose.external-db.yml
+++ b/docker-compose.external-db.yml
@@ -1,0 +1,20 @@
+name: lgym-api
+
+services:
+  api:
+    image: ${LGYM_API_IMAGE:-lgym-api:local}
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "${LGYM_API_PORT:-18080}:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Development}
+      LGYM_APP_CONFIG_PATH: /run/config/appsettings.container.json
+      ConnectionStrings__Postgres: ${LGYM_POSTGRES_CONNECTION_STRING:?Set LGYM_POSTGRES_CONNECTION_STRING in .env or your shell}
+      Jwt__SigningKey: ${LGYM_JWT_SIGNING_KEY:?Set LGYM_JWT_SIGNING_KEY in .env or your shell}
+    volumes:
+      - ${LGYM_CONFIG_FILE:-./appsettings.container.example.json}:/run/config/appsettings.container.json:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped

--- a/docker-compose.external-db.yml
+++ b/docker-compose.external-db.yml
@@ -2,19 +2,19 @@ name: lgym-api
 
 services:
   api:
-    image: ${LGYM_API_IMAGE:-lgym-api:local}
+    image: "${LGYM_API_IMAGE:-lgym-api:local}"
     build:
       context: .
       dockerfile: Dockerfile
     ports:
       - "${LGYM_API_PORT:-18080}:8080"
     environment:
-      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Development}
-      LGYM_APP_CONFIG_PATH: /run/config/appsettings.container.json
-      ConnectionStrings__Postgres: ${LGYM_POSTGRES_CONNECTION_STRING:?Set LGYM_POSTGRES_CONNECTION_STRING in .env or your shell}
-      Jwt__SigningKey: ${LGYM_JWT_SIGNING_KEY:?Set LGYM_JWT_SIGNING_KEY in .env or your shell}
+      ASPNETCORE_ENVIRONMENT: "${ASPNETCORE_ENVIRONMENT:-Development}"
+      LGYM_APP_CONFIG_PATH: "/run/config/appsettings.container.json"
+      ConnectionStrings__Postgres: "${LGYM_POSTGRES_CONNECTION_STRING:?Set LGYM_POSTGRES_CONNECTION_STRING in .env or your shell}"
+      Jwt__SigningKey: "${LGYM_JWT_SIGNING_KEY:?Set LGYM_JWT_SIGNING_KEY in .env or your shell}"
     volumes:
-      - ${LGYM_CONFIG_FILE:-./appsettings.container.example.json}:/run/config/appsettings.container.json:ro
+      - "${LGYM_CONFIG_FILE:-./appsettings.container.example.json}:/run/config/appsettings.container.json:ro"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add a multi-stage Dockerfile for the .NET 10 API image.
- Add Docker Compose config that runs only the API and connects to an external PostgreSQL service via `host.docker.internal`.
- Add example runtime config and `.env.example` values for a local non-Docker database.
- Update README with build/run instructions and allow the tracked example config files in `.gitignore`.

## Notes
- The image does not include PostgreSQL and does not bake secrets into the image.
- Runtime config is still mounted at `/run/config/appsettings.container.json` through `LGYM_APP_CONFIG_PATH`.

## Testing
- Not run locally; changes are configuration/documentation only and were reviewed by diff.