### PR TITLE
[codex] issue 216 db-backed CI strategy

### DIFF
--- a/.github/workflows/pr-and-main-tests.yml
+++ b/.github/workflows/pr-and-main-tests.yml
@@ -6,6 +6,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
+  schedule:
+    - cron: '0 2 * * *'
 
 permissions:
   contents: read
@@ -19,6 +21,8 @@ jobs:
   tests:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    env:
+      DB_BACKED_INTEGRATION_FILTER: ${{ github.event_name == 'pull_request' && 'FullyQualifiedName~LgymApi.IntegrationTests.UserSessionIntegrationTests|FullyQualifiedName~LgymApi.IntegrationTests.ReliabilityReplayTests' || 'TestCategory=DbBacked' }}
 
     services:
       postgres:
@@ -61,8 +65,8 @@ jobs:
       - name: Run architecture tests
         run: dotnet test LgymApi.ArchitectureTests/LgymApi.ArchitectureTests.csproj --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=architecture-tests.trx" --results-directory ./TestResults/Architecture
 
-      - name: Run integration tests
-        run: dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=integration-tests.trx" --results-directory ./TestResults/Integration
+      - name: Run DB-backed integration checks
+        run: dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=integration-tests.trx" --results-directory ./TestResults/Integration --filter "$DB_BACKED_INTEGRATION_FILTER"
 
       - name: Run DataSeeder tests
         run: dotnet test LgymApi.DataSeeder.Tests/LgymApi.DataSeeder.Tests.csproj --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=dataseeder-tests.trx" --results-directory ./TestResults/DataSeeder

--- a/LgymApi.IntegrationTests/LgymApi.IntegrationTests.md
+++ b/LgymApi.IntegrationTests/LgymApi.IntegrationTests.md
@@ -5,4 +5,5 @@
 - Rules: reuse integration helpers and validate legacy contract compatibility for changed endpoints.
 - Boundary: keep these tests at the API boundary, not unit-test scope.
 - DB-backed selection: tests that must run against PostgreSQL are marked with `Category(TestCategories.DbBacked)`.
+- CI runtime targets: pull requests run the fast subset from `docs/DB_BACKED_INTEGRATION_SCOPE.md`, while `main` pushes and the nightly schedule run the full `DbBacked` set.
 - Local filter: use `dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --filter TestCategory=DbBacked` to run the DB-backed subset.

--- a/docs/DB_BACKED_INTEGRATION_SCOPE.md
+++ b/docs/DB_BACKED_INTEGRATION_SCOPE.md
@@ -60,5 +60,6 @@ The full main-branch DB-backed set should include the PR subset plus the additio
 - This scope intentionally stays at the scenario level rather than the workflow level.
 - The NUnit category used for these scenarios is `DbBacked` (`TestCategories.DbBacked` in `LgymApi.IntegrationTests`).
 - Run the subset locally with `dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --filter TestCategory=DbBacked`.
+- CI runtime targets are split as follows: pull requests run the fast subset (`UserSessionIntegrationTests` and `ReliabilityReplayTests`), while `main` pushes and the nightly schedule run the full `DbBacked` set.
 - Later issues can attach containerized database bootstrap and workflow selectors to the scenarios defined here.
 - If a future change adds or removes a scenario from the DB-backed stage, update this document first.


### PR DESCRIPTION
﻿## What changed
- Route PR runs to the fast DB-backed subset by filtering the `UserSessionIntegrationTests` and `ReliabilityReplayTests` classes.
- Keep `main` pushes and a nightly schedule on the full DB-backed test set.
- Document the CI runtime targets in the DB-backed scope notes.

## Validation
- `dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --configuration Release --no-restore --no-build --filter "FullyQualifiedName~LgymApi.IntegrationTests.UserSessionIntegrationTests|FullyQualifiedName~LgymApi.IntegrationTests.ReliabilityReplayTests" --list-tests`
- `dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --configuration Release --no-restore --no-build --filter "TestCategory=DbBacked" --list-tests` was attempted, but the local build outputs did not reflect the fresh category annotations yet.
