### PR TITLE
[codex] Add DbBacked category for integration tests

### DIFF
--- a/LgymApi.IntegrationTests/AppConfigAdminTests.cs
+++ b/LgymApi.IntegrationTests/AppConfigAdminTests.cs
@@ -8,6 +8,7 @@ using LgymApi.Domain.ValueObjects;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class AppConfigAdminTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/AppConfigTests.cs
+++ b/LgymApi.IntegrationTests/AppConfigTests.cs
@@ -7,6 +7,7 @@ using LgymApi.Domain.ValueObjects;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class AppConfigTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/ExerciseScoresTests.cs
+++ b/LgymApi.IntegrationTests/ExerciseScoresTests.cs
@@ -6,6 +6,7 @@ using LgymApi.Domain.Enums;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class ExerciseScoresTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/ExerciseTests.cs
+++ b/LgymApi.IntegrationTests/ExerciseTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class ExerciseTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/GymTests.cs
+++ b/LgymApi.IntegrationTests/GymTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class GymTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/InAppNotifications/InAppNotificationApiTests.cs
+++ b/LgymApi.IntegrationTests/InAppNotifications/InAppNotificationApiTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace LgymApi.IntegrationTests.InAppNotifications;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class InAppNotificationApiTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/InAppNotifications/NotificationHubConnectionTests.cs
+++ b/LgymApi.IntegrationTests/InAppNotifications/NotificationHubConnectionTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 
 namespace LgymApi.IntegrationTests.InAppNotifications;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class NotificationHubConnectionTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/LgymApi.IntegrationTests.md
+++ b/LgymApi.IntegrationTests/LgymApi.IntegrationTests.md
@@ -4,3 +4,5 @@
 - Contains: `WebApplicationFactory`, middleware/auth/serialization/localization coverage, and test persistence.
 - Rules: reuse integration helpers and validate legacy contract compatibility for changed endpoints.
 - Boundary: keep these tests at the API boundary, not unit-test scope.
+- DB-backed selection: tests that must run against PostgreSQL are marked with `Category(TestCategories.DbBacked)`.
+- Local filter: use `dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --filter TestCategory=DbBacked` to run the DB-backed subset.

--- a/LgymApi.IntegrationTests/MainRecordsTests.cs
+++ b/LgymApi.IntegrationTests/MainRecordsTests.cs
@@ -8,6 +8,7 @@ using LgymApi.Domain.ValueObjects;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class MainRecordsTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/MeasurementsTests.cs
+++ b/LgymApi.IntegrationTests/MeasurementsTests.cs
@@ -8,6 +8,7 @@ using UserEntity = LgymApi.Domain.Entities.User;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class MeasurementsTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/PasswordRecoveryTests.cs
+++ b/LgymApi.IntegrationTests/PasswordRecoveryTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class PasswordRecoveryTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/PlanDayTests.cs
+++ b/LgymApi.IntegrationTests/PlanDayTests.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class PlanDayTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/PlanTests.cs
+++ b/LgymApi.IntegrationTests/PlanTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class PlanTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/ReliabilityReplayTests.cs
+++ b/LgymApi.IntegrationTests/ReliabilityReplayTests.cs
@@ -14,6 +14,7 @@ namespace LgymApi.IntegrationTests;
 /// T12 Reliability Tests - Replay Detection and Conflict Handling
 /// Tests same-key replay safety, same-key-different-body conflicts, and idempotency record persistence.
 /// </summary>
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class ReliabilityReplayTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/ReliabilityUniquenessCheckTests.cs
+++ b/LgymApi.IntegrationTests/ReliabilityUniquenessCheckTests.cs
@@ -15,6 +15,7 @@ namespace LgymApi.IntegrationTests;
 /// This is a critical prerequisite for T12: these tests MUST pass to guarantee
 /// that reliability tests can actually verify uniqueness enforcement.
 /// </summary>
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public class ReliabilityUniquenessCheckTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/TestCategories.cs
+++ b/LgymApi.IntegrationTests/TestCategories.cs
@@ -1,0 +1,9 @@
+namespace LgymApi.IntegrationTests;
+
+/// <summary>
+/// Shared NUnit category names for integration test selection.
+/// </summary>
+internal static class TestCategories
+{
+    public const string DbBacked = "DbBacked";
+}

--- a/LgymApi.IntegrationTests/TrainerEmailInvitationTests.cs
+++ b/LgymApi.IntegrationTests/TrainerEmailInvitationTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class TrainerEmailInvitationTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/TrainerRelationshipTests.cs
+++ b/LgymApi.IntegrationTests/TrainerRelationshipTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class TrainerRelationshipTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/TrainingTests.cs
+++ b/LgymApi.IntegrationTests/TrainingTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class TrainingTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/UserAuthTests.cs
+++ b/LgymApi.IntegrationTests/UserAuthTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class UserAuthTests : IntegrationTestBase
 {

--- a/LgymApi.IntegrationTests/UserSessionIntegrationTests.cs
+++ b/LgymApi.IntegrationTests/UserSessionIntegrationTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace LgymApi.IntegrationTests;
 
+[Category(TestCategories.DbBacked)]
 [TestFixture]
 public sealed class UserSessionIntegrationTests : IntegrationTestBase
 {

--- a/docs/DB_BACKED_INTEGRATION_SCOPE.md
+++ b/docs/DB_BACKED_INTEGRATION_SCOPE.md
@@ -58,5 +58,7 @@ The full main-branch DB-backed set should include the PR subset plus the additio
 ## Notes
 
 - This scope intentionally stays at the scenario level rather than the workflow level.
-- Later issues can attach traits, containerized database bootstrap, and workflow selectors to the scenarios defined here.
+- The NUnit category used for these scenarios is `DbBacked` (`TestCategories.DbBacked` in `LgymApi.IntegrationTests`).
+- Run the subset locally with `dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --filter TestCategory=DbBacked`.
+- Later issues can attach containerized database bootstrap and workflow selectors to the scenarios defined here.
 - If a future change adds or removes a scenario from the DB-backed stage, update this document first.


### PR DESCRIPTION
What changed:
- Added a shared NUnit category constant, DbBacked, for DB-backed integration tests.
- Tagged the integration test classes covered by docs/DB_BACKED_INTEGRATION_SCOPE.md.
- Documented the category and local filter command in the integration test project doc and scope doc.

Why:
- This gives CI and local runs a stable selector for the PostgreSQL-backed subset.

Validation:
- git diff --check
- dotnet build LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --configuration Release --no-restore failed in this environment with MSBuild target NETStandardCompatError_Mono_TextTemplating_net6_0 before compilation completed.