### PR TITLE
[codex] Add Postgres CI health checks

### DIFF
--- a/.github/workflows/pr-and-main-tests.yml
+++ b/.github/workflows/pr-and-main-tests.yml
@@ -20,6 +20,21 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: LGYM-APP
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: REPLACE_ME
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d LGYM-APP"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What changed\n- Added a Postgres service container to the PR/main test workflow.\n- Configured GitHub Actions health checks so the job waits for DB readiness before running tests.\n- Pinned the service port to 5433 to match the repository's existing Postgres connection string defaults.\n\n## Why\n- Issue #211 asks for Postgres-backed integration checks in CI with an early failure when the database is unavailable.\n\n## Validation\n- Reviewed the workflow diff locally.\n- Ran git diff --check.