### PR TITLE
fix(trainer-dashboard): hide no-relationship trainees after unlink

### DIFF
--- a/LgymApi.Infrastructure/Repositories/TrainerRelationshipRepository.DashboardQueries.cs
+++ b/LgymApi.Infrastructure/Repositories/TrainerRelationshipRepository.DashboardQueries.cs
@@ -115,6 +115,11 @@ public sealed partial class TrainerRelationshipRepository
             : baseQuery.Where(x => EF.Functions.Like(x.Name, pattern) || EF.Functions.Like(x.Email, pattern));
     }
 
+    private static IQueryable<DashboardTraineeProjection> ExcludeNoRelationshipRows(IQueryable<DashboardTraineeProjection> baseQuery)
+    {
+        return baseQuery.Where(x => x.LinkedAt != null || (x.LastInvitationStatus != null && x.LastInvitationStatus != TrainerInvitationStatus.Revoked));
+    }
+
     private static IQueryable<DashboardTraineeProjection> ApplyStatusFilter(
         IQueryable<DashboardTraineeProjection> baseQuery,
         string? status,

--- a/LgymApi.Infrastructure/Repositories/TrainerRelationshipRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/TrainerRelationshipRepository.cs
@@ -135,6 +135,7 @@ public sealed partial class TrainerRelationshipRepository : ITrainerRelationship
 
         var baseQuery = BuildDashboardBaseQuery(trainerId, now);
         baseQuery = ApplySearch(baseQuery, query.Search);
+        baseQuery = ExcludeNoRelationshipRows(baseQuery);
         baseQuery = ApplyStatusFilter(baseQuery, query.Status, now);
 
         var filterInput = BuildFilterInput(query);

--- a/LgymApi.IntegrationTests/Pagination/TrainerDashboardGridifyPaginationTests.cs
+++ b/LgymApi.IntegrationTests/Pagination/TrainerDashboardGridifyPaginationTests.cs
@@ -89,6 +89,99 @@ public sealed class TrainerDashboardGridifyPaginationTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task TrainerDashboardGridifyPagination_DoesNotListRevokedInvitationRowsByDefault()
+    {
+        // Arrange
+        var trainer = await SeedTrainerAsync("trainer-grid-revoked-default", "trainer-grid-revoked-default@example.com");
+        var linked = await SeedDashboardTraineeAsync(trainer.Id, "linked-visible-default", "linked-visible-default@example.com", linked: true, linkedAt: DateTimeOffset.UtcNow.AddDays(-2));
+        var pending = await SeedDashboardTraineeAsync(trainer.Id, "pending-visible-default", "pending-visible-default@example.com", invited: true, invitationStatus: TrainerInvitationStatus.Pending, invitationExpiresAt: DateTimeOffset.UtcNow.AddDays(2));
+        var revoked = await SeedDashboardTraineeAsync(trainer.Id, "revoked-hidden-default", "revoked-hidden-default@example.com", invited: true, invitationStatus: TrainerInvitationStatus.Revoked, invitationExpiresAt: DateTimeOffset.UtcNow.AddDays(-1));
+        SetAuthorizationHeader(trainer.Id);
+
+        // Act
+        var response = await Client.GetAsync("/api/trainer/trainees?page=1&pageSize=10");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await ParseDashboardResponseAsync(response);
+        body.GetProperty("total").GetInt32().Should().Be(2);
+
+        var items = body.GetProperty("items").EnumerateArray().ToArray();
+        items.Select(x => x.GetProperty("_id").GetString()).Should().Contain(new[] { linked.Id.ToString(), pending.Id.ToString() });
+        items.Select(x => x.GetProperty("_id").GetString()).Should().NotContain(revoked.Id.ToString());
+    }
+
+    [Test]
+    public async Task TrainerDashboardGridifyPagination_DoesNotCountRevokedInvitationRowsForPaging()
+    {
+        // Arrange
+        var trainer = await SeedTrainerAsync("trainer-grid-revoked-page", "trainer-grid-revoked-page@example.com");
+        await SeedDashboardTraineeAsync(trainer.Id, "linked-visible-page", "linked-visible-page@example.com", linked: true, linkedAt: DateTimeOffset.UtcNow.AddDays(-2));
+        await SeedDashboardTraineeAsync(trainer.Id, "pending-visible-page", "pending-visible-page@example.com", invited: true, invitationStatus: TrainerInvitationStatus.Pending, invitationExpiresAt: DateTimeOffset.UtcNow.AddDays(2));
+        var revoked = await SeedDashboardTraineeAsync(trainer.Id, "revoked-hidden-page", "revoked-hidden-page@example.com", invited: true, invitationStatus: TrainerInvitationStatus.Revoked, invitationExpiresAt: DateTimeOffset.UtcNow.AddDays(-1));
+        SetAuthorizationHeader(trainer.Id);
+
+        // Act
+        var response = await Client.GetAsync("/api/trainer/trainees?page=2&pageSize=2");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await ParseDashboardResponseAsync(response);
+        body.GetProperty("page").GetInt32().Should().Be(2);
+        body.GetProperty("pageSize").GetInt32().Should().Be(2);
+        body.GetProperty("total").GetInt32().Should().Be(2);
+        body.GetProperty("items").EnumerateArray().Should().NotContain(x => x.GetProperty("_id").GetString() == revoked.Id.ToString());
+        body.GetProperty("items").EnumerateArray().Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task TrainerDashboardGridifyPagination_SearchDoesNotListRevokedInvitationRows()
+    {
+        // Arrange
+        var trainer = await SeedTrainerAsync("trainer-grid-revoked-search", "trainer-grid-revoked-search@example.com");
+        var linked = await SeedDashboardTraineeAsync(trainer.Id, "match linked visible", "match-linked-visible@example.com", linked: true, linkedAt: DateTimeOffset.UtcNow.AddDays(-2));
+        var pending = await SeedDashboardTraineeAsync(trainer.Id, "match pending visible", "match-pending-visible@example.com", invited: true, invitationStatus: TrainerInvitationStatus.Pending, invitationExpiresAt: DateTimeOffset.UtcNow.AddDays(2));
+        var revoked = await SeedDashboardTraineeAsync(trainer.Id, "match revoked hidden", "match-revoked-hidden@example.com", invited: true, invitationStatus: TrainerInvitationStatus.Revoked, invitationExpiresAt: DateTimeOffset.UtcNow.AddDays(-1));
+        SetAuthorizationHeader(trainer.Id);
+
+        // Act
+        var response = await Client.GetAsync("/api/trainer/trainees?search=match&page=1&pageSize=10");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await ParseDashboardResponseAsync(response);
+        body.GetProperty("total").GetInt32().Should().Be(2);
+
+        var itemIds = body.GetProperty("items").EnumerateArray().Select(x => x.GetProperty("_id").GetString()).ToArray();
+        itemIds.Should().Contain(new[] { linked.Id.ToString(), pending.Id.ToString() });
+        itemIds.Should().NotContain(revoked.Id.ToString());
+    }
+
+    [Test]
+    public async Task TrainerDashboardGridifyPagination_NoRelationshipStatusReturnsEmptyPage()
+    {
+        // Arrange
+        var trainer = await SeedTrainerAsync("trainer-grid-no-relationship", "trainer-grid-no-relationship@example.com");
+        await SeedDashboardTraineeAsync(trainer.Id, "linked-visible-no-relationship", "linked-visible-no-relationship@example.com", linked: true, linkedAt: DateTimeOffset.UtcNow.AddDays(-2));
+        await SeedDashboardTraineeAsync(trainer.Id, "pending-visible-no-relationship", "pending-visible-no-relationship@example.com", invited: true, invitationStatus: TrainerInvitationStatus.Pending, invitationExpiresAt: DateTimeOffset.UtcNow.AddDays(2));
+        await SeedDashboardTraineeAsync(trainer.Id, "revoked-hidden-no-relationship", "revoked-hidden-no-relationship@example.com", invited: true, invitationStatus: TrainerInvitationStatus.Revoked, invitationExpiresAt: DateTimeOffset.UtcNow.AddDays(-1));
+        SetAuthorizationHeader(trainer.Id);
+
+        // Act
+        var response = await Client.GetAsync("/api/trainer/trainees?status=NoRelationship&page=1&pageSize=10");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await ParseDashboardResponseAsync(response);
+        body.GetProperty("total").GetInt32().Should().Be(0);
+        body.GetProperty("items").EnumerateArray().Should().BeEmpty();
+    }
+
+    [Test]
     public async Task TrainerDashboardGridifyPagination_ReturnsEmptyPageBeyondTotal()
     {
         // Arrange

--- a/LgymApi.IntegrationTests/TrainerRelationshipTests.cs
+++ b/LgymApi.IntegrationTests/TrainerRelationshipTests.cs
@@ -1121,6 +1121,54 @@ public sealed class TrainerRelationshipTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task UnlinkByTrainer_AndDashboardFetch_ExcludesUnlinkedTrainee()
+    {
+        var trainer = await SeedTrainerAsync("trainer-unlink-dashboard", "trainer-unlink-dashboard@example.com");
+        var trainee = await SeedUserAsync(name: "trainee-unlink-dashboard", email: "trainee-unlink-dashboard@example.com", password: "password123");
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            db.TrainerTraineeLinks.Add(new TrainerTraineeLink
+            {
+                Id = Id<TrainerTraineeLink>.New(),
+                TrainerId = trainer.Id,
+                TraineeId = trainee.Id
+            });
+            db.TrainerInvitations.Add(new TrainerInvitation
+            {
+                Id = Id<TrainerInvitation>.New(),
+                TrainerId = trainer.Id,
+                TraineeId = trainee.Id,
+                Code = "UNLINKDASHREV",
+                Status = TrainerInvitationStatus.Revoked,
+                ExpiresAt = DateTimeOffset.UtcNow.AddDays(-1),
+                RespondedAt = DateTimeOffset.UtcNow.AddHours(-1)
+            });
+            await db.SaveChangesAsync();
+        }
+
+        SetAuthorizationHeader(trainer.Id);
+
+        var beforeUnlinkResponse = await Client.GetAsync("/api/trainer/trainees?page=1&pageSize=20");
+        beforeUnlinkResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var beforeUnlink = await beforeUnlinkResponse.Content.ReadFromJsonAsync<TrainerDashboardTraineesResponse>();
+        beforeUnlink.Should().NotBeNull();
+        beforeUnlink!.Total.Should().Be(1);
+        beforeUnlink.Items.Should().ContainSingle(x => x.Id == trainee.Id.ToString());
+
+        var unlinkResponse = await Client.PostAsync($"/api/trainer/trainees/{trainee.Id}/unlink", null);
+        unlinkResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var afterUnlinkResponse = await Client.GetAsync("/api/trainer/trainees?page=1&pageSize=20");
+        afterUnlinkResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var afterUnlink = await afterUnlinkResponse.Content.ReadFromJsonAsync<TrainerDashboardTraineesResponse>();
+        afterUnlink.Should().NotBeNull();
+        afterUnlink!.Total.Should().Be(0);
+        afterUnlink.Items.Should().NotContain(x => x.Id == trainee.Id.ToString());
+    }
+
+    [Test]
     public async Task DetachByTrainee_RemovesExistingLink()
     {
         var trainer = await SeedTrainerAsync("trainer-detach", "trainer-detach@example.com");


### PR DESCRIPTION
## Summary
Fix the trainer dashboard trainees query so GET /api/trainer/trainees never returns rows whose resolved status is NoRelationship, including immediately after POST /api/trainer/trainees/{id}/unlink.

## Changes
- Added pre-Gridify exclusion of NoRelationship rows in the dashboard repository
- Added regression tests for unlink → dashboard behavior
- Added pagination/search/status-filter regression coverage

## Task Reference
- Task: #342
- Issue: https://github.com/lgym/lgym-app-api/issues/342