### PR TITLE
Fix EF translation for typed ID ordering

### DIFF
--- a/LgymApi.Domain/ValueObjects/Id.cs
+++ b/LgymApi.Domain/ValueObjects/Id.cs
@@ -1,6 +1,6 @@
 namespace LgymApi.Domain.ValueObjects;
 
-public readonly record struct Id<TEntity>
+public readonly record struct Id<TEntity> : IComparable<Id<TEntity>>, IComparable
 {
     public Guid Value { get; }
 
@@ -32,6 +32,23 @@ public readonly record struct Id<TEntity>
     public Guid GetValue() => Value;
 
     public int CompareByValue(Id<TEntity> other) => Value.CompareTo(other.Value);
+
+    public int CompareTo(Id<TEntity> other) => CompareByValue(other);
+
+    public int CompareTo(object? obj)
+    {
+        if (obj is null)
+        {
+            return 1;
+        }
+
+        if (obj is Id<TEntity> other)
+        {
+            return CompareTo(other);
+        }
+
+        throw new ArgumentException($"Object must be of type {typeof(Id<TEntity>)}.", nameof(obj));
+    }
 
     public Id<TScope> Rebind<TScope>() => new(Value);
 

--- a/LgymApi.Infrastructure/Repositories/PlanDayExerciseRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/PlanDayExerciseRepository.cs
@@ -21,9 +21,9 @@ public sealed class PlanDayExerciseRepository : IPlanDayExerciseRepository
         return _dbContext.PlanDayExercises
             .AsNoTracking()
             .Where(e => planDayIds.Contains(e.PlanDayId))
-            .OrderBy(e => e.PlanDayId.GetValue())
+            .OrderBy(e => e.PlanDayId)
             .ThenBy(e => e.Order)
-            .ThenBy(e => e.Id.GetValue())
+            .ThenBy(e => e.Id)
             .ToListAsync(cancellationToken);
     }
 
@@ -33,7 +33,7 @@ public sealed class PlanDayExerciseRepository : IPlanDayExerciseRepository
             .AsNoTracking()
             .Where(e => e.PlanDayId == planDayId)
             .OrderBy(e => e.Order)
-            .ThenBy(e => e.Id.GetValue())
+            .ThenBy(e => e.Id)
             .ToListAsync(cancellationToken);
     }
 
@@ -71,9 +71,9 @@ public sealed class PlanDayExerciseRepository : IPlanDayExerciseRepository
 
         var orderedExercises = await _dbContext.PlanDayExercises
             .Where(e => affectedPlanDayIds.Contains(e.PlanDayId))
-            .OrderBy(e => e.PlanDayId.GetValue())
+            .OrderBy(e => e.PlanDayId)
             .ThenBy(e => e.Order)
-            .ThenBy(e => e.Id.GetValue())
+            .ThenBy(e => e.Id)
             .ToListAsync(cancellationToken);
 
         Id<PlanDay>? currentPlanDayId = null;

--- a/LgymApi.Infrastructure/Repositories/TrainingExerciseScoreRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/TrainingExerciseScoreRepository.cs
@@ -15,19 +15,19 @@ public sealed class TrainingExerciseScoreRepository : ITrainingExerciseScoreRepo
         _dbContext = dbContext;
     }
 
-    public Task AddRangeAsync(IEnumerable<TrainingExerciseScore> scores, CancellationToken cancellationToken = default)
+    public Task AddRangeAsync(IEnumerable<TrainingExerciseScore> items, CancellationToken cancellationToken = default)
     {
-        return _dbContext.TrainingExerciseScores.AddRangeAsync(scores, cancellationToken);
+        return _dbContext.TrainingExerciseScores.AddRangeAsync(items, cancellationToken);
     }
 
     public Task<List<TrainingExerciseScore>> GetByTrainingIdsAsync(List<Id<Training>> trainingIds, CancellationToken cancellationToken = default)
     {
         return _dbContext.TrainingExerciseScores
             .AsNoTracking()
-            .Where(t => trainingIds.Contains(t.TrainingId))
-            .OrderBy(t => t.TrainingId.GetValue())
-            .ThenBy(t => t.Order)
-            .ThenBy(t => t.Id.GetValue())
+            .Where(item => trainingIds.Contains(item.TrainingId))
+            .OrderBy(item => item.TrainingId)
+            .ThenBy(item => item.Order)
+            .ThenBy(item => item.Id)
             .ToListAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- fixes EF Core translation failure caused by calling `Id<T>.GetValue()` inside LINQ-to-Entities ordering
- orders by mapped typed-ID properties directly, letting EF translate them through the registered value converters
- makes `Id<T>` comparable so typed-ID ordering also has a deterministic comparer outside relational SQL translation

## Root cause
The merged `Value -> GetValue()` change introduced expressions like:

```csharp
.ThenBy(e => e.Id.GetValue())
```

EF Core cannot translate that custom method call to SQL, which matches the production exception from `PlanDayService.GetPlanDayAsync` through `PlanDayExerciseRepository.GetByPlanDayIdAsync`.

## Testing
Not run locally in this environment; the container cannot reach GitHub to clone/restore the solution. The change is intentionally narrow and targets the exact LINQ expressions from the exception.