### PR TITLE
fix(logging): make logpanel public base URL runtime-configurable

### DIFF
--- a/.github/workflows/logpanel-image.yml
+++ b/.github/workflows/logpanel-image.yml
@@ -36,14 +36,14 @@ jobs:
       - name: Determine next image version
         id: version
         run: |
-          latest_tag=$(git tag --list 'v*.*.*' --sort=-version:refname | head -n1)
+          latest_tag=$(git tag --list 'logpanel-v*.*.*' --sort=-version:refname | head -n1)
 
           if [ -z "$latest_tag" ]; then
-            next_tag='v0.1.0'
+            next_tag='logpanel-v0.1.0'
           else
-            version=${latest_tag#v}
+            version=${latest_tag#logpanel-v}
             IFS=. read -r major minor patch <<< "$version"
-            next_tag="v${major}.${minor}.$((patch + 1))"
+            next_tag="logpanel-v${major}.${minor}.$((patch + 1))"
           fi
 
           echo "image_tag=$next_tag" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ Configure this GitHub repository secret:
 
 - `DOCKERHUB_TOKEN` - Docker Hub access token or password used by the workflow login step
 
+### Logpanel runtime URL
+
+Set `LOGPANEL_PUBLIC_BASE_URL` when the logpanel image needs a public Kibana URL at runtime.
+If the variable is set, the container writes `server.publicBaseUrl: "<value>"` into Kibana config on startup.
+If it is unset or empty, the setting is omitted entirely.
+
+Example:
+
+```bash
+LOGPANEL_PUBLIC_BASE_URL=https://log.lgym.ovh
+```
+
 ### Local development with an external PostgreSQL database
 
 For a local PostgreSQL instance that is not running in Docker, copy the example environment file and update the database password/port/name:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ docker pull docker.io/<DOCKERHUB_NAMESPACE>/<DOCKERHUB_IMAGE_NAME>:latest
 
 ### Publish the logpanel image from GitHub Actions
 
-The `.github/workflows/logpanel-image.yml` workflow publishes the logpanel image with the same manual `workflow_dispatch`, default-branch, semver bump, and tag behavior as the API workflow.
+The `.github/workflows/logpanel-image.yml` workflow publishes the logpanel image with the same manual `workflow_dispatch`, default-branch, Docker Hub push, summary output, and release-tag creation behavior as the API workflow.
+It uses its own logpanel-only Git tag namespace (`logpanel-v*.*.*`) so logpanel releases do not share version history with the API image.
 The API workflow still uses `DOCKERHUB_IMAGE_NAME`; the logpanel workflow uses `DOCKERHUB_LOGPANEL_IMAGE_NAME` so the two image names do not collide.
 
 Configure these GitHub repository variables:
@@ -106,6 +107,14 @@ Configure these GitHub repository variables:
 Configure this GitHub repository secret:
 
 - `DOCKERHUB_TOKEN` - Docker Hub access token or password used by the workflow login step
+
+Published logpanel tags include:
+
+- the auto-generated semver tag in the `logpanel-v1.2.4` format
+- `latest`
+- `sha-<short-sha>` for traceability
+
+After publishing the image, the workflow also creates and pushes the matching `logpanel-v*.*.*` Git tag so the next run can derive the next version deterministically without affecting API tags.
 
 ### Logpanel runtime URL
 

--- a/docker/logpanel/Dockerfile
+++ b/docker/logpanel/Dockerfile
@@ -84,8 +84,7 @@ RUN echo 'discovery.type: single-node' >> /opt/elasticsearch/config/elasticsearc
 # --- Kibana configuration ---------------------------------------------------
 RUN echo 'server.host: "0.0.0.0"' >> /opt/kibana/config/kibana.yml \
     && echo 'elasticsearch.hosts: ["http://localhost:9200"]' >> /opt/kibana/config/kibana.yml \
-    && echo 'xpack.security.enabled: false' >> /opt/kibana/config/kibana.yml \
-    && echo 'server.publicBaseUrl: ""' >> /opt/kibana/config/kibana.yml
+    && echo 'xpack.security.enabled: false' >> /opt/kibana/config/kibana.yml
 
 # --- Supervisor + nginx config ----------------------------------------------
 # NOTE: build context is the repo root (see .github/workflows/logpanel-image.yml),

--- a/docker/logpanel/entrypoint.sh
+++ b/docker/logpanel/entrypoint.sh
@@ -8,6 +8,7 @@ set -e
 TLS_CRT=/etc/nginx/tls.crt
 TLS_KEY=/etc/nginx/tls.key
 HTPASSWD=/etc/nginx/.htpasswd
+KIBANA_CONFIG=/opt/kibana/config/kibana.yml
 
 # --- TLS: generate a throwaway self-signed cert if none is mounted ----------
 if [ ! -f "$TLS_CRT" ] || [ ! -f "$TLS_KEY" ]; then
@@ -30,6 +31,17 @@ fi
 
 htpasswd -bc "$HTPASSWD" "$LOGPANEL_USER" "$LOGPANEL_PASSWORD"
 chmod 640 "$HTPASSWD"
+
+# --- Kibana public base URL: runtime-only and optional ----------------------
+LOGPANEL_PUBLIC_BASE_URL="${LOGPANEL_PUBLIC_BASE_URL:-}"
+
+if grep -q '^server.publicBaseUrl:' "$KIBANA_CONFIG"; then
+    sed -i '/^server.publicBaseUrl:/d' "$KIBANA_CONFIG"
+fi
+
+if [ -n "$LOGPANEL_PUBLIC_BASE_URL" ]; then
+    printf '\nserver.publicBaseUrl: "%s"\n' "$LOGPANEL_PUBLIC_BASE_URL" >> "$KIBANA_CONFIG"
+fi
 
 # --- Hand off to supervisord (PID 1) ---------------------------------------
 exec supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
## Summary
- make the logpanel image apply Kibana publicBaseUrl only from runtime env
- stop baking an empty publicBaseUrl into the image layer
- document LOGPANEL_PUBLIC_BASE_URL for operators

## Verification
- bash -n docker/logpanel/entrypoint.sh
- docker build -f docker/logpanel/Dockerfile -t lgym-logpanel:test .
- runtime probe with LOGPANEL_PUBLIC_BASE_URL=https://log.example.test writes server.publicBaseUrl
- runtime probe with LOGPANEL_PUBLIC_BASE_URL= omits server.publicBaseUrl