### PR TITLE
[Subtask] Add migration/seed bootstrap for CI test database

### DIFF
--- a/.github/workflows/pr-and-main-tests.yml
+++ b/.github/workflows/pr-and-main-tests.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Run architecture tests
         run: dotnet test LgymApi.ArchitectureTests/LgymApi.ArchitectureTests.csproj --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=architecture-tests.trx" --results-directory ./TestResults/Architecture
 
+      - name: Bootstrap CI database
+        env:
+          LGYM_SEEDER_BASE_PATH: ${{ github.workspace }}
+        run: printf 'n\nn\n' | dotnet run --project LgymApi.DataSeeder/LgymApi.DataSeeder.csproj --configuration Release --no-build --no-restore
+
       - name: Run DB-backed integration checks
         run: dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=integration-tests.trx" --results-directory ./TestResults/Integration --filter "$DB_BACKED_INTEGRATION_FILTER"
 

--- a/LgymApi.DataSeeder/LgymApi.DataSeeder.md
+++ b/LgymApi.DataSeeder/LgymApi.DataSeeder.md
@@ -2,5 +2,6 @@
 
 - Purpose: deterministic bootstrap and data seeding executable.
 - Contains: infrastructure and EF tooling used to seed or initialize data.
+- CI usage: the GitHub Actions DB-backed test job runs this project before integration tests to apply migrations and seed required rows.
 - Rules: do not make API startup depend on this executable.
 - Boundary: keep this as a console entrypoint, not a web host.

--- a/LgymApi.IntegrationTests/LgymApi.IntegrationTests.md
+++ b/LgymApi.IntegrationTests/LgymApi.IntegrationTests.md
@@ -6,4 +6,5 @@
 - Boundary: keep these tests at the API boundary, not unit-test scope.
 - DB-backed selection: tests that must run against PostgreSQL are marked with `Category(TestCategories.DbBacked)`.
 - CI runtime targets: pull requests run the fast subset from `docs/DB_BACKED_INTEGRATION_SCOPE.md`, while `main` pushes and the nightly schedule run the full `DbBacked` set.
+- CI bootstrap: `.github/workflows/pr-and-main-tests.yml` runs `LgymApi.DataSeeder` against the Postgres service before the DB-backed integration step so migrations and required seed data are always present.
 - Local filter: use `dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --filter TestCategory=DbBacked` to run the DB-backed subset.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,7 @@ This document explains how the backend is structured and how to add a new module
 - `LgymApi.Domain` - core domain types (entities, enums, domain-only helpers).
 - `LgymApi.Infrastructure` - persistence and technical implementations (EF Core `DbContext`, repository implementations, UoW, migrations).
 - `LgymApi.UnitTests` - focused unit tests and architecture guard tests.
-- `LgymApi.IntegrationTests` - end-to-end API tests with `WebApplicationFactory` and an in-memory fixture today; the initial DB-backed CI scope is documented in `docs/DB_BACKED_INTEGRATION_SCOPE.md`.
+- `LgymApi.IntegrationTests` - end-to-end API tests with `WebApplicationFactory`; DB-backed scenarios are categorized with `TestCategories.DbBacked` and bootstrapped in CI before execution.
 - `LgymApi.Resources` and `LgymApi.Resources.Generator` - localized resources and source generators for strongly-typed message access.
 
 ## 2. Request Flow

--- a/docs/DB_BACKED_INTEGRATION_SCOPE.md
+++ b/docs/DB_BACKED_INTEGRATION_SCOPE.md
@@ -61,5 +61,5 @@ The full main-branch DB-backed set should include the PR subset plus the additio
 - The NUnit category used for these scenarios is `DbBacked` (`TestCategories.DbBacked` in `LgymApi.IntegrationTests`).
 - Run the subset locally with `dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --filter TestCategory=DbBacked`.
 - CI runtime targets are split as follows: pull requests run the fast subset (`UserSessionIntegrationTests` and `ReliabilityReplayTests`), while `main` pushes and the nightly schedule run the full `DbBacked` set.
-- Later issues can attach containerized database bootstrap and workflow selectors to the scenarios defined here.
+- Before the DB-backed test step, CI runs `LgymApi.DataSeeder` against the Postgres service so migrations and required seed data are applied deterministically.
 - If a future change adds or removes a scenario from the DB-backed stage, update this document first.


### PR DESCRIPTION
Implements issue #215.

- Run LgymApi.DataSeeder before DB-backed integration checks in CI
- Apply migrations and required seed data deterministically
- Keep the bootstrap scoped to the CI workflow and docs