### PR TITLE
Add privacy-safe push notification pipeline

### DIFF
--- a/LgymApi.Api/Features/InAppNotification/Contracts/EnqueueTestPushEventRequest.cs
+++ b/LgymApi.Api/Features/InAppNotification/Contracts/EnqueueTestPushEventRequest.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+using LgymApi.Api.Interfaces;
+
+namespace LgymApi.Api.Features.InAppNotification.Contracts;
+
+public sealed record EnqueueTestPushEventRequest(
+    [property: JsonPropertyName("recipientUserId")] string RecipientUserId,
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("eventId")] string EventId,
+    [property: JsonPropertyName("entityId")] string? EntityId,
+    [property: JsonPropertyName("inAppNotificationId")] string? InAppNotificationId,
+    [property: JsonPropertyName("deeplink")] string? Deeplink) : IDto;

--- a/LgymApi.Api/Features/InAppNotification/Controllers/PushNotificationAdminController.cs
+++ b/LgymApi.Api/Features/InAppNotification/Controllers/PushNotificationAdminController.cs
@@ -29,7 +29,7 @@ public sealed class PushNotificationAdminController : ControllerBase
     }
 
     [HttpPost("test-event")]
-    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status202Accepted)]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> EnqueueTestEvent(
         [FromBody] EnqueueTestPushEventRequest request,
@@ -46,6 +46,6 @@ public sealed class PushNotificationAdminController : ControllerBase
 
         await _notificationEventBridge.EnqueueAsync(input, cancellationToken);
 
-        return Accepted(_mapper.Map<string, ResponseMessageDto>("Push test event queued"));
+        return Ok(_mapper.Map<string, ResponseMessageDto>("Push test event queued"));
     }
 }

--- a/LgymApi.Api/Features/InAppNotification/Controllers/PushNotificationAdminController.cs
+++ b/LgymApi.Api/Features/InAppNotification/Controllers/PushNotificationAdminController.cs
@@ -1,0 +1,51 @@
+using LgymApi.Api.Features.Common.Contracts;
+using LgymApi.Api.Features.InAppNotification.Contracts;
+using LgymApi.Api.Middleware;
+using LgymApi.Application.Mapping.Core;
+using LgymApi.Application.Notifications;
+using LgymApi.Application.Notifications.Models;
+using LgymApi.Domain.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using InAppNotificationEntity = global::LgymApi.Domain.Entities.InAppNotification;
+using UserEntity = global::LgymApi.Domain.Entities.User;
+
+namespace LgymApi.Api.Features.InAppNotification.Controllers;
+
+[ApiController]
+[Route("api/internal/push")]
+[Authorize(Policy = AuthConstants.Policies.AdminAccess)]
+public sealed class PushNotificationAdminController : ControllerBase
+{
+    private const int SchemaVersion = 1;
+
+    private readonly INotificationEventBridge _notificationEventBridge;
+    private readonly IMapper _mapper;
+
+    public PushNotificationAdminController(INotificationEventBridge notificationEventBridge, IMapper mapper)
+    {
+        _notificationEventBridge = notificationEventBridge;
+        _mapper = mapper;
+    }
+
+    [HttpPost("test-event")]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status202Accepted)]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> EnqueueTestEvent(
+        [FromBody] EnqueueTestPushEventRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var input = new EnqueueNotificationEventInput(
+            request.RecipientUserId.ToIdOrEmpty<UserEntity>(),
+            SchemaVersion,
+            request.Type,
+            request.EventId,
+            request.EntityId,
+            request.InAppNotificationId.ToNullableId<InAppNotificationEntity>(),
+            request.Deeplink);
+
+        await _notificationEventBridge.EnqueueAsync(input, cancellationToken);
+
+        return Accepted(_mapper.Map<string, ResponseMessageDto>("Push test event queued"));
+    }
+}

--- a/LgymApi.Api/Features/InAppNotification/Validation/EnqueueTestPushEventRequestValidator.cs
+++ b/LgymApi.Api/Features/InAppNotification/Validation/EnqueueTestPushEventRequestValidator.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+using LgymApi.Api.Features.InAppNotification.Contracts;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.Resources;
+using InAppNotificationEntity = global::LgymApi.Domain.Entities.InAppNotification;
+using UserEntity = global::LgymApi.Domain.Entities.User;
+
+namespace LgymApi.Api.Features.InAppNotification.Validation;
+
+public sealed class EnqueueTestPushEventRequestValidator : AbstractValidator<EnqueueTestPushEventRequest>
+{
+    public EnqueueTestPushEventRequestValidator()
+    {
+        RuleFor(x => x.RecipientUserId)
+            .NotEmpty()
+            .WithMessage(Messages.FieldRequired)
+            .Must(static raw => Id<UserEntity>.TryParse(raw, out _))
+            .WithMessage(Messages.UserIdRequired);
+
+        RuleFor(x => x.Type)
+            .NotEmpty()
+            .WithMessage(Messages.FieldRequired);
+
+        RuleFor(x => x.EventId)
+            .NotEmpty()
+            .WithMessage(Messages.FieldRequired);
+
+        RuleFor(x => x.InAppNotificationId)
+            .Must(static raw => string.IsNullOrWhiteSpace(raw) || Id<InAppNotificationEntity>.TryParse(raw, out _))
+            .WithMessage(Messages.FieldRequired);
+    }
+}

--- a/LgymApi.Api/Features/User/Contracts/UserDtos.cs
+++ b/LgymApi.Api/Features/User/Contracts/UserDtos.cs
@@ -54,6 +54,33 @@ public sealed class ResetPasswordRequest : IDto
     public string ConfirmPassword { get; set; } = string.Empty;
 }
 
+public sealed class RegisterPushInstallationRequest : IDto
+{
+    [JsonPropertyName("installationId")]
+    public string InstallationId { get; set; } = string.Empty;
+
+    [JsonPropertyName("platform")]
+    public string Platform { get; set; } = string.Empty;
+
+    [JsonPropertyName("fcmToken")]
+    public string FcmToken { get; set; } = string.Empty;
+
+    [JsonPropertyName("appVersion")]
+    public string? AppVersion { get; set; }
+
+    [JsonPropertyName("environment")]
+    public string Environment { get; set; } = string.Empty;
+
+    [JsonPropertyName("permissionStatus")]
+    public string? PermissionStatus { get; set; }
+}
+
+public sealed class PushInstallationActionRequest : IDto
+{
+    [JsonPropertyName("installationId")]
+    public string InstallationId { get; set; } = string.Empty;
+}
+
 public sealed class RankDto : IResultDto
 {
     [JsonPropertyName("name")]

--- a/LgymApi.Api/Features/User/Controllers/PushInstallationController.cs
+++ b/LgymApi.Api/Features/User/Controllers/PushInstallationController.cs
@@ -1,0 +1,101 @@
+using LgymApi.Api.Extensions;
+using LgymApi.Api.Features.Common.Contracts;
+using LgymApi.Api.Features.User.Contracts;
+using LgymApi.Api.Middleware;
+using LgymApi.Application.Common.Results;
+using LgymApi.Application.Features.User;
+using LgymApi.Application.Features.User.Models;
+using LgymApi.Application.Mapping.Core;
+using LgymApi.Domain.Security;
+using LgymApi.Domain.ValueObjects;
+using Microsoft.AspNetCore.Mvc;
+using UserEntity = LgymApi.Domain.Entities.User;
+using UserSessionEntity = LgymApi.Domain.Entities.UserSession;
+
+namespace LgymApi.Api.Features.User.Controllers;
+
+[ApiController]
+[Route("api/push/installations")]
+public sealed class PushInstallationController : ControllerBase
+{
+    private readonly IUserService _userService;
+    private readonly IMapper _mapper;
+
+    public PushInstallationController(IUserService userService, IMapper mapper)
+    {
+        _userService = userService;
+        _mapper = mapper;
+    }
+
+    [HttpPost("register")]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Register([FromBody] RegisterPushInstallationRequest request, CancellationToken cancellationToken = default)
+    {
+        var input = new RegisterPushInstallationInput(
+            request.InstallationId,
+            request.Platform,
+            request.FcmToken,
+            request.AppVersion,
+            request.Environment,
+            request.PermissionStatus);
+
+        var result = await _userService.RegisterPushInstallationAsync(
+            HttpContext.GetCurrentUser(),
+            ParseCurrentSessionId(),
+            input,
+            cancellationToken);
+        if (result.IsFailure)
+        {
+            return result.ToActionResult();
+        }
+
+        return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
+    }
+
+    [HttpPost("unregister")]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Unregister([FromBody] PushInstallationActionRequest request, CancellationToken cancellationToken = default)
+    {
+        var result = await _userService.UnregisterPushInstallationAsync(
+            HttpContext.GetCurrentUser(),
+            ParseCurrentSessionId(),
+            new PushInstallationActionInput(request.InstallationId),
+            cancellationToken);
+        if (result.IsFailure)
+        {
+            return result.ToActionResult();
+        }
+
+        return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
+    }
+
+    [HttpPost("disassociate")]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Disassociate([FromBody] PushInstallationActionRequest request, CancellationToken cancellationToken = default)
+    {
+        var result = await _userService.DisassociatePushInstallationAsync(
+            HttpContext.GetCurrentUser(),
+            ParseCurrentSessionId(),
+            new PushInstallationActionInput(request.InstallationId),
+            cancellationToken);
+        if (result.IsFailure)
+        {
+            return result.ToActionResult();
+        }
+
+        return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
+    }
+
+    private Id<UserSessionEntity>? ParseCurrentSessionId()
+    {
+        var rawSessionId = HttpContext.User.FindFirst(AuthConstants.ClaimNames.SessionId)?.Value;
+        if (string.IsNullOrWhiteSpace(rawSessionId))
+        {
+            return null;
+        }
+
+        return Id<UserSessionEntity>.TryParse(rawSessionId, out var parsedSessionId)
+            ? parsedSessionId
+            : null;
+    }
+}

--- a/LgymApi.Api/Features/User/Controllers/UserController.cs
+++ b/LgymApi.Api/Features/User/Controllers/UserController.cs
@@ -104,12 +104,72 @@ public sealed class UserController : ControllerBase
     public async Task<IActionResult> Logout(CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var rawSessionId = HttpContext.User.FindFirst(AuthConstants.ClaimNames.SessionId)?.Value;
-        var sessionId = Id<UserSessionEntity>.TryParse(rawSessionId, out var parsedSessionId)
-            ? parsedSessionId
-            : (Id<UserSessionEntity>?)null;
+        var sessionId = ParseCurrentSessionId();
 
         var result = await _userService.LogoutAsync(user, sessionId, cancellationToken);
+        if (result.IsFailure)
+        {
+            return result.ToActionResult();
+        }
+
+        return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
+    }
+
+    [HttpPost("push/installations/register")]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> RegisterPushInstallation([FromBody] RegisterPushInstallationRequest request, CancellationToken cancellationToken = default)
+    {
+        var user = HttpContext.GetCurrentUser();
+        var sessionId = ParseCurrentSessionId();
+        var input = new RegisterPushInstallationInput(
+            request.InstallationId,
+            request.Platform,
+            request.FcmToken,
+            request.AppVersion,
+            request.Environment,
+            request.PermissionStatus);
+
+        var result = await _userService.RegisterPushInstallationAsync(user, sessionId, input, cancellationToken);
+        if (result.IsFailure)
+        {
+            return result.ToActionResult();
+        }
+
+        return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
+    }
+
+    [HttpPost("push/installations/unregister")]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> UnregisterPushInstallation([FromBody] PushInstallationActionRequest request, CancellationToken cancellationToken = default)
+    {
+        var user = HttpContext.GetCurrentUser();
+        var sessionId = ParseCurrentSessionId();
+        var result = await _userService.UnregisterPushInstallationAsync(
+            user,
+            sessionId,
+            new PushInstallationActionInput(request.InstallationId),
+            cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return result.ToActionResult();
+        }
+
+        return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
+    }
+
+    [HttpPost("push/installations/disassociate")]
+    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> DisassociatePushInstallation([FromBody] PushInstallationActionRequest request, CancellationToken cancellationToken = default)
+    {
+        var user = HttpContext.GetCurrentUser();
+        var sessionId = ParseCurrentSessionId();
+        var result = await _userService.DisassociatePushInstallationAsync(
+            user,
+            sessionId,
+            new PushInstallationActionInput(request.InstallationId),
+            cancellationToken);
+
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -151,6 +211,19 @@ public sealed class UserController : ControllerBase
         return Id<UserEntity>.TryParse(value, out var parsedUserId)
             ? parsedUserId
             : Id<UserEntity>.Empty;
+    }
+
+    private Id<UserSessionEntity>? ParseCurrentSessionId()
+    {
+        var rawSessionId = HttpContext.User.FindFirst(AuthConstants.ClaimNames.SessionId)?.Value;
+        if (string.IsNullOrWhiteSpace(rawSessionId))
+        {
+            return null;
+        }
+
+        return Id<UserSessionEntity>.TryParse(rawSessionId, out var parsedSessionId)
+            ? parsedSessionId
+            : (Id<UserSessionEntity>?)null;
     }
 
     [HttpGet("deleteAccount")]

--- a/LgymApi.Api/Features/User/Controllers/UserController.cs
+++ b/LgymApi.Api/Features/User/Controllers/UserController.cs
@@ -104,72 +104,12 @@ public sealed class UserController : ControllerBase
     public async Task<IActionResult> Logout(CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var sessionId = ParseCurrentSessionId();
+        var rawSessionId = HttpContext.User.FindFirst(AuthConstants.ClaimNames.SessionId)?.Value;
+        var sessionId = !string.IsNullOrWhiteSpace(rawSessionId) && Id<UserSessionEntity>.TryParse(rawSessionId, out var parsedSessionId)
+            ? parsedSessionId
+            : (Id<UserSessionEntity>?)null;
 
         var result = await _userService.LogoutAsync(user, sessionId, cancellationToken);
-        if (result.IsFailure)
-        {
-            return result.ToActionResult();
-        }
-
-        return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
-    }
-
-    [HttpPost("push/installations/register")]
-    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> RegisterPushInstallation([FromBody] RegisterPushInstallationRequest request, CancellationToken cancellationToken = default)
-    {
-        var user = HttpContext.GetCurrentUser();
-        var sessionId = ParseCurrentSessionId();
-        var input = new RegisterPushInstallationInput(
-            request.InstallationId,
-            request.Platform,
-            request.FcmToken,
-            request.AppVersion,
-            request.Environment,
-            request.PermissionStatus);
-
-        var result = await _userService.RegisterPushInstallationAsync(user, sessionId, input, cancellationToken);
-        if (result.IsFailure)
-        {
-            return result.ToActionResult();
-        }
-
-        return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
-    }
-
-    [HttpPost("push/installations/unregister")]
-    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> UnregisterPushInstallation([FromBody] PushInstallationActionRequest request, CancellationToken cancellationToken = default)
-    {
-        var user = HttpContext.GetCurrentUser();
-        var sessionId = ParseCurrentSessionId();
-        var result = await _userService.UnregisterPushInstallationAsync(
-            user,
-            sessionId,
-            new PushInstallationActionInput(request.InstallationId),
-            cancellationToken);
-
-        if (result.IsFailure)
-        {
-            return result.ToActionResult();
-        }
-
-        return Ok(_mapper.Map<string, ResponseMessageDto>(Messages.Updated));
-    }
-
-    [HttpPost("push/installations/disassociate")]
-    [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
-    public async Task<IActionResult> DisassociatePushInstallation([FromBody] PushInstallationActionRequest request, CancellationToken cancellationToken = default)
-    {
-        var user = HttpContext.GetCurrentUser();
-        var sessionId = ParseCurrentSessionId();
-        var result = await _userService.DisassociatePushInstallationAsync(
-            user,
-            sessionId,
-            new PushInstallationActionInput(request.InstallationId),
-            cancellationToken);
-
         if (result.IsFailure)
         {
             return result.ToActionResult();
@@ -213,19 +153,6 @@ public sealed class UserController : ControllerBase
             : Id<UserEntity>.Empty;
     }
 
-    private Id<UserSessionEntity>? ParseCurrentSessionId()
-    {
-        var rawSessionId = HttpContext.User.FindFirst(AuthConstants.ClaimNames.SessionId)?.Value;
-        if (string.IsNullOrWhiteSpace(rawSessionId))
-        {
-            return null;
-        }
-
-        return Id<UserSessionEntity>.TryParse(rawSessionId, out var parsedSessionId)
-            ? parsedSessionId
-            : (Id<UserSessionEntity>?)null;
-    }
-
     [HttpGet("deleteAccount")]
     [ProducesResponseType(typeof(ResponseMessageDto), StatusCodes.Status200OK)]
     public async Task<IActionResult> DeleteAccount(CancellationToken cancellationToken = default)
@@ -245,7 +172,8 @@ public sealed class UserController : ControllerBase
     public async Task<IActionResult> ChangeVisibilityInRanking([FromBody] ChangeVisibilityInRankingRequest request, CancellationToken cancellationToken = default)
     {
         var user = HttpContext.GetCurrentUser();
-        var result = await _userService.ChangeVisibilityInRankingAsync(user, request.IsVisibleInRanking.Value, cancellationToken);
+        var isVisibleInRanking = request.IsVisibleInRanking.GetValueOrDefault();
+        var result = await _userService.ChangeVisibilityInRankingAsync(user, isVisibleInRanking, cancellationToken);
         if (result.IsFailure)
         {
             return result.ToActionResult();

--- a/LgymApi.Api/Features/User/Validation/PushInstallationRequestValidators.cs
+++ b/LgymApi.Api/Features/User/Validation/PushInstallationRequestValidators.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+using LgymApi.Api.Features.User.Contracts;
+using LgymApi.Resources;
+
+namespace LgymApi.Api.Features.User.Validation;
+
+public sealed class RegisterPushInstallationRequestValidator : AbstractValidator<RegisterPushInstallationRequest>
+{
+    public RegisterPushInstallationRequestValidator()
+    {
+        RuleFor(x => x.InstallationId)
+            .NotEmpty()
+            .WithMessage(Messages.FieldRequired);
+
+        RuleFor(x => x.Platform)
+            .NotEmpty()
+            .WithMessage(Messages.FieldRequired);
+
+        RuleFor(x => x.FcmToken)
+            .NotEmpty()
+            .WithMessage(Messages.FieldRequired);
+
+        RuleFor(x => x.Environment)
+            .NotEmpty()
+            .WithMessage(Messages.FieldRequired);
+    }
+}
+
+public sealed class PushInstallationActionRequestValidator : AbstractValidator<PushInstallationActionRequest>
+{
+    public PushInstallationActionRequestValidator()
+    {
+        RuleFor(x => x.InstallationId)
+            .NotEmpty()
+            .WithMessage(Messages.FieldRequired);
+    }
+}

--- a/LgymApi.Api/LgymApi.Api.md
+++ b/LgymApi.Api/LgymApi.Api.md
@@ -8,3 +8,7 @@
 - Enum-backed choice lists must return `LookupItem`-style payloads with stable enum-string `id`; `name` and `displayName` both carry translated display text.
 - Exercise ELO formulas must be sourced from the enum lookup API (`/api/enums/enumType/ExerciseEloFormula`) and must not be hardcoded in the front-end.
 - Lookup-backed request values such as `ExerciseExtendedFormDto.EloFormula` must be mapped in API mapping profiles from lookup ids to application enums; controllers should not parse them.
+- Push installation endpoints live under `/api/push/installations/*`, rely on middleware-authenticated `User` plus `sid` claims, and never trust client-supplied user identity for device registration or disassociation.
+- Push sender configuration follows the existing `appsettings.json` convention under `PushNotifications:*`; the API host composes the enqueue service and background worker pieces but does not send push notifications synchronously inside controllers.
+- The only API-level push bridge path is the admin-only test endpoint at `/api/internal/push/test-event`; it accepts privacy-safe IDs only and exists to prove generic enqueue wiring without auto-converting all in-app notifications to push.
+- Rollout guardrails rely on `PushNotifications:SendEnabled` for send-only disablement plus the recurring `push-stale-installation-cleanup` Hangfire job for inactive-token tombstoning.

--- a/LgymApi.Api/Program.Hangfire.cs
+++ b/LgymApi.Api/Program.Hangfire.cs
@@ -21,5 +21,6 @@ internal static class ProgramHangfire
         RecurringJob.AddOrUpdate<ICommittedIntentDispatchJob>("reliability-committed-intent-dispatch", job => job.ExecuteAsync(CancellationToken.None), Cron.Minutely);
         RecurringJob.AddOrUpdate<IExpiredPhotoUploadCleanupJob>("reporting-expired-photo-upload-cleanup", job => job.ExecuteAsync(CancellationToken.None), Cron.Minutely);
         RecurringJob.AddOrUpdate<IRecurringReportAssignmentProcessingJob>("reporting-recurring-report-assignments", job => job.ExecuteAsync(CancellationToken.None), Cron.Minutely);
+        RecurringJob.AddOrUpdate<IStalePushInstallationCleanupJob>("push-stale-installation-cleanup", job => job.ExecuteAsync(CancellationToken.None), Cron.Daily(3));
     }
 }

--- a/LgymApi.Api/appsettings.json
+++ b/LgymApi.Api/appsettings.json
@@ -48,6 +48,20 @@
     "DevMaxUploadsPerDay": 200,
     "DevMaxUploadInitPerUserPerHour": 50
   },
+  "PushNotifications": {
+    "Enabled": false,
+    "SendEnabled": false,
+    "RetryDelaysSeconds": [ 30, 120, 600 ],
+    "StaleTokenCleanupEnabled": true,
+    "StaleTokenInactivityDays": 45,
+    "StaleTokenCleanupBatchSize": 500,
+    "Fcm": {
+      "ProjectId": "YOUR_FIREBASE_PROJECT_ID",
+      "CredentialsPath": "",
+      "CredentialsJson": "",
+      "BaseUrl": "https://fcm.googleapis.com"
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/LgymApi.Application/LgymApi.Application.md
+++ b/LgymApi.Application/LgymApi.Application.md
@@ -9,3 +9,8 @@
 - Enum lookups are the source of truth for front-end choice lists; `ExerciseEloFormula` is exposed through the enum lookup service and should not be duplicated as a hardcoded UI list.
 - Enum lookup entries should carry a stable enum-string `id`; `name` and `displayName` should both be translated display text. Front-end choice lists should bind to the lookup `id`.
 - Application input records for lookup-backed exercise forms should receive already-normalized enum values from API mapping profiles; do not parse lookup ids inside application services.
+- Push installation registration lives in `UserService` and binds installation records to the authenticated user plus current `UserSession`; logout revokes the session and disassociates any installations attached to that session in the same unit of work.
+- Generic push enqueueing lives in `Notifications/PushNotificationService`; it creates installation-scoped durable push intents from privacy-safe payload contracts and enforces per-installation `(type,eventId)` idempotency before any background send occurs.
+- `Notifications/InAppNotificationService` is the shared fanout point after a notification is durably saved: it publishes the existing SignalR in-app update and also enqueues a privacy-safe push event with the saved `InAppNotification` id plus `RedirectUrl` as the push deeplink.
+- `Notifications/NotificationEventBridge` is the internal seam for backend event producers and the in-app fanout path; it forwards generic push events with IDs only and links the existing `InAppNotification` id for mobile lookup/routing.
+- `Notifications/StalePushInstallationCleanupService` tombstones inactive installations by `LastSeenAt` and preserves installation/message audit history instead of deleting old rows.

--- a/LgymApi.Application/Notifications/IInAppNotificationServiceDependencies.cs
+++ b/LgymApi.Application/Notifications/IInAppNotificationServiceDependencies.cs
@@ -7,6 +7,7 @@ public interface IInAppNotificationServiceDependencies
     IInAppNotificationRepository InAppNotificationRepository { get; }
     IUnitOfWork UnitOfWork { get; }
     IInAppNotificationPushPublisher PushPublisher { get; }
+    INotificationEventBridge NotificationEventBridge { get; }
 }
 
 internal sealed record InAppNotificationServiceDependencies : IInAppNotificationServiceDependencies
@@ -14,11 +15,17 @@ internal sealed record InAppNotificationServiceDependencies : IInAppNotification
     public IInAppNotificationRepository InAppNotificationRepository { get; }
     public IUnitOfWork UnitOfWork { get; }
     public IInAppNotificationPushPublisher PushPublisher { get; }
+    public INotificationEventBridge NotificationEventBridge { get; }
 
-    public InAppNotificationServiceDependencies(IInAppNotificationRepository inAppNotificationRepository, IUnitOfWork unitOfWork, IInAppNotificationPushPublisher pushPublisher)
+    public InAppNotificationServiceDependencies(
+        IInAppNotificationRepository inAppNotificationRepository,
+        IUnitOfWork unitOfWork,
+        IInAppNotificationPushPublisher pushPublisher,
+        INotificationEventBridge notificationEventBridge)
     {
         InAppNotificationRepository = inAppNotificationRepository;
         UnitOfWork = unitOfWork;
         PushPublisher = pushPublisher;
+        NotificationEventBridge = notificationEventBridge;
     }
 }

--- a/LgymApi.Application/Notifications/INotificationEventBridge.cs
+++ b/LgymApi.Application/Notifications/INotificationEventBridge.cs
@@ -1,0 +1,8 @@
+using LgymApi.Application.Notifications.Models;
+
+namespace LgymApi.Application.Notifications;
+
+public interface INotificationEventBridge
+{
+    Task EnqueueAsync(EnqueueNotificationEventInput input, CancellationToken cancellationToken = default);
+}

--- a/LgymApi.Application/Notifications/IPushNotificationService.cs
+++ b/LgymApi.Application/Notifications/IPushNotificationService.cs
@@ -1,0 +1,8 @@
+using LgymApi.Application.Notifications.Models;
+
+namespace LgymApi.Application.Notifications;
+
+public interface IPushNotificationService
+{
+    Task EnqueueAsync(EnqueuePushNotificationInput input, CancellationToken cancellationToken = default);
+}

--- a/LgymApi.Application/Notifications/IStalePushInstallationCleanupService.cs
+++ b/LgymApi.Application/Notifications/IStalePushInstallationCleanupService.cs
@@ -1,0 +1,6 @@
+namespace LgymApi.Application.Notifications;
+
+public interface IStalePushInstallationCleanupService
+{
+    Task<int> CleanupAsync(CancellationToken cancellationToken = default);
+}

--- a/LgymApi.Application/Notifications/IStalePushInstallationCleanupSettings.cs
+++ b/LgymApi.Application/Notifications/IStalePushInstallationCleanupSettings.cs
@@ -1,0 +1,8 @@
+namespace LgymApi.Application.Notifications;
+
+public interface IStalePushInstallationCleanupSettings
+{
+    bool Enabled { get; }
+    int InactivityDays { get; }
+    int BatchSize { get; }
+}

--- a/LgymApi.Application/Notifications/InAppNotificationService.cs
+++ b/LgymApi.Application/Notifications/InAppNotificationService.cs
@@ -11,6 +11,8 @@ namespace LgymApi.Application.Notifications;
 
 public sealed class InAppNotificationService : IInAppNotificationService
 {
+    private const int PushSchemaVersion = 1;
+
     private readonly IInAppNotificationServiceDependencies _deps;
     private readonly ILogger<InAppNotificationService> _logger;
 
@@ -22,6 +24,7 @@ public sealed class InAppNotificationService : IInAppNotificationService
 
     public async Task<Result<InAppNotificationResult, AppError>> CreateAsync(CreateInAppNotificationInput input, CancellationToken cancellationToken = default)
     {
+        var isNewNotification = true;
         var notification = new InAppNotification
         {
             Id = Id<InAppNotification>.New(),
@@ -37,31 +40,48 @@ public sealed class InAppNotificationService : IInAppNotificationService
 
         await _deps.InAppNotificationRepository.AddAsync(notification, cancellationToken);
 
+        InAppNotificationResult result;
         try
         {
             await _deps.UnitOfWork.SaveChangesAsync(cancellationToken);
+            result = MapToResult(notification);
         }
         catch (Exception ex)
         {
             var existingResult = await TryResolveDuplicateDeliveryAsync(input, notification, ex, cancellationToken);
             if (existingResult != null)
             {
-                return Result<InAppNotificationResult, AppError>.Success(existingResult);
+                result = existingResult;
+                isNewNotification = false;
             }
-
-            throw;
+            else
+            {
+                throw;
+            }
         }
 
-        var result = MapToResult(notification);
-
-        try
+        if (isNewNotification)
         {
-            await _deps.PushPublisher.PushAsync(result, cancellationToken);
+            try
+            {
+                await _deps.PushPublisher.PushAsync(result, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to push notification for recipient {RecipientId}", input.RecipientId);
+            }
         }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to push notification for recipient {RecipientId}", input.RecipientId);
-        }
+
+        await _deps.NotificationEventBridge.EnqueueAsync(
+            new EnqueueNotificationEventInput(
+                result.RecipientId,
+                PushSchemaVersion,
+                result.Type.Value,
+                result.Id.ToString(),
+                null,
+                result.Id,
+                result.RedirectUrl),
+            cancellationToken);
 
         return Result<InAppNotificationResult, AppError>.Success(result);
     }

--- a/LgymApi.Application/Notifications/Models/EnqueueNotificationEventInput.cs
+++ b/LgymApi.Application/Notifications/Models/EnqueueNotificationEventInput.cs
@@ -7,7 +7,7 @@ public sealed record EnqueueNotificationEventInput(
     Id<User> UserId,
     int SchemaVersion,
     string Type,
-    string EventId,
-    string? EntityId,
+    string EventKey,
+    string? EntityKey,
     Id<InAppNotification>? InAppNotificationId,
     string? Deeplink);

--- a/LgymApi.Application/Notifications/Models/EnqueueNotificationEventInput.cs
+++ b/LgymApi.Application/Notifications/Models/EnqueueNotificationEventInput.cs
@@ -1,0 +1,13 @@
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.Application.Notifications.Models;
+
+public sealed record EnqueueNotificationEventInput(
+    Id<User> UserId,
+    int SchemaVersion,
+    string Type,
+    string EventId,
+    string? EntityId,
+    Id<InAppNotification>? InAppNotificationId,
+    string? Deeplink);

--- a/LgymApi.Application/Notifications/Models/EnqueuePushNotificationInput.cs
+++ b/LgymApi.Application/Notifications/Models/EnqueuePushNotificationInput.cs
@@ -1,0 +1,13 @@
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.Application.Notifications.Models;
+
+public sealed record EnqueuePushNotificationInput(
+    Id<User> UserId,
+    int SchemaVersion,
+    string Type,
+    string EventId,
+    string? EntityId,
+    Id<InAppNotification>? InAppNotificationId,
+    string? Deeplink);

--- a/LgymApi.Application/Notifications/Models/EnqueuePushNotificationInput.cs
+++ b/LgymApi.Application/Notifications/Models/EnqueuePushNotificationInput.cs
@@ -7,7 +7,7 @@ public sealed record EnqueuePushNotificationInput(
     Id<User> UserId,
     int SchemaVersion,
     string Type,
-    string EventId,
-    string? EntityId,
+    string EventKey,
+    string? EntityKey,
     Id<InAppNotification>? InAppNotificationId,
     string? Deeplink);

--- a/LgymApi.Application/Notifications/NotificationEventBridge.cs
+++ b/LgymApi.Application/Notifications/NotificationEventBridge.cs
@@ -1,0 +1,27 @@
+using LgymApi.Application.Notifications.Models;
+
+namespace LgymApi.Application.Notifications;
+
+public sealed class NotificationEventBridge : INotificationEventBridge
+{
+    private readonly IPushNotificationService _pushNotificationService;
+
+    public NotificationEventBridge(IPushNotificationService pushNotificationService)
+    {
+        _pushNotificationService = pushNotificationService;
+    }
+
+    public Task EnqueueAsync(EnqueueNotificationEventInput input, CancellationToken cancellationToken = default)
+    {
+        return _pushNotificationService.EnqueueAsync(
+            new EnqueuePushNotificationInput(
+                input.UserId,
+                input.SchemaVersion,
+                input.Type,
+                input.EventId,
+                input.EntityId,
+                input.InAppNotificationId,
+                input.Deeplink),
+            cancellationToken);
+    }
+}

--- a/LgymApi.Application/Notifications/NotificationEventBridge.cs
+++ b/LgymApi.Application/Notifications/NotificationEventBridge.cs
@@ -18,8 +18,8 @@ public sealed class NotificationEventBridge : INotificationEventBridge
                 input.UserId,
                 input.SchemaVersion,
                 input.Type,
-                input.EventId,
-                input.EntityId,
+                input.EventKey,
+                input.EntityKey,
                 input.InAppNotificationId,
                 input.Deeplink),
             cancellationToken);

--- a/LgymApi.Application/Notifications/PushNotificationService.cs
+++ b/LgymApi.Application/Notifications/PushNotificationService.cs
@@ -43,7 +43,7 @@ public sealed class PushNotificationService : IPushNotificationService
     public async Task EnqueueAsync(EnqueuePushNotificationInput input, CancellationToken cancellationToken = default)
     {
         var normalizedType = NormalizeRequired(input.Type);
-        var normalizedEventId = NormalizeRequired(input.EventId);
+        var normalizedEventId = NormalizeRequired(input.EventKey);
         if (normalizedType == null || normalizedEventId == null || input.SchemaVersion <= 0)
         {
             throw new InvalidOperationException("Push notification input is missing required values.");
@@ -99,7 +99,7 @@ public sealed class PushNotificationService : IPushNotificationService
                 input.SchemaVersion,
                 normalizedType,
                 normalizedEventId,
-                NormalizeOptional(input.EntityId),
+                NormalizeOptional(input.EntityKey),
                 input.InAppNotificationId?.ToString(),
                 NormalizeOptional(input.Deeplink));
 

--- a/LgymApi.Application/Notifications/PushNotificationService.cs
+++ b/LgymApi.Application/Notifications/PushNotificationService.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using LgymApi.Application.Notifications.Models;
+using LgymApi.Application.Repositories;
+using LgymApi.BackgroundWorker.Common.Push;
+using LgymApi.BackgroundWorker.Common.Push.Models;
+using LgymApi.BackgroundWorker.Common.Serialization;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.Enums;
+using LgymApi.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
+
+namespace LgymApi.Application.Notifications;
+
+public sealed class PushNotificationService : IPushNotificationService
+{
+    private static readonly HashSet<string> SkippedPermissionStatuses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "denied",
+        "blocked",
+        "disabled"
+    };
+
+    private readonly IPushInstallationRepository _pushInstallationRepository;
+    private readonly IPushNotificationMessageRepository _pushNotificationMessageRepository;
+    private readonly IPushBackgroundScheduler _pushBackgroundScheduler;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<PushNotificationService> _logger;
+
+    public PushNotificationService(
+        IPushInstallationRepository pushInstallationRepository,
+        IPushNotificationMessageRepository pushNotificationMessageRepository,
+        IPushBackgroundScheduler pushBackgroundScheduler,
+        IUnitOfWork unitOfWork,
+        ILogger<PushNotificationService> logger)
+    {
+        _pushInstallationRepository = pushInstallationRepository;
+        _pushNotificationMessageRepository = pushNotificationMessageRepository;
+        _pushBackgroundScheduler = pushBackgroundScheduler;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task EnqueueAsync(EnqueuePushNotificationInput input, CancellationToken cancellationToken = default)
+    {
+        var normalizedType = NormalizeRequired(input.Type);
+        var normalizedEventId = NormalizeRequired(input.EventId);
+        if (normalizedType == null || normalizedEventId == null || input.SchemaVersion <= 0)
+        {
+            throw new InvalidOperationException("Push notification input is missing required values.");
+        }
+
+        var installations = await _pushInstallationRepository.GetActiveByUserIdAsync(input.UserId, cancellationToken);
+        if (installations.Count == 0)
+        {
+            _logger.LogInformation(
+                "Skipping push enqueue for user {UserId}, event {EventId}, category {Category}; no active installations.",
+                input.UserId,
+                normalizedEventId,
+                normalizedType);
+            return;
+        }
+
+        var scheduleCandidates = new List<(PushNotificationMessage Message, PushInstallation Installation)>();
+        var hasStagedMessages = false;
+        foreach (var installation in installations)
+        {
+            var existing = await _pushNotificationMessageRepository.FindByDeliveryKeyAsync(
+                installation.Id,
+                normalizedType,
+                normalizedEventId,
+                cancellationToken);
+
+            if (existing != null)
+            {
+                if (ShouldScheduleExisting(existing))
+                {
+                    scheduleCandidates.Add((existing, installation));
+                    _logger.LogInformation(
+                        "Found existing unscheduled push notification {NotificationId} for installation {InstallationId}, event {EventId}, category {Category}; scheduling existing message.",
+                        existing.Id,
+                        installation.InstallationId,
+                        normalizedEventId,
+                        normalizedType);
+                }
+                else
+                {
+                    _logger.LogInformation(
+                        "Found existing push notification {NotificationId} for installation {InstallationId}, event {EventId}, category {Category}; skipping duplicate enqueue.",
+                        existing.Id,
+                        installation.InstallationId,
+                        normalizedEventId,
+                        normalizedType);
+                }
+
+                continue;
+            }
+
+            var payload = new PushEventPayload(
+                input.SchemaVersion,
+                normalizedType,
+                normalizedEventId,
+                NormalizeOptional(input.EntityId),
+                input.InAppNotificationId?.ToString(),
+                NormalizeOptional(input.Deeplink));
+
+            var message = new PushNotificationMessage
+            {
+                Id = Id<PushNotificationMessage>.New(),
+                UserId = input.UserId,
+                PushInstallationId = installation.Id,
+                SchemaVersion = payload.SchemaVersion,
+                Type = payload.Type,
+                EventId = payload.EventId,
+                EntityId = payload.EntityId,
+                InAppNotificationId = input.InAppNotificationId,
+                Deeplink = payload.Deeplink,
+                PayloadJson = JsonSerializer.Serialize(payload, SharedSerializationOptions.Current)
+            };
+
+            if (ShouldSkipForPreference(installation))
+            {
+                message.Status = PushNotificationStatus.Skipped;
+                message.FailureKind = PushNotificationFailureKind.Preference;
+                message.ProviderStatus = "Skipped";
+                message.ProviderResponseSummary = $"Permission status '{installation.PermissionStatus}' is not eligible for push delivery.";
+                _logger.LogInformation(
+                    "Skipping push delivery for installation {InstallationId}, event {EventId}, category {Category} because permission status is {PermissionStatus}.",
+                    installation.InstallationId,
+                    normalizedEventId,
+                    normalizedType,
+                    installation.PermissionStatus);
+            }
+            else
+            {
+                scheduleCandidates.Add((message, installation));
+            }
+
+            await _pushNotificationMessageRepository.AddAsync(message, cancellationToken);
+            hasStagedMessages = true;
+        }
+
+        if (hasStagedMessages)
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+        }
+
+        foreach (var (message, installation) in scheduleCandidates)
+        {
+            message.SchedulerJobId = Schedule(message);
+            _logger.LogInformation(
+                "Queued push notification {NotificationId} for installation {InstallationId}, event {EventId}, category {Category}.",
+                message.Id,
+                installation.InstallationId,
+                message.EventId,
+                message.Type);
+        }
+
+        if (scheduleCandidates.Count > 0)
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private static bool ShouldSkipForPreference(PushInstallation installation)
+    {
+        return installation.PermissionStatus != null
+            && SkippedPermissionStatuses.Contains(installation.PermissionStatus.Trim());
+    }
+
+    private static bool ShouldScheduleExisting(PushNotificationMessage message)
+    {
+        return string.IsNullOrWhiteSpace(message.SchedulerJobId)
+            && (message.Status == PushNotificationStatus.Pending
+                || (message.Status == PushNotificationStatus.Failed && message.FailureKind == PushNotificationFailureKind.Transient));
+    }
+
+    private string? Schedule(PushNotificationMessage message)
+    {
+        if (message.Status == PushNotificationStatus.Failed
+            && message.FailureKind == PushNotificationFailureKind.Transient
+            && message.NextAttemptAt is { } nextAttemptAt
+            && nextAttemptAt > DateTimeOffset.UtcNow)
+        {
+            return _pushBackgroundScheduler.ScheduleRetry(message.Id, nextAttemptAt - DateTimeOffset.UtcNow);
+        }
+
+        return _pushBackgroundScheduler.Enqueue(message.Id);
+    }
+
+    private static string? NormalizeRequired(string? value)
+    {
+        var normalized = NormalizeOptional(value);
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+}

--- a/LgymApi.Application/Notifications/StalePushInstallationCleanupService.cs
+++ b/LgymApi.Application/Notifications/StalePushInstallationCleanupService.cs
@@ -1,0 +1,64 @@
+using LgymApi.Application.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace LgymApi.Application.Notifications;
+
+public sealed class StalePushInstallationCleanupService : IStalePushInstallationCleanupService
+{
+    internal const string StaleInstallationDisabledReason = "InactiveStale";
+
+    private readonly IPushInstallationRepository _pushInstallationRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IStalePushInstallationCleanupSettings _settings;
+    private readonly ILogger<StalePushInstallationCleanupService> _logger;
+
+    public StalePushInstallationCleanupService(
+        IPushInstallationRepository pushInstallationRepository,
+        IUnitOfWork unitOfWork,
+        IStalePushInstallationCleanupSettings settings,
+        ILogger<StalePushInstallationCleanupService> logger)
+    {
+        _pushInstallationRepository = pushInstallationRepository;
+        _unitOfWork = unitOfWork;
+        _settings = settings;
+        _logger = logger;
+    }
+
+    public async Task<int> CleanupAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_settings.Enabled)
+        {
+            _logger.LogInformation("Push stale-installation cleanup skipped because the cleanup flag is disabled.");
+            return 0;
+        }
+
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-_settings.InactivityDays);
+        var staleInstallations = await _pushInstallationRepository.GetStaleActiveAsync(
+            cutoff,
+            _settings.BatchSize,
+            cancellationToken);
+
+        foreach (var installation in staleInstallations)
+        {
+            installation.DisabledAt = DateTimeOffset.UtcNow;
+            installation.DisabledReason = StaleInstallationDisabledReason;
+            await _pushInstallationRepository.UpdateAsync(installation, cancellationToken);
+        }
+
+        if (staleInstallations.Count == 0)
+        {
+            _logger.LogInformation(
+                "Push stale-installation cleanup found no candidates before cutoff {CutoffUtc}.",
+                cutoff);
+            return 0;
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation(
+            "Push stale-installation cleanup disabled {InstallationCount} installations before cutoff {CutoffUtc}.",
+            staleInstallations.Count,
+            cutoff);
+
+        return staleInstallations.Count;
+    }
+}

--- a/LgymApi.Application/Repositories/IPushInstallationRepository.cs
+++ b/LgymApi.Application/Repositories/IPushInstallationRepository.cs
@@ -1,0 +1,16 @@
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.Application.Repositories;
+
+public interface IPushInstallationRepository
+{
+    Task<PushInstallation?> FindByIdAsync(Id<PushInstallation> id, CancellationToken cancellationToken = default);
+    Task<PushInstallation?> FindByInstallationIdAsync(string installationId, CancellationToken cancellationToken = default);
+    Task<PushInstallation?> FindBoundToUserOrSessionAsync(string installationId, Id<User> userId, Id<UserSession> sessionId, CancellationToken cancellationToken = default);
+    Task<List<PushInstallation>> GetActiveByUserIdAsync(Id<User> userId, CancellationToken cancellationToken = default);
+    Task<List<PushInstallation>> GetBySessionIdAsync(Id<UserSession> sessionId, CancellationToken cancellationToken = default);
+    Task<List<PushInstallation>> GetStaleActiveAsync(DateTimeOffset lastSeenBefore, int limit, CancellationToken cancellationToken = default);
+    Task AddAsync(PushInstallation installation, CancellationToken cancellationToken = default);
+    Task UpdateAsync(PushInstallation installation, CancellationToken cancellationToken = default);
+}

--- a/LgymApi.Application/Repositories/IPushNotificationMessageRepository.cs
+++ b/LgymApi.Application/Repositories/IPushNotificationMessageRepository.cs
@@ -1,0 +1,15 @@
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.Enums;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.Application.Repositories;
+
+public interface IPushNotificationMessageRepository
+{
+    Task AddAsync(PushNotificationMessage message, CancellationToken cancellationToken = default);
+    Task<PushNotificationMessage?> FindByIdAsync(Id<PushNotificationMessage> id, CancellationToken cancellationToken = default);
+    Task<PushNotificationMessage?> FindByDeliveryKeyAsync(Id<PushInstallation> installationId, string type, string eventId, CancellationToken cancellationToken = default);
+    Task<bool> TryTransitionToSendingAsync(Id<PushNotificationMessage> id, CancellationToken cancellationToken = default);
+    Task UpdateAsync(PushNotificationMessage message, CancellationToken cancellationToken = default);
+    Task<List<PushNotificationMessage>> GetByStatusAsync(PushNotificationStatus status, CancellationToken cancellationToken = default);
+}

--- a/LgymApi.Application/ServiceCollectionExtensions.cs
+++ b/LgymApi.Application/ServiceCollectionExtensions.cs
@@ -48,6 +48,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IMeasurementsService, MeasurementsService>();
         services.AddScoped<IInAppNotificationServiceDependencies, InAppNotificationServiceDependencies>();
         services.AddScoped<IInAppNotificationService, InAppNotificationService>();
+        services.AddScoped<IPushNotificationService, PushNotificationService>();
+        services.AddScoped<IStalePushInstallationCleanupService, StalePushInstallationCleanupService>();
+        services.AddScoped<INotificationEventBridge, NotificationEventBridge>();
         services.AddScoped<PasswordResetServiceDependencies>();
         services.AddScoped<IPasswordResetTokenGenerationService, PasswordResetTokenGenerationService>();
         services.AddScoped<IPasswordResetService, PasswordResetService>();

--- a/LgymApi.Application/User/IUserService.cs
+++ b/LgymApi.Application/User/IUserService.cs
@@ -11,6 +11,9 @@ public interface IUserService
 {
     Task<Result<Unit, AppError>> RegisterAsync(RegisterUserInput input, CancellationToken cancellationToken = default);
     Task<Result<Unit, AppError>> RegisterTrainerAsync(RegisterUserInput input, CancellationToken cancellationToken = default);
+    Task<Result<Unit, AppError>> RegisterPushInstallationAsync(UserEntity? currentUser, Id<UserSessionEntity>? sessionId, RegisterPushInstallationInput input, CancellationToken cancellationToken = default);
+    Task<Result<Unit, AppError>> UnregisterPushInstallationAsync(UserEntity? currentUser, Id<UserSessionEntity>? sessionId, PushInstallationActionInput input, CancellationToken cancellationToken = default);
+    Task<Result<Unit, AppError>> DisassociatePushInstallationAsync(UserEntity? currentUser, Id<UserSessionEntity>? sessionId, PushInstallationActionInput input, CancellationToken cancellationToken = default);
     Task<Result<LoginResult, AppError>> LoginAsync(string name, string password, CancellationToken cancellationToken = default);
     Task<Result<LoginResult, AppError>> LoginTrainerAsync(string name, string password, CancellationToken cancellationToken = default);
     Task<bool> IsAdminAsync(Id<UserEntity> userId, CancellationToken cancellationToken = default);

--- a/LgymApi.Application/User/IUserServiceDependencies.cs
+++ b/LgymApi.Application/User/IUserServiceDependencies.cs
@@ -9,6 +9,7 @@ namespace LgymApi.Application.Features.User;
 
 public interface IUserServiceDependencies
 {
+    IPushInstallationRepository PushInstallationRepository { get; }
     IUserRepository UserRepository { get; }
     IRoleRepository RoleRepository { get; }
     IEloRegistryRepository EloRepository { get; }
@@ -26,6 +27,7 @@ public interface IUserServiceDependencies
 internal sealed class UserServiceDependencies : IUserServiceDependencies
 {
     public UserServiceDependencies(
+        IPushInstallationRepository pushInstallationRepository,
         IUserRepository userRepository,
         IRoleRepository roleRepository,
         IEloRegistryRepository eloRepository,
@@ -39,6 +41,7 @@ internal sealed class UserServiceDependencies : IUserServiceDependencies
         AppDefaultsOptions appDefaultsOptions,
         ITutorialService tutorialService)
     {
+        PushInstallationRepository = pushInstallationRepository;
         UserRepository = userRepository;
         RoleRepository = roleRepository;
         EloRepository = eloRepository;
@@ -53,6 +56,7 @@ internal sealed class UserServiceDependencies : IUserServiceDependencies
         TutorialService = tutorialService;
     }
 
+    public IPushInstallationRepository PushInstallationRepository { get; }
     public IUserRepository UserRepository { get; }
     public IRoleRepository RoleRepository { get; }
     public IEloRegistryRepository EloRepository { get; }

--- a/LgymApi.Application/User/IUserServiceDependencies.cs
+++ b/LgymApi.Application/User/IUserServiceDependencies.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using LgymApi.Application.Options;
 using LgymApi.Application.Repositories;
 using LgymApi.Application.Services;
@@ -26,6 +27,8 @@ public interface IUserServiceDependencies
 
 internal sealed class UserServiceDependencies : IUserServiceDependencies
 {
+    [SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "This type is the existing DI aggregate for UserService dependencies.")]
+    [SuppressMessage("Major Code Smell", "S6672:Generic logger injection should match the enclosing type", Justification = "The aggregate forwards the logger to UserService, which is the actual logging category.")]
     public UserServiceDependencies(
         IPushInstallationRepository pushInstallationRepository,
         IUserRepository userRepository,

--- a/LgymApi.Application/User/Models/PushInstallationInputs.cs
+++ b/LgymApi.Application/User/Models/PushInstallationInputs.cs
@@ -1,0 +1,11 @@
+namespace LgymApi.Application.Features.User.Models;
+
+public sealed record RegisterPushInstallationInput(
+    string InstallationId,
+    string Platform,
+    string FcmToken,
+    string? AppVersion,
+    string Environment,
+    string? PermissionStatus);
+
+public sealed record PushInstallationActionInput(string InstallationId);

--- a/LgymApi.Application/User/Models/PushInstallationInputs.cs
+++ b/LgymApi.Application/User/Models/PushInstallationInputs.cs
@@ -1,11 +1,11 @@
 namespace LgymApi.Application.Features.User.Models;
 
 public sealed record RegisterPushInstallationInput(
-    string InstallationId,
+    string InstallationKey,
     string Platform,
     string FcmToken,
     string? AppVersion,
     string Environment,
     string? PermissionStatus);
 
-public sealed record PushInstallationActionInput(string InstallationId);
+public sealed record PushInstallationActionInput(string InstallationKey);

--- a/LgymApi.Application/User/UserService.Profile.cs
+++ b/LgymApi.Application/User/UserService.Profile.cs
@@ -85,6 +85,7 @@ public sealed partial class UserService : IUserService
         if (sessionId.HasValue)
         {
             await _userSessionStore.RevokeSessionAsync(sessionId.Value, cancellationToken);
+            await DisassociateInstallationsForSessionAsync(sessionId.Value, cancellationToken);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
         }
 

--- a/LgymApi.Application/User/UserService.PushInstallations.cs
+++ b/LgymApi.Application/User/UserService.PushInstallations.cs
@@ -24,7 +24,7 @@ public sealed partial class UserService : IUserService
             return Result<Unit, AppError>.Failure(new UserUnauthorizedError(Messages.Unauthorized));
         }
 
-        var normalizedInstallationId = NormalizeRequiredValue(input.InstallationId);
+        var normalizedInstallationId = NormalizeRequiredValue(input.InstallationKey);
         var normalizedPlatform = NormalizeRequiredValue(input.Platform);
         var normalizedToken = NormalizeRequiredValue(input.FcmToken);
         var normalizedEnvironment = NormalizeRequiredValue(input.Environment);
@@ -131,7 +131,7 @@ public sealed partial class UserService : IUserService
             return Result<PushInstallation?, AppError>.Failure(new UserUnauthorizedError(Messages.Unauthorized));
         }
 
-        var normalizedInstallationId = NormalizeRequiredValue(input.InstallationId);
+        var normalizedInstallationId = NormalizeRequiredValue(input.InstallationKey);
         if (normalizedInstallationId == null)
         {
             return Result<PushInstallation?, AppError>.Failure(new InvalidUserError(Messages.FieldRequired));

--- a/LgymApi.Application/User/UserService.PushInstallations.cs
+++ b/LgymApi.Application/User/UserService.PushInstallations.cs
@@ -1,0 +1,175 @@
+using LgymApi.Application.Common.Errors;
+using LgymApi.Application.Common.Results;
+using LgymApi.Application.Features.User.Models;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.Resources;
+using UserEntity = LgymApi.Domain.Entities.User;
+using UserSessionEntity = LgymApi.Domain.Entities.UserSession;
+
+namespace LgymApi.Application.Features.User;
+
+public sealed partial class UserService : IUserService
+{
+    private const string UnregisteredDisabledReason = "Unregistered";
+
+    public async Task<Result<Unit, AppError>> RegisterPushInstallationAsync(
+        UserEntity? currentUser,
+        Id<UserSessionEntity>? sessionId,
+        RegisterPushInstallationInput input,
+        CancellationToken cancellationToken = default)
+    {
+        if (currentUser == null || !sessionId.HasValue)
+        {
+            return Result<Unit, AppError>.Failure(new UserUnauthorizedError(Messages.Unauthorized));
+        }
+
+        var normalizedInstallationId = NormalizeRequiredValue(input.InstallationId);
+        var normalizedPlatform = NormalizeRequiredValue(input.Platform);
+        var normalizedToken = NormalizeRequiredValue(input.FcmToken);
+        var normalizedEnvironment = NormalizeRequiredValue(input.Environment);
+
+        if (normalizedInstallationId == null
+            || normalizedPlatform == null
+            || normalizedToken == null
+            || normalizedEnvironment == null)
+        {
+            return Result<Unit, AppError>.Failure(new InvalidUserError(Messages.FieldRequired));
+        }
+
+        var installation = await _pushInstallationRepository.FindByInstallationIdAsync(normalizedInstallationId, cancellationToken);
+        var isNewInstallation = installation == null;
+        if (installation == null)
+        {
+            installation = new PushInstallation
+            {
+                Id = Id<PushInstallation>.New(),
+                InstallationId = normalizedInstallationId
+            };
+
+            await _pushInstallationRepository.AddAsync(installation, cancellationToken);
+        }
+
+        installation.UserId = currentUser.Id;
+        installation.SessionId = sessionId.Value;
+        installation.InstallationId = normalizedInstallationId;
+        installation.Platform = normalizedPlatform;
+        installation.FcmToken = normalizedToken;
+        installation.AppVersion = NormalizeOptionalValue(input.AppVersion);
+        installation.Environment = normalizedEnvironment;
+        installation.PermissionStatus = NormalizeOptionalValue(input.PermissionStatus);
+        installation.LastSeenAt = DateTimeOffset.UtcNow;
+        installation.DisabledAt = null;
+        installation.DisabledReason = null;
+
+        if (!isNewInstallation)
+        {
+            await _pushInstallationRepository.UpdateAsync(installation, cancellationToken);
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result<Unit, AppError>.Success(Unit.Value);
+    }
+
+    public async Task<Result<Unit, AppError>> UnregisterPushInstallationAsync(
+        UserEntity? currentUser,
+        Id<UserSessionEntity>? sessionId,
+        PushInstallationActionInput input,
+        CancellationToken cancellationToken = default)
+    {
+        var installation = await GetBoundInstallationAsync(currentUser, sessionId, input, cancellationToken);
+        if (installation.IsFailure)
+        {
+            return Result<Unit, AppError>.Failure(installation.Error);
+        }
+
+        if (installation.Value == null)
+        {
+            return Result<Unit, AppError>.Success(Unit.Value);
+        }
+
+        installation.Value.DisabledAt = DateTimeOffset.UtcNow;
+        installation.Value.DisabledReason = UnregisteredDisabledReason;
+        installation.Value.LastSeenAt = DateTimeOffset.UtcNow;
+
+        await _pushInstallationRepository.UpdateAsync(installation.Value, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result<Unit, AppError>.Success(Unit.Value);
+    }
+
+    public async Task<Result<Unit, AppError>> DisassociatePushInstallationAsync(
+        UserEntity? currentUser,
+        Id<UserSessionEntity>? sessionId,
+        PushInstallationActionInput input,
+        CancellationToken cancellationToken = default)
+    {
+        var installation = await GetBoundInstallationAsync(currentUser, sessionId, input, cancellationToken);
+        if (installation.IsFailure)
+        {
+            return Result<Unit, AppError>.Failure(installation.Error);
+        }
+
+        if (installation.Value == null)
+        {
+            return Result<Unit, AppError>.Success(Unit.Value);
+        }
+
+        DisassociateInstallation(installation.Value);
+        await _pushInstallationRepository.UpdateAsync(installation.Value, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result<Unit, AppError>.Success(Unit.Value);
+    }
+
+    private async Task<Result<PushInstallation?, AppError>> GetBoundInstallationAsync(
+        UserEntity? currentUser,
+        Id<UserSessionEntity>? sessionId,
+        PushInstallationActionInput input,
+        CancellationToken cancellationToken)
+    {
+        if (currentUser == null || !sessionId.HasValue)
+        {
+            return Result<PushInstallation?, AppError>.Failure(new UserUnauthorizedError(Messages.Unauthorized));
+        }
+
+        var normalizedInstallationId = NormalizeRequiredValue(input.InstallationId);
+        if (normalizedInstallationId == null)
+        {
+            return Result<PushInstallation?, AppError>.Failure(new InvalidUserError(Messages.FieldRequired));
+        }
+
+        var installation = await _pushInstallationRepository.FindBoundToUserOrSessionAsync(
+            normalizedInstallationId,
+            currentUser.Id,
+            sessionId.Value,
+            cancellationToken);
+
+        return Result<PushInstallation?, AppError>.Success(installation);
+    }
+
+    private async Task DisassociateInstallationsForSessionAsync(Id<UserSessionEntity> sessionId, CancellationToken cancellationToken)
+    {
+        var installations = await _pushInstallationRepository.GetBySessionIdAsync(sessionId, cancellationToken);
+        foreach (var installation in installations)
+        {
+            DisassociateInstallation(installation);
+        }
+    }
+
+    private static void DisassociateInstallation(PushInstallation installation)
+    {
+        installation.UserId = null;
+        installation.SessionId = null;
+        installation.LastSeenAt = DateTimeOffset.UtcNow;
+    }
+
+    private static string? NormalizeRequiredValue(string? value)
+    {
+        var normalized = NormalizeOptionalValue(value);
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static string? NormalizeOptionalValue(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+}

--- a/LgymApi.Application/User/UserService.cs
+++ b/LgymApi.Application/User/UserService.cs
@@ -12,6 +12,7 @@ namespace LgymApi.Application.Features.User;
 
 public sealed partial class UserService : IUserService
 {
+    private readonly IPushInstallationRepository _pushInstallationRepository;
     private readonly IUserRepository _userRepository;
     private readonly IRoleRepository _roleRepository;
     private readonly IEloRegistryRepository _eloRepository;
@@ -27,6 +28,7 @@ public sealed partial class UserService : IUserService
 
     public UserService(IUserServiceDependencies dependencies)
     {
+        _pushInstallationRepository = dependencies.PushInstallationRepository;
         _userRepository = dependencies.UserRepository;
         _roleRepository = dependencies.RoleRepository;
         _eloRepository = dependencies.EloRepository;

--- a/LgymApi.BackgroundWorker.Common/Jobs/IPushNotificationJob.cs
+++ b/LgymApi.BackgroundWorker.Common/Jobs/IPushNotificationJob.cs
@@ -1,0 +1,9 @@
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.BackgroundWorker.Common.Jobs;
+
+public interface IPushNotificationJob
+{
+    Task ExecuteAsync(Id<PushNotificationMessage> notificationId, CancellationToken cancellationToken = default);
+}

--- a/LgymApi.BackgroundWorker.Common/Jobs/IStalePushInstallationCleanupJob.cs
+++ b/LgymApi.BackgroundWorker.Common/Jobs/IStalePushInstallationCleanupJob.cs
@@ -1,0 +1,6 @@
+namespace LgymApi.BackgroundWorker.Common.Jobs;
+
+public interface IStalePushInstallationCleanupJob
+{
+    Task ExecuteAsync(CancellationToken cancellationToken = default);
+}

--- a/LgymApi.BackgroundWorker.Common/LgymApi.BackgroundWorker.Common.md
+++ b/LgymApi.BackgroundWorker.Common/LgymApi.BackgroundWorker.Common.md
@@ -4,3 +4,4 @@
 - Contains: job contracts, serialization helpers, DI abstractions, and notification/job models.
 - Rules: put cross-boundary worker contracts here, not HTTP/controller code.
 - Boundary: keep this module reusable from worker and application sides.
+- Shared push contracts now live here too: the generic payload DTO, provider-sender abstractions, and Hangfire job/scheduler interfaces are worker-safe cross-boundary contracts rather than API-layer types.

--- a/LgymApi.BackgroundWorker.Common/Push/IPushBackgroundScheduler.cs
+++ b/LgymApi.BackgroundWorker.Common/Push/IPushBackgroundScheduler.cs
@@ -1,0 +1,10 @@
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.BackgroundWorker.Common.Push;
+
+public interface IPushBackgroundScheduler
+{
+    string? Enqueue(Id<PushNotificationMessage> notificationId);
+    string? ScheduleRetry(Id<PushNotificationMessage> notificationId, TimeSpan delay);
+}

--- a/LgymApi.BackgroundWorker.Common/Push/IPushProviderSender.cs
+++ b/LgymApi.BackgroundWorker.Common/Push/IPushProviderSender.cs
@@ -1,0 +1,12 @@
+using LgymApi.BackgroundWorker.Common.Push.Models;
+using LgymApi.Domain.Entities;
+
+namespace LgymApi.BackgroundWorker.Common.Push;
+
+public interface IPushProviderSender
+{
+    Task<PushSendAttemptResult> SendAsync(
+        PushInstallation installation,
+        PushEventPayload payload,
+        CancellationToken cancellationToken = default);
+}

--- a/LgymApi.BackgroundWorker.Common/Push/Models/PushEventPayload.cs
+++ b/LgymApi.BackgroundWorker.Common/Push/Models/PushEventPayload.cs
@@ -1,0 +1,9 @@
+namespace LgymApi.BackgroundWorker.Common.Push.Models;
+
+public sealed record PushEventPayload(
+    int SchemaVersion,
+    string Type,
+    string EventId,
+    string? EntityId,
+    string? InAppNotificationId,
+    string? Deeplink);

--- a/LgymApi.BackgroundWorker.Common/Push/Models/PushSendAttemptResult.cs
+++ b/LgymApi.BackgroundWorker.Common/Push/Models/PushSendAttemptResult.cs
@@ -1,0 +1,17 @@
+namespace LgymApi.BackgroundWorker.Common.Push.Models;
+
+public enum PushSendOutcome
+{
+    Sent = 0,
+    TransientFailure = 1,
+    InvalidToken = 2,
+    PermanentFailure = 3,
+    Skipped = 4
+}
+
+public sealed record PushSendAttemptResult(
+    PushSendOutcome Outcome,
+    string ProviderStatus,
+    string? ProviderMessageId,
+    string? ProviderErrorCode,
+    string? ProviderResponseSummary);

--- a/LgymApi.BackgroundWorker/Jobs/PushNotificationJob.cs
+++ b/LgymApi.BackgroundWorker/Jobs/PushNotificationJob.cs
@@ -1,0 +1,23 @@
+using Hangfire;
+using LgymApi.BackgroundWorker.Common.Jobs;
+using LgymApi.BackgroundWorker.Push;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.BackgroundWorker.Jobs;
+
+[AutomaticRetry(Attempts = 0)]
+public sealed class PushNotificationJob : IPushNotificationJob
+{
+    private readonly PushNotificationJobHandlerService _handler;
+
+    public PushNotificationJob(PushNotificationJobHandlerService handler)
+    {
+        _handler = handler;
+    }
+
+    public Task ExecuteAsync(Id<PushNotificationMessage> notificationId, CancellationToken cancellationToken = default)
+    {
+        return _handler.ProcessAsync(notificationId, cancellationToken);
+    }
+}

--- a/LgymApi.BackgroundWorker/Jobs/StalePushInstallationCleanupJob.cs
+++ b/LgymApi.BackgroundWorker/Jobs/StalePushInstallationCleanupJob.cs
@@ -1,0 +1,19 @@
+using LgymApi.Application.Notifications;
+using LgymApi.BackgroundWorker.Common.Jobs;
+
+namespace LgymApi.BackgroundWorker.Jobs;
+
+public sealed class StalePushInstallationCleanupJob : IStalePushInstallationCleanupJob
+{
+    private readonly IStalePushInstallationCleanupService _cleanupService;
+
+    public StalePushInstallationCleanupJob(IStalePushInstallationCleanupService cleanupService)
+    {
+        _cleanupService = cleanupService;
+    }
+
+    public Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        return _cleanupService.CleanupAsync(cancellationToken);
+    }
+}

--- a/LgymApi.BackgroundWorker/LgymApi.BackgroundWorker.md
+++ b/LgymApi.BackgroundWorker/LgymApi.BackgroundWorker.md
@@ -5,3 +5,6 @@
 - Rules: keep jobs idempotent where practical and register worker services in the worker module.
 - Boundary: do not let the worker module become a second composition root for the API.
 - **Background Job Updates**: Added `[DisableConcurrentExecution(60)]` attribute to `EmailJob.ExecuteAsync` to serialize overlapping `EmailJob.ExecuteAsync` executions across worker instances. This reduces concurrent overlap, but exactly-once delivery still relies on the durable notification guard in `EmailJobHandlerService.ProcessAsync` (via `TryTransitionToSendingAsync`) because Hangfire locking is not keyed by `notificationId`.
+- Push delivery uses `PushNotificationJob` plus `PushNotificationJobHandlerService` for claim/send/retry flow; retries are scheduled only after transient provider outcomes, while invalid-token outcomes immediately tombstone the bound installation.
+- Background-created in-app notifications flow through `InAppNotificationService`, so they enqueue durable push intents after persistence in the API composition root. Worker-only test registration uses `NoOpNotificationEventBridge` to keep isolated handler DI tests lightweight.
+- Recurring job `push-stale-installation-cleanup` marks inactive installations with `DisabledReason=InactiveStale`; it is intended as rollout hygiene and should stay enabled even when outbound send delivery is feature-flagged off.

--- a/LgymApi.BackgroundWorker/Push/PushNotificationJobHandlerService.cs
+++ b/LgymApi.BackgroundWorker/Push/PushNotificationJobHandlerService.cs
@@ -1,0 +1,175 @@
+using System.Text.Json;
+using LgymApi.Application.Repositories;
+using LgymApi.BackgroundWorker.Common.Push;
+using LgymApi.BackgroundWorker.Common.Push.Models;
+using LgymApi.BackgroundWorker.Common.Serialization;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.Enums;
+using LgymApi.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
+using LgymApi.Infrastructure.Options;
+
+namespace LgymApi.BackgroundWorker.Push;
+
+public sealed class PushNotificationJobHandlerService
+{
+    private const string InvalidTokenDisabledReason = "InvalidFcmToken";
+
+    private readonly IPushNotificationMessageRepository _pushNotificationMessageRepository;
+    private readonly IPushInstallationRepository _pushInstallationRepository;
+    private readonly IPushProviderSender _pushProviderSender;
+    private readonly IPushBackgroundScheduler _pushBackgroundScheduler;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly PushNotificationOptions _options;
+    private readonly ILogger<PushNotificationJobHandlerService> _logger;
+
+    public PushNotificationJobHandlerService(
+        IPushNotificationMessageRepository pushNotificationMessageRepository,
+        IPushInstallationRepository pushInstallationRepository,
+        IPushProviderSender pushProviderSender,
+        IPushBackgroundScheduler pushBackgroundScheduler,
+        IUnitOfWork unitOfWork,
+        PushNotificationOptions options,
+        ILogger<PushNotificationJobHandlerService> logger)
+    {
+        _pushNotificationMessageRepository = pushNotificationMessageRepository;
+        _pushInstallationRepository = pushInstallationRepository;
+        _pushProviderSender = pushProviderSender;
+        _pushBackgroundScheduler = pushBackgroundScheduler;
+        _unitOfWork = unitOfWork;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task ProcessAsync(Id<PushNotificationMessage> notificationId, CancellationToken cancellationToken = default)
+    {
+        var claimed = await _pushNotificationMessageRepository.TryTransitionToSendingAsync(notificationId, cancellationToken);
+        if (!claimed)
+        {
+            _logger.LogInformation(
+                "Push notification {NotificationId} could not be claimed for sending; skipping duplicate work.",
+                notificationId);
+            return;
+        }
+
+        var message = await _pushNotificationMessageRepository.FindByIdAsync(notificationId, cancellationToken);
+        if (message == null)
+        {
+            _logger.LogWarning("Push notification {NotificationId} was not found after claim.", notificationId);
+            return;
+        }
+
+        var installation = await _pushInstallationRepository.FindByIdAsync(message.PushInstallationId, cancellationToken);
+        if (installation == null)
+        {
+            message.Status = PushNotificationStatus.Failed;
+            message.FailureKind = PushNotificationFailureKind.Permanent;
+            message.ProviderStatus = "InstallationMissing";
+            message.LastError = "Push installation no longer exists.";
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+            return;
+        }
+
+        message.Attempts += 1;
+        var payload = JsonSerializer.Deserialize<PushEventPayload>(message.PayloadJson, SharedSerializationOptions.Current)
+            ?? throw new InvalidOperationException($"Failed to deserialize push payload for notification {notificationId}.");
+
+        var result = await _pushProviderSender.SendAsync(installation, payload, cancellationToken);
+        ApplyProviderResult(message, installation, result);
+        _logger.LogInformation(
+            "Processed push notification {NotificationId} for installation {InstallationId}, event {EventId}, category {Category} with provider status {ProviderStatus} and outcome {Outcome}.",
+            message.Id,
+            installation.InstallationId,
+            message.EventId,
+            message.Type,
+            result.ProviderStatus,
+            result.Outcome);
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        if (result.Outcome == PushSendOutcome.TransientFailure)
+        {
+            ScheduleRetryIfAvailable(message);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private void ApplyProviderResult(PushNotificationMessage message, PushInstallation installation, PushSendAttemptResult result)
+    {
+        message.ProviderStatus = result.ProviderStatus;
+        message.ProviderMessageId = result.ProviderMessageId;
+        message.ProviderErrorCode = result.ProviderErrorCode;
+        message.ProviderResponseSummary = result.ProviderResponseSummary;
+        message.LastError = result.ProviderResponseSummary;
+
+        switch (result.Outcome)
+        {
+            case PushSendOutcome.Sent:
+                message.Status = PushNotificationStatus.Sent;
+                message.FailureKind = PushNotificationFailureKind.None;
+                message.SentAt = DateTimeOffset.UtcNow;
+                message.NextAttemptAt = null;
+                message.LastError = null;
+                break;
+
+            case PushSendOutcome.Skipped:
+                message.Status = PushNotificationStatus.Skipped;
+                message.FailureKind = PushNotificationFailureKind.Preference;
+                message.NextAttemptAt = null;
+                break;
+
+            case PushSendOutcome.InvalidToken:
+                message.Status = PushNotificationStatus.Failed;
+                message.FailureKind = PushNotificationFailureKind.InvalidToken;
+                message.NextAttemptAt = null;
+                installation.DisabledAt = DateTimeOffset.UtcNow;
+                installation.DisabledReason = InvalidTokenDisabledReason;
+                installation.LastSeenAt = DateTimeOffset.UtcNow;
+                break;
+
+            case PushSendOutcome.TransientFailure:
+                message.Status = PushNotificationStatus.Failed;
+                message.FailureKind = PushNotificationFailureKind.Transient;
+                message.NextAttemptAt = ResolveNextAttemptAt(message.Attempts);
+                break;
+
+            default:
+                message.Status = PushNotificationStatus.Failed;
+                message.FailureKind = PushNotificationFailureKind.Permanent;
+                message.NextAttemptAt = null;
+                break;
+        }
+    }
+
+    private void ScheduleRetryIfAvailable(PushNotificationMessage message)
+    {
+        var delay = ResolveRetryDelay(message.Attempts);
+        if (delay == null)
+        {
+            _logger.LogWarning(
+                "Transient push notification {NotificationId} exhausted retry attempts at attempt {Attempt}.",
+                message.Id,
+                message.Attempts);
+            message.NextAttemptAt = null;
+            return;
+        }
+
+        message.SchedulerJobId = _pushBackgroundScheduler.ScheduleRetry(message.Id, delay.Value);
+    }
+
+    private DateTimeOffset? ResolveNextAttemptAt(int attempts)
+    {
+        var delay = ResolveRetryDelay(attempts);
+        return delay == null ? null : DateTimeOffset.UtcNow.Add(delay.Value);
+    }
+
+    private TimeSpan? ResolveRetryDelay(int attempts)
+    {
+        if (attempts <= 0 || attempts > _options.RetryDelaysSeconds.Length)
+        {
+            return null;
+        }
+
+        return TimeSpan.FromSeconds(_options.RetryDelaysSeconds[attempts - 1]);
+    }
+}

--- a/LgymApi.BackgroundWorker/ServiceProvider.cs
+++ b/LgymApi.BackgroundWorker/ServiceProvider.cs
@@ -13,6 +13,7 @@ using LgymApi.Infrastructure.Services;
 using LgymApi.Application.Notifications;
 using LgymApi.BackgroundWorker.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace LgymApi.BackgroundWorker;
 
@@ -40,7 +41,7 @@ public static class ServiceProvider
 
         if (isTesting)
         {
-            services.AddScoped<IPushBackgroundScheduler, NoOpPushBackgroundScheduler>();
+            services.AddScoped<IPushBackgroundScheduler, Services.NoOpPushBackgroundScheduler>();
         }
         else
         {
@@ -77,7 +78,7 @@ public static class ServiceProvider
         services.AddNotificationsModule();
         if (isTesting)
         {
-            services.AddScoped<INotificationEventBridge, NoOpNotificationEventBridge>();
+            services.TryAddScoped<INotificationEventBridge, NoOpNotificationEventBridge>();
         }
 
         // Register typed background action handlers

--- a/LgymApi.BackgroundWorker/ServiceProvider.cs
+++ b/LgymApi.BackgroundWorker/ServiceProvider.cs
@@ -4,11 +4,14 @@ using LgymApi.BackgroundWorker.Common.Commands;
 using LgymApi.BackgroundWorker.Common.Notifications;
 using LgymApi.BackgroundWorker.Common.Notifications.Models;
 using LgymApi.BackgroundWorker.Common.Jobs;
+using LgymApi.BackgroundWorker.Common.Push;
 using LgymApi.BackgroundWorker.Jobs;
+using LgymApi.BackgroundWorker.Push;
 using LgymApi.BackgroundWorker.Notifications;
 using LgymApi.Infrastructure.Jobs;
 using LgymApi.Infrastructure.Services;
 using LgymApi.Application.Notifications;
+using LgymApi.BackgroundWorker.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LgymApi.BackgroundWorker;
@@ -35,6 +38,15 @@ public static class ServiceProvider
             services.AddScoped<IActionMessageScheduler, HangfireActionMessageScheduler>();
         }
 
+        if (isTesting)
+        {
+            services.AddScoped<IPushBackgroundScheduler, NoOpPushBackgroundScheduler>();
+        }
+        else
+        {
+            services.AddScoped<IPushBackgroundScheduler, HangfirePushBackgroundScheduler>();
+        }
+
         services.AddScoped<IEmailScheduler<InvitationEmailPayload>, EmailSchedulerService<InvitationEmailPayload>>();
         services.AddScoped<IEmailScheduler<InvitationAcceptedEmailPayload>, EmailSchedulerService<InvitationAcceptedEmailPayload>>();
         services.AddScoped<IEmailScheduler<InvitationRevokedEmailPayload>, EmailSchedulerService<InvitationRevokedEmailPayload>>();
@@ -46,18 +58,27 @@ public static class ServiceProvider
         services.AddScoped<IInvitationEmailJob, InvitationEmailJob>();
         services.AddScoped<IWelcomeEmailJob, WelcomeEmailJob>();
         services.AddScoped<IEmailJob, EmailJob>();
+        services.AddScoped<IPushNotificationJob, PushNotificationJob>();
 
         services.AddScoped<InvitationEmailJob>();
         services.AddScoped<WelcomeEmailJob>();
         services.AddScoped<EmailJob>();
+        services.AddScoped<PushNotificationJob>();
         services.AddScoped<IActionMessageJob, ActionMessageJob>();
         services.AddScoped<ActionMessageJob>();
         services.AddScoped<ICommittedIntentDispatchJob, CommittedIntentDispatchJob>();
         services.AddScoped<IExpiredPhotoUploadCleanupJob, ExpiredPhotoUploadCleanupJob>();
         services.AddScoped<IRecurringReportAssignmentProcessingJob, RecurringReportAssignmentProcessingJob>();
+        services.AddScoped<IStalePushInstallationCleanupJob, StalePushInstallationCleanupJob>();
 
         services.AddScoped<BackgroundActionOrchestratorService>();
+        services.AddScoped<PushNotificationJobHandlerService>();
+        services.AddScoped<StalePushInstallationCleanupJob>();
         services.AddNotificationsModule();
+        if (isTesting)
+        {
+            services.AddScoped<INotificationEventBridge, NoOpNotificationEventBridge>();
+        }
 
         // Register typed background action handlers
         services.AddBackgroundAction<UserRegisteredCommand, SendRegistrationEmailHandler>();

--- a/LgymApi.BackgroundWorker/Services/NoOpNotificationEventBridge.cs
+++ b/LgymApi.BackgroundWorker/Services/NoOpNotificationEventBridge.cs
@@ -1,0 +1,12 @@
+using LgymApi.Application.Notifications;
+using LgymApi.Application.Notifications.Models;
+
+namespace LgymApi.BackgroundWorker.Services;
+
+internal sealed class NoOpNotificationEventBridge : INotificationEventBridge
+{
+    public Task EnqueueAsync(EnqueueNotificationEventInput input, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/LgymApi.BackgroundWorker/Services/NoOpPushBackgroundScheduler.cs
+++ b/LgymApi.BackgroundWorker/Services/NoOpPushBackgroundScheduler.cs
@@ -1,0 +1,18 @@
+using LgymApi.BackgroundWorker.Common.Push;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.BackgroundWorker.Services;
+
+public sealed class NoOpPushBackgroundScheduler : IPushBackgroundScheduler
+{
+    public string? Enqueue(Id<PushNotificationMessage> notificationId)
+    {
+        return null;
+    }
+
+    public string? ScheduleRetry(Id<PushNotificationMessage> notificationId, TimeSpan delay)
+    {
+        return null;
+    }
+}

--- a/LgymApi.DataSeeder/Program.cs
+++ b/LgymApi.DataSeeder/Program.cs
@@ -108,6 +108,8 @@ public static class Program
         services.AddScoped<IEntitySeeder, UserExternalLoginSeeder>();
         services.AddScoped<IEntitySeeder, PhotoSeeder>();
         services.AddScoped<IEntitySeeder, PhotoUploadSessionSeeder>();
+        services.AddScoped<IEntitySeeder, PushInstallationSeeder>();
+        services.AddScoped<IEntitySeeder, PushNotificationMessageSeeder>();
         services.AddScoped<SeedOrchestrator>();
         return services.BuildServiceProvider();
     }

--- a/LgymApi.DataSeeder/Seeders/PushInstallationSeeder.cs
+++ b/LgymApi.DataSeeder/Seeders/PushInstallationSeeder.cs
@@ -1,0 +1,15 @@
+using LgymApi.Infrastructure.Data;
+
+namespace LgymApi.DataSeeder.Seeders;
+
+public sealed class PushInstallationSeeder : IEntitySeeder
+{
+    public int Order => 89;
+
+    public Task SeedAsync(AppDbContext context, SeedContext seedContext, CancellationToken cancellationToken)
+    {
+        SeedOperationConsole.Start("push installations");
+        SeedOperationConsole.Skip("push installations");
+        return Task.CompletedTask;
+    }
+}

--- a/LgymApi.DataSeeder/Seeders/PushNotificationMessageSeeder.cs
+++ b/LgymApi.DataSeeder/Seeders/PushNotificationMessageSeeder.cs
@@ -1,0 +1,15 @@
+using LgymApi.Infrastructure.Data;
+
+namespace LgymApi.DataSeeder.Seeders;
+
+public sealed class PushNotificationMessageSeeder : IEntitySeeder
+{
+    public int Order => 90;
+
+    public Task SeedAsync(AppDbContext context, SeedContext seedContext, CancellationToken cancellationToken)
+    {
+        SeedOperationConsole.Start("push notification messages");
+        SeedOperationConsole.Skip("push notification messages");
+        return Task.CompletedTask;
+    }
+}

--- a/LgymApi.Domain/Entities/PushInstallation.cs
+++ b/LgymApi.Domain/Entities/PushInstallation.cs
@@ -1,0 +1,18 @@
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.Domain.Entities;
+
+public sealed class PushInstallation : EntityBase<PushInstallation>
+{
+    public Id<User>? UserId { get; set; }
+    public Id<UserSession>? SessionId { get; set; }
+    public string InstallationId { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public string FcmToken { get; set; } = string.Empty;
+    public string? AppVersion { get; set; }
+    public string Environment { get; set; } = string.Empty;
+    public string? PermissionStatus { get; set; }
+    public DateTimeOffset LastSeenAt { get; set; }
+    public DateTimeOffset? DisabledAt { get; set; }
+    public string? DisabledReason { get; set; }
+}

--- a/LgymApi.Domain/Entities/PushNotificationMessage.cs
+++ b/LgymApi.Domain/Entities/PushNotificationMessage.cs
@@ -1,0 +1,29 @@
+using LgymApi.Domain.Enums;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.Domain.Entities;
+
+public sealed class PushNotificationMessage : EntityBase<PushNotificationMessage>
+{
+    public Id<User> UserId { get; set; }
+    public Id<PushInstallation> PushInstallationId { get; set; }
+    public int SchemaVersion { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public string EventId { get; set; } = string.Empty;
+    public string? EntityId { get; set; }
+    public Id<InAppNotification>? InAppNotificationId { get; set; }
+    public string? Deeplink { get; set; }
+    public string PayloadJson { get; set; } = string.Empty;
+    public PushNotificationStatus Status { get; set; } = PushNotificationStatus.Pending;
+    public PushNotificationFailureKind FailureKind { get; set; }
+    public int Attempts { get; set; }
+    public DateTimeOffset? NextAttemptAt { get; set; }
+    public DateTimeOffset? LastAttemptAt { get; set; }
+    public DateTimeOffset? SentAt { get; set; }
+    public string? LastError { get; set; }
+    public string? ProviderStatus { get; set; }
+    public string? ProviderMessageId { get; set; }
+    public string? ProviderErrorCode { get; set; }
+    public string? ProviderResponseSummary { get; set; }
+    public string? SchedulerJobId { get; set; }
+}

--- a/LgymApi.Domain/Enums/NotificationChannel.cs
+++ b/LgymApi.Domain/Enums/NotificationChannel.cs
@@ -3,5 +3,6 @@ namespace LgymApi.Domain.Enums;
 public enum NotificationChannel
 {
     Email = 0,
-    InApp = 1
+    InApp = 1,
+    Push = 2
 }

--- a/LgymApi.Domain/Enums/PushNotificationFailureKind.cs
+++ b/LgymApi.Domain/Enums/PushNotificationFailureKind.cs
@@ -1,0 +1,10 @@
+namespace LgymApi.Domain.Enums;
+
+public enum PushNotificationFailureKind
+{
+    None = 0,
+    Transient = 1,
+    InvalidToken = 2,
+    Permanent = 3,
+    Preference = 4
+}

--- a/LgymApi.Domain/Enums/PushNotificationStatus.cs
+++ b/LgymApi.Domain/Enums/PushNotificationStatus.cs
@@ -1,0 +1,10 @@
+namespace LgymApi.Domain.Enums;
+
+public enum PushNotificationStatus
+{
+    Pending = 0,
+    Sending = 1,
+    Sent = 2,
+    Failed = 3,
+    Skipped = 4
+}

--- a/LgymApi.Domain/LgymApi.Domain.md
+++ b/LgymApi.Domain/LgymApi.Domain.md
@@ -6,3 +6,4 @@
 - Boundary: do not reorder or renumber existing enums.
 - `Exercise` now carries `ExerciseEloFormula` with `Standard` as the default profile.
 - `ExerciseEloFormula.PullupWeighted` rewards lower weight for pull-up style exercises where added weight makes the score worse.
+- `PushInstallation` stores installation-scoped FCM registration state with optional user/session binding so logout and account-switch flows can disassociate a device without deleting its installation record.

--- a/LgymApi.Infrastructure/Configuration/PushNotificationOptionsFactory.cs
+++ b/LgymApi.Infrastructure/Configuration/PushNotificationOptionsFactory.cs
@@ -1,0 +1,55 @@
+using LgymApi.Infrastructure.Options;
+using Microsoft.Extensions.Configuration;
+
+namespace LgymApi.Infrastructure.Configuration;
+
+internal static class PushNotificationOptionsFactory
+{
+    internal static PushNotificationOptions Create(IConfiguration configuration)
+    {
+        var options = configuration.GetSection("PushNotifications").Get<PushNotificationOptions>() ?? new PushNotificationOptions();
+        options.SendEnabled ??= options.Enabled;
+        options.RetryDelaysSeconds = options.RetryDelaysSeconds
+            .Where(x => x > 0)
+            .Distinct()
+            .ToArray();
+
+        if (options.RetryDelaysSeconds.Length == 0)
+        {
+            options.RetryDelaysSeconds = [30, 120, 600];
+        }
+
+        options.Fcm.ProjectId = options.Fcm.ProjectId?.Trim() ?? string.Empty;
+        options.Fcm.CredentialsPath = NormalizeOptional(options.Fcm.CredentialsPath);
+        options.Fcm.CredentialsJson = NormalizeOptional(options.Fcm.CredentialsJson);
+        options.Fcm.BaseUrl = string.IsNullOrWhiteSpace(options.Fcm.BaseUrl)
+            ? "https://fcm.googleapis.com"
+            : options.Fcm.BaseUrl.Trim().TrimEnd('/');
+        options.StaleTokenInactivityDays = options.StaleTokenInactivityDays <= 0 ? 45 : options.StaleTokenInactivityDays;
+        options.StaleTokenCleanupBatchSize = options.StaleTokenCleanupBatchSize <= 0 ? 500 : options.StaleTokenCleanupBatchSize;
+        return options;
+    }
+
+    internal static void Validate(PushNotificationOptions options)
+    {
+        if (!options.IsSendEnabled)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Fcm.ProjectId))
+        {
+            throw new InvalidOperationException("PushNotifications:Fcm:ProjectId is required when push notifications are enabled.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Fcm.CredentialsPath) && string.IsNullOrWhiteSpace(options.Fcm.CredentialsJson))
+        {
+            throw new InvalidOperationException("PushNotifications:Fcm:CredentialsPath or PushNotifications:Fcm:CredentialsJson is required when push notifications are enabled.");
+        }
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+}

--- a/LgymApi.Infrastructure/Configuration/PushNotificationOptionsFactory.cs
+++ b/LgymApi.Infrastructure/Configuration/PushNotificationOptionsFactory.cs
@@ -22,9 +22,7 @@ internal static class PushNotificationOptionsFactory
         options.Fcm.ProjectId = options.Fcm.ProjectId?.Trim() ?? string.Empty;
         options.Fcm.CredentialsPath = NormalizeOptional(options.Fcm.CredentialsPath);
         options.Fcm.CredentialsJson = NormalizeOptional(options.Fcm.CredentialsJson);
-        options.Fcm.BaseUrl = string.IsNullOrWhiteSpace(options.Fcm.BaseUrl)
-            ? "https://fcm.googleapis.com"
-            : options.Fcm.BaseUrl.Trim().TrimEnd('/');
+        options.Fcm.BaseUrl = NormalizeOptional(options.Fcm.BaseUrl)?.TrimEnd('/') ?? string.Empty;
         options.StaleTokenInactivityDays = options.StaleTokenInactivityDays <= 0 ? 45 : options.StaleTokenInactivityDays;
         options.StaleTokenCleanupBatchSize = options.StaleTokenCleanupBatchSize <= 0 ? 500 : options.StaleTokenCleanupBatchSize;
         return options;
@@ -45,6 +43,11 @@ internal static class PushNotificationOptionsFactory
         if (string.IsNullOrWhiteSpace(options.Fcm.CredentialsPath) && string.IsNullOrWhiteSpace(options.Fcm.CredentialsJson))
         {
             throw new InvalidOperationException("PushNotifications:Fcm:CredentialsPath or PushNotifications:Fcm:CredentialsJson is required when push notifications are enabled.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Fcm.BaseUrl))
+        {
+            throw new InvalidOperationException("PushNotifications:Fcm:BaseUrl is required when push notifications are enabled.");
         }
     }
 

--- a/LgymApi.Infrastructure/Data/AppDbContext.cs
+++ b/LgymApi.Infrastructure/Data/AppDbContext.cs
@@ -13,6 +13,10 @@ namespace LgymApi.Infrastructure.Data;
 
 public sealed class AppDbContext : DbContext
 {
+    private const string ActiveRowsFilter = "\"IsDeleted\" = FALSE";
+    private const string ActiveShareCodeFilter = ActiveRowsFilter + " AND \"ShareCode\" IS NOT NULL";
+    private const string ActiveDeliveryKeyFilter = ActiveRowsFilter + " AND \"DeliveryKey\" IS NOT NULL";
+
     public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
     {
     }
@@ -88,10 +92,10 @@ public sealed class AppDbContext : DbContext
                 .HasConversion(email => email.Value, value => new Email(value));
             entity.HasIndex(u => u.Email)
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasIndex(u => u.Name)
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne(u => u.Plan)
                 .WithMany()
                 .HasForeignKey(u => u.PlanId)
@@ -110,7 +114,7 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.DisabledReason).HasMaxLength(128);
             entity.HasIndex(e => e.InstallationId)
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne<User>()
                 .WithMany()
                 .HasForeignKey(e => e.UserId)
@@ -139,9 +143,9 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.SchedulerJobId).HasMaxLength(128);
             entity.HasIndex(e => new { e.PushInstallationId, e.Type, e.EventId })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasIndex(e => new { e.Status, e.NextAttemptAt, e.CreatedAt })
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne<User>()
                 .WithMany()
                 .HasForeignKey(e => e.UserId)
@@ -161,7 +165,7 @@ public sealed class AppDbContext : DbContext
             entity.ToTable("Plans");
             entity.HasIndex(p => p.ShareCode)
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE AND \"ShareCode\" IS NOT NULL");
+                .HasFilter(ActiveShareCodeFilter);
             entity.HasOne(p => p.User)
                 .WithMany(u => u.Plans)
                 .HasForeignKey(p => p.UserId);
@@ -202,7 +206,7 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
             entity.HasIndex(e => new { e.ExerciseId, e.Culture })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne(e => e.Exercise)
                 .WithMany(e => e.Translations)
                 .HasForeignKey(e => e.ExerciseId)
@@ -300,7 +304,7 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.Name).IsRequired();
             entity.HasIndex(e => e.Name)
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
         });
 
         modelBuilder.Entity<UserRole>(entity =>
@@ -324,7 +328,7 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.ClaimValue).IsRequired();
             entity.HasIndex(e => new { e.RoleId, e.ClaimType, e.ClaimValue })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne(e => e.Role)
                 .WithMany(r => r.RoleClaims)
                 .HasForeignKey(e => e.RoleId)
@@ -338,7 +342,7 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.Status).HasConversion<string>();
             entity.HasIndex(e => e.Code)
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne(e => e.Trainer)
                 .WithMany()
                 .HasForeignKey(e => e.TrainerId)
@@ -355,7 +359,7 @@ public sealed class AppDbContext : DbContext
             entity.ToTable("TrainerTraineeLinks");
             entity.HasIndex(e => e.TraineeId)
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasIndex(e => new { e.TrainerId, e.TraineeId });
             entity.HasOne(e => e.Trainer)
                 .WithMany()
@@ -384,7 +388,7 @@ public sealed class AppDbContext : DbContext
             entity.HasIndex(e => new { e.Status, e.NextAttemptAt, e.CreatedAt });
             entity.HasIndex(e => new { e.Channel, e.Type, e.CorrelationId, e.Recipient })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
         });
 
         modelBuilder.Entity<EmailNotificationSubscription>(entity =>
@@ -393,7 +397,7 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.NotificationType).IsRequired();
             entity.HasIndex(e => new { e.UserId, e.NotificationType })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne(e => e.User)
                 .WithMany()
                 .HasForeignKey(e => e.UserId)
@@ -421,7 +425,7 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.Type).HasConversion<string>();
             entity.HasIndex(e => new { e.TemplateId, e.Key })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne(e => e.Template)
                 .WithMany(e => e.Fields)
                 .HasForeignKey(e => e.TemplateId)
@@ -466,7 +470,7 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.TrainerFieldCommentsJson).HasColumnType("text");
             entity.HasIndex(e => e.ReportRequestId)
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne(e => e.Trainee)
                 .WithMany()
                 .HasForeignKey(e => e.TraineeId)
@@ -537,7 +541,7 @@ public sealed class AppDbContext : DbContext
             entity.ToTable("SupplementIntakeLogs");
             entity.HasIndex(e => new { e.TraineeId, e.PlanItemId, e.IntakeDate })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne(e => e.Trainee)
                 .WithMany()
                 .HasForeignKey(e => e.TraineeId)
@@ -655,12 +659,12 @@ public sealed class AppDbContext : DbContext
             // This enforces DB-level duplicate protection for concurrent dispatch attempts
             entity.HasIndex(e => e.CorrelationId)
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             // Work retrieval index: (Status, NextAttemptAt) for pending retries
             entity.HasIndex(e => new { e.Status, e.NextAttemptAt })
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasIndex(e => new { e.Status, e.ProcessingStartedAtUtc })
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             // One-to-many relationship with ExecutionLog
             entity.HasMany(e => e.ExecutionLogs)
                 .WithOne(l => l.CommandEnvelope)
@@ -690,13 +694,13 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.Status).HasConversion<string>();
             // Index for finding execution history by envelope and status
             entity.HasIndex(e => new { e.CommandEnvelopeId, e.Status })
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             // Index for finding logs by action type (supports filtering by operation kind)
             entity.HasIndex(e => new { e.CommandEnvelopeId, e.ActionType })
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             // Timestamp index for retrieving recent logs efficiently
             entity.HasIndex(e => e.CreatedAt)
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             // Foreign key is configured by CommandEnvelope HasMany
         });
 
@@ -711,10 +715,10 @@ public sealed class AppDbContext : DbContext
             // Unique index on UserId + TutorialType (enforces one progress per user per tutorial)
             entity.HasIndex(utp => new { utp.UserId, utp.TutorialType })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             // Index on UserId + IsCompleted (for querying completion status)
             entity.HasIndex(utp => new { utp.UserId, utp.IsCompleted })
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
         });
 
         modelBuilder.Entity<UserTutorialStepProgress>(entity =>
@@ -728,7 +732,7 @@ public sealed class AppDbContext : DbContext
             // Unique index on UserTutorialProgressId + TutorialStep (prevents duplicate step completions)
             entity.HasIndex(utsp => new { utsp.UserTutorialProgressId, utsp.TutorialStep })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
          });
 
         modelBuilder.Entity<ApiIdempotencyRecord>(entity =>
@@ -742,10 +746,10 @@ public sealed class AppDbContext : DbContext
             // Enforces one idempotency record per endpoint scope + key combination
             entity.HasIndex(e => new { e.ScopeTuple, e.IdempotencyKey })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             // Lookup index for replay/conflict checks
             entity.HasIndex(e => new { e.ScopeTuple, e.IdempotencyKey, e.RequestFingerprint })
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
         });
 
         modelBuilder.Entity<PasswordResetToken>(entity =>
@@ -754,7 +758,7 @@ public sealed class AppDbContext : DbContext
             entity.HasIndex(e => e.TokenHash)
                 .IsUnique();
             entity.HasIndex(e => new { e.UserId, e.IsUsed, e.ExpiresAt })
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne(e => e.User)
                 .WithMany()
                 .HasForeignKey(e => e.UserId)
@@ -774,7 +778,7 @@ public sealed class AppDbContext : DbContext
             entity.HasIndex(e => new { e.RecipientId, e.CreatedAt, e.Id });
             entity.HasIndex(e => new { e.RecipientId, e.Type, e.DeliveryKey })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE AND \"DeliveryKey\" IS NOT NULL");
+                .HasFilter(ActiveDeliveryKeyFilter);
         });
 
         modelBuilder.Entity<UserSession>(entity =>
@@ -784,7 +788,7 @@ public sealed class AppDbContext : DbContext
             entity.HasIndex(e => e.UserId);
             entity.HasIndex(e => e.Jti)
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne<User>()
                 .WithMany()
                 .HasForeignKey(e => e.UserId);
@@ -798,10 +802,10 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.ProviderEmail).HasMaxLength(256);
             entity.HasIndex(e => new { e.Provider, e.ProviderKey })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasIndex(e => new { e.UserId, e.Provider })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasOne(e => e.User)
                 .WithMany(u => u.ExternalLogins)
                 .HasForeignKey(e => e.UserId)
@@ -817,7 +821,7 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.Checksum).IsRequired();
             entity.HasIndex(e => new { e.ReportRequestId, e.ViewType })
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasIndex(e => new { e.OwnerUserId, e.CreatedAt });
             entity.HasOne(e => e.ReportRequest)
                 .WithMany()
@@ -842,7 +846,7 @@ public sealed class AppDbContext : DbContext
             entity.Property(e => e.FailureReason).HasMaxLength(500);
             entity.HasIndex(e => e.StorageKey)
                 .IsUnique()
-                .HasFilter("\"IsDeleted\" = FALSE");
+                .HasFilter(ActiveRowsFilter);
             entity.HasIndex(e => new { e.OwnerUserId, e.CreatedAt });
             entity.HasIndex(e => new { e.ReportRequestId, e.ViewType });
             entity.HasIndex(e => new { e.Status, e.ExpiresAtUtc });

--- a/LgymApi.Infrastructure/Data/AppDbContext.cs
+++ b/LgymApi.Infrastructure/Data/AppDbContext.cs
@@ -60,6 +60,8 @@ public sealed class AppDbContext : DbContext
     public DbSet<PasswordResetToken> PasswordResetTokens => Set<PasswordResetToken>();
     public DbSet<InAppNotification> InAppNotifications => Set<InAppNotification>();
     public DbSet<UserSession> UserSessions => Set<UserSession>();
+    public DbSet<PushInstallation> PushInstallations => Set<PushInstallation>();
+    public DbSet<PushNotificationMessage> PushNotificationMessages => Set<PushNotificationMessage>();
     public DbSet<UserExternalLogin> UserExternalLogins => Set<UserExternalLogin>();
     public DbSet<Photo> Photos => Set<Photo>();
     public DbSet<PhotoUploadSession> PhotoUploadSessions => Set<PhotoUploadSession>();
@@ -93,6 +95,64 @@ public sealed class AppDbContext : DbContext
             entity.HasOne(u => u.Plan)
                 .WithMany()
                 .HasForeignKey(u => u.PlanId)
+                .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        modelBuilder.Entity<PushInstallation>(entity =>
+        {
+            entity.ToTable("PushInstallations");
+            entity.Property(e => e.InstallationId).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.Platform).HasMaxLength(32).IsRequired();
+            entity.Property(e => e.FcmToken).HasMaxLength(512).IsRequired();
+            entity.Property(e => e.AppVersion).HasMaxLength(64);
+            entity.Property(e => e.Environment).HasMaxLength(32).IsRequired();
+            entity.Property(e => e.PermissionStatus).HasMaxLength(64);
+            entity.Property(e => e.DisabledReason).HasMaxLength(128);
+            entity.HasIndex(e => e.InstallationId)
+                .IsUnique()
+                .HasFilter("\"IsDeleted\" = FALSE");
+            entity.HasOne<User>()
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.SetNull);
+            entity.HasOne<UserSession>()
+                .WithMany()
+                .HasForeignKey(e => e.SessionId)
+                .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        modelBuilder.Entity<PushNotificationMessage>(entity =>
+        {
+            entity.ToTable("PushNotificationMessages");
+            entity.Property(e => e.Type).HasMaxLength(120).IsRequired();
+            entity.Property(e => e.EventId).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.EntityId).HasMaxLength(200);
+            entity.Property(e => e.Deeplink).HasMaxLength(500);
+            entity.Property(e => e.PayloadJson).IsRequired();
+            entity.Property(e => e.Status).HasConversion<string>();
+            entity.Property(e => e.FailureKind).HasConversion<string>();
+            entity.Property(e => e.LastError).HasMaxLength(400);
+            entity.Property(e => e.ProviderStatus).HasMaxLength(120);
+            entity.Property(e => e.ProviderMessageId).HasMaxLength(200);
+            entity.Property(e => e.ProviderErrorCode).HasMaxLength(120);
+            entity.Property(e => e.ProviderResponseSummary).HasMaxLength(1000);
+            entity.Property(e => e.SchedulerJobId).HasMaxLength(128);
+            entity.HasIndex(e => new { e.PushInstallationId, e.Type, e.EventId })
+                .IsUnique()
+                .HasFilter("\"IsDeleted\" = FALSE");
+            entity.HasIndex(e => new { e.Status, e.NextAttemptAt, e.CreatedAt })
+                .HasFilter("\"IsDeleted\" = FALSE");
+            entity.HasOne<User>()
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne<PushInstallation>()
+                .WithMany()
+                .HasForeignKey(e => e.PushInstallationId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne<InAppNotification>()
+                .WithMany()
+                .HasForeignKey(e => e.InAppNotificationId)
                 .OnDelete(DeleteBehavior.SetNull);
         });
 

--- a/LgymApi.Infrastructure/LgymApi.Infrastructure.md
+++ b/LgymApi.Infrastructure/LgymApi.Infrastructure.md
@@ -6,3 +6,6 @@
 - Boundary: do not register Application services here.
 - Exercise persistence maps the ELO profile as a string column with `Standard` as the database default for new rows.
 - **Persistence Updates**: Added `EmailNotificationStatus.Sending = 3` (explicit numeric value) to support exactly-once delivery guards. Added `NotificationMessage.DeliveredAt` (nullable DateTimeOffset) for crash-safe delivery tracking. Notification send claims now stamp `Status=Sending` and `LastAttemptAt` in one atomic update so interrupted claims do not leave unrecoverable `Sending` rows.
+- Push installations are persisted as installation-scoped rows with a unique `InstallationId`, optional `UserId` and `SessionId`, mutable FCM token/app metadata, and disablement metadata used for unregister/logout/account-switch flows.
+- Push delivery now persists `PushNotificationMessage` rows with payload metadata (`schemaVersion`, `type`, `eventId`, optional entity linkage), provider response summaries, retry timestamps, and failure classification; the FCM sender is configured through `PushNotifications:Fcm:*` without committed credentials.
+- Push infrastructure now separates `PushNotifications:SendEnabled` from registration and uses `LastSeenAt` plus recurring cleanup thresholds to mark stale installations as disabled without deleting audit rows.

--- a/LgymApi.Infrastructure/Migrations/20260710192851_AddPushInstallations.Designer.cs
+++ b/LgymApi.Infrastructure/Migrations/20260710192851_AddPushInstallations.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LgymApi.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LgymApi.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710192851_AddPushInstallations")]
+    partial class AddPushInstallations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1218,114 +1221,6 @@ namespace LgymApi.Infrastructure.Migrations
                     b.HasIndex("UserId");
 
                     b.ToTable("PushInstallations", (string)null);
-                });
-
-            modelBuilder.Entity("LgymApi.Domain.Entities.PushNotificationMessage", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<int>("Attempts")
-                        .HasColumnType("integer");
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Deeplink")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
-
-                    b.Property<string>("EntityId")
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<string>("EventId")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<string>("FailureKind")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<Guid?>("InAppNotificationId")
-                        .HasColumnType("uuid");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("boolean");
-
-                    b.Property<DateTimeOffset?>("LastAttemptAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("LastError")
-                        .HasMaxLength(400)
-                        .HasColumnType("character varying(400)");
-
-                    b.Property<DateTimeOffset?>("NextAttemptAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("PayloadJson")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("ProviderErrorCode")
-                        .HasMaxLength(120)
-                        .HasColumnType("character varying(120)");
-
-                    b.Property<string>("ProviderMessageId")
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
-
-                    b.Property<string>("ProviderResponseSummary")
-                        .HasMaxLength(1000)
-                        .HasColumnType("character varying(1000)");
-
-                    b.Property<string>("ProviderStatus")
-                        .HasMaxLength(120)
-                        .HasColumnType("character varying(120)");
-
-                    b.Property<Guid>("PushInstallationId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("SchedulerJobId")
-                        .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
-
-                    b.Property<int>("SchemaVersion")
-                        .HasColumnType("integer");
-
-                    b.Property<DateTimeOffset?>("SentAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Status")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("Type")
-                        .IsRequired()
-                        .HasMaxLength(120)
-                        .HasColumnType("character varying(120)");
-
-                    b.Property<DateTimeOffset>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid>("UserId")
-                        .HasColumnType("uuid");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("InAppNotificationId");
-
-                    b.HasIndex("UserId");
-
-                    b.HasIndex("PushInstallationId", "Type", "EventId")
-                        .IsUnique()
-                        .HasFilter("\"IsDeleted\" = FALSE");
-
-                    b.HasIndex("Status", "NextAttemptAt", "CreatedAt")
-                        .HasFilter("\"IsDeleted\" = FALSE");
-
-                    b.ToTable("PushNotificationMessages", (string)null);
                 });
 
             modelBuilder.Entity("LgymApi.Domain.Entities.RecurringReportAssignment", b =>
@@ -2651,26 +2546,6 @@ namespace LgymApi.Infrastructure.Migrations
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.SetNull);
-                });
-
-            modelBuilder.Entity("LgymApi.Domain.Entities.PushNotificationMessage", b =>
-                {
-                    b.HasOne("LgymApi.Domain.Entities.InAppNotification", null)
-                        .WithMany()
-                        .HasForeignKey("InAppNotificationId")
-                        .OnDelete(DeleteBehavior.SetNull);
-
-                    b.HasOne("LgymApi.Domain.Entities.PushInstallation", null)
-                        .WithMany()
-                        .HasForeignKey("PushInstallationId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("LgymApi.Domain.Entities.User", null)
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
                 });
 
             modelBuilder.Entity("LgymApi.Domain.Entities.RecurringReportAssignment", b =>

--- a/LgymApi.Infrastructure/Migrations/20260710192851_AddPushInstallations.cs
+++ b/LgymApi.Infrastructure/Migrations/20260710192851_AddPushInstallations.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LgymApi.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPushInstallations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PushInstallations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    SessionId = table.Column<Guid>(type: "uuid", nullable: true),
+                    InstallationId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Platform = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    FcmToken = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    AppVersion = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    Environment = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    PermissionStatus = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    LastSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    DisabledAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DisabledReason = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PushInstallations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PushInstallations_UserSessions_SessionId",
+                        column: x => x.SessionId,
+                        principalTable: "UserSessions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_PushInstallations_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PushInstallations_InstallationId",
+                table: "PushInstallations",
+                column: "InstallationId",
+                unique: true,
+                filter: "\"IsDeleted\" = FALSE");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PushInstallations_SessionId",
+                table: "PushInstallations",
+                column: "SessionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PushInstallations_UserId",
+                table: "PushInstallations",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PushInstallations");
+        }
+    }
+}

--- a/LgymApi.Infrastructure/Migrations/20260710201009_AddPushNotificationMessages.Designer.cs
+++ b/LgymApi.Infrastructure/Migrations/20260710201009_AddPushNotificationMessages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LgymApi.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LgymApi.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710201009_AddPushNotificationMessages")]
+    partial class AddPushNotificationMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LgymApi.Infrastructure/Migrations/20260710201009_AddPushNotificationMessages.cs
+++ b/LgymApi.Infrastructure/Migrations/20260710201009_AddPushNotificationMessages.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LgymApi.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPushNotificationMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PushNotificationMessages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PushInstallationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SchemaVersion = table.Column<int>(type: "integer", nullable: false),
+                    Type = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: false),
+                    EventId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    EntityId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    InAppNotificationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Deeplink = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    PayloadJson = table.Column<string>(type: "text", nullable: false),
+                    Status = table.Column<string>(type: "text", nullable: false),
+                    FailureKind = table.Column<string>(type: "text", nullable: false),
+                    Attempts = table.Column<int>(type: "integer", nullable: false),
+                    NextAttemptAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    LastAttemptAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    SentAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    LastError = table.Column<string>(type: "character varying(400)", maxLength: 400, nullable: true),
+                    ProviderStatus = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: true),
+                    ProviderMessageId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    ProviderErrorCode = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: true),
+                    ProviderResponseSummary = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    SchedulerJobId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PushNotificationMessages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PushNotificationMessages_PushInstallations_PushInstallation~",
+                        column: x => x.PushInstallationId,
+                        principalTable: "PushInstallations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PushNotificationMessages_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PushNotificationMessages_in_app_notifications_InAppNotifica~",
+                        column: x => x.InAppNotificationId,
+                        principalTable: "in_app_notifications",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PushNotificationMessages_InAppNotificationId",
+                table: "PushNotificationMessages",
+                column: "InAppNotificationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PushNotificationMessages_PushInstallationId_Type_EventId",
+                table: "PushNotificationMessages",
+                columns: new[] { "PushInstallationId", "Type", "EventId" },
+                unique: true,
+                filter: "\"IsDeleted\" = FALSE");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PushNotificationMessages_Status_NextAttemptAt_CreatedAt",
+                table: "PushNotificationMessages",
+                columns: new[] { "Status", "NextAttemptAt", "CreatedAt" },
+                filter: "\"IsDeleted\" = FALSE");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PushNotificationMessages_UserId",
+                table: "PushNotificationMessages",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PushNotificationMessages");
+        }
+    }
+}

--- a/LgymApi.Infrastructure/Options/PushNotificationOptions.cs
+++ b/LgymApi.Infrastructure/Options/PushNotificationOptions.cs
@@ -17,6 +17,6 @@ public sealed class PushNotificationOptions
         public string ProjectId { get; set; } = string.Empty;
         public string? CredentialsPath { get; set; }
         public string? CredentialsJson { get; set; }
-        public string BaseUrl { get; set; } = "https://fcm.googleapis.com";
+        public string BaseUrl { get; set; } = string.Empty;
     }
 }

--- a/LgymApi.Infrastructure/Options/PushNotificationOptions.cs
+++ b/LgymApi.Infrastructure/Options/PushNotificationOptions.cs
@@ -1,0 +1,22 @@
+namespace LgymApi.Infrastructure.Options;
+
+public sealed class PushNotificationOptions
+{
+    public bool Enabled { get; set; }
+    public bool? SendEnabled { get; set; }
+    public int[] RetryDelaysSeconds { get; set; } = [30, 120, 600];
+    public bool StaleTokenCleanupEnabled { get; set; } = true;
+    public int StaleTokenInactivityDays { get; set; } = 45;
+    public int StaleTokenCleanupBatchSize { get; set; } = 500;
+    public FcmOptions Fcm { get; set; } = new();
+
+    public bool IsSendEnabled => SendEnabled ?? Enabled;
+
+    public sealed class FcmOptions
+    {
+        public string ProjectId { get; set; } = string.Empty;
+        public string? CredentialsPath { get; set; }
+        public string? CredentialsJson { get; set; }
+        public string BaseUrl { get; set; } = "https://fcm.googleapis.com";
+    }
+}

--- a/LgymApi.Infrastructure/Repositories/PushInstallationRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/PushInstallationRepository.cs
@@ -1,0 +1,75 @@
+using LgymApi.Application.Repositories;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace LgymApi.Infrastructure.Repositories;
+
+public sealed class PushInstallationRepository : IPushInstallationRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public PushInstallationRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<PushInstallation?> FindByIdAsync(Id<PushInstallation> id, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PushInstallations.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+    }
+
+    public Task<PushInstallation?> FindByInstallationIdAsync(string installationId, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PushInstallations
+            .FirstOrDefaultAsync(x => x.InstallationId == installationId, cancellationToken);
+    }
+
+    public Task<PushInstallation?> FindBoundToUserOrSessionAsync(
+        string installationId,
+        Id<User> userId,
+        Id<UserSession> sessionId,
+        CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PushInstallations
+            .FirstOrDefaultAsync(
+                x => x.InstallationId == installationId
+                    && (x.UserId == userId || x.SessionId == sessionId),
+                cancellationToken);
+    }
+
+    public Task<List<PushInstallation>> GetBySessionIdAsync(Id<UserSession> sessionId, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PushInstallations
+            .Where(x => x.SessionId == sessionId)
+            .ToListAsync(cancellationToken);
+    }
+
+    public Task<List<PushInstallation>> GetActiveByUserIdAsync(Id<User> userId, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PushInstallations
+            .Where(x => x.UserId == userId && x.DisabledAt == null)
+            .ToListAsync(cancellationToken);
+    }
+
+    public Task<List<PushInstallation>> GetStaleActiveAsync(DateTimeOffset lastSeenBefore, int limit, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PushInstallations
+            .Where(x => x.DisabledAt == null && x.LastSeenAt < lastSeenBefore)
+            .OrderBy(x => x.LastSeenAt)
+            .Take(limit)
+            .ToListAsync(cancellationToken);
+    }
+
+    public Task AddAsync(PushInstallation installation, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PushInstallations.AddAsync(installation, cancellationToken).AsTask();
+    }
+
+    public Task UpdateAsync(PushInstallation installation, CancellationToken cancellationToken = default)
+    {
+        _dbContext.PushInstallations.Update(installation);
+        return Task.CompletedTask;
+    }
+}

--- a/LgymApi.Infrastructure/Repositories/PushNotificationMessageRepository.cs
+++ b/LgymApi.Infrastructure/Repositories/PushNotificationMessageRepository.cs
@@ -1,0 +1,74 @@
+using LgymApi.Application.Repositories;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.Enums;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.Infrastructure.Data;
+using LgymApi.Infrastructure.Extensions;
+using Microsoft.EntityFrameworkCore;
+
+namespace LgymApi.Infrastructure.Repositories;
+
+public sealed class PushNotificationMessageRepository : IPushNotificationMessageRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public PushNotificationMessageRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task AddAsync(PushNotificationMessage message, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PushNotificationMessages.AddAsync(message, cancellationToken).AsTask();
+    }
+
+    public Task<PushNotificationMessage?> FindByIdAsync(Id<PushNotificationMessage> id, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PushNotificationMessages.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+    }
+
+    public Task<PushNotificationMessage?> FindByDeliveryKeyAsync(
+        Id<PushInstallation> installationId,
+        string type,
+        string eventId,
+        CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PushNotificationMessages.FirstOrDefaultAsync(
+            x => x.PushInstallationId == installationId && x.Type == type && x.EventId == eventId,
+            cancellationToken);
+    }
+
+    public async Task<bool> TryTransitionToSendingAsync(Id<PushNotificationMessage> id, CancellationToken cancellationToken = default)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var claimed = await _dbContext.PushNotificationMessages
+            .Where(x => x.Id == id
+                        && (x.Status == PushNotificationStatus.Pending
+                            || (x.Status == PushNotificationStatus.Failed
+                                && x.FailureKind == PushNotificationFailureKind.Transient
+                                && (x.NextAttemptAt == null || x.NextAttemptAt <= now))))
+            .StageUpdateAsync(
+                _dbContext,
+                x => x.Status,
+                _ => PushNotificationStatus.Sending,
+                x => x.LastAttemptAt,
+                _ => now,
+                cancellationToken);
+
+        return claimed > 0;
+    }
+
+    public Task UpdateAsync(PushNotificationMessage message, CancellationToken cancellationToken = default)
+    {
+        _dbContext.PushNotificationMessages.Update(message);
+        return Task.CompletedTask;
+    }
+
+    public Task<List<PushNotificationMessage>> GetByStatusAsync(PushNotificationStatus status, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PushNotificationMessages
+            .Where(x => x.Status == status)
+            .OrderBy(x => x.CreatedAt)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
+++ b/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
@@ -117,6 +117,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<LocalPhotoDevelopmentStore>();
         services.AddSingleton<InMemoryPhotoUploadInitTracker>();
         services.AddScoped<IPushProviderSender, FcmPushSender>();
+        services.AddScoped<IPushBackgroundScheduler, HangfirePushBackgroundScheduler>();
         services.AddScoped<IPhotoUploadInitTracker, DbPhotoUploadInitTracker>();
         RegisterPhotoStorageProvider(services, photoStorageOptions, isDevelopmentOrTesting);
         services.AddScoped<IUserRepository, UserRepository>();

--- a/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
+++ b/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
@@ -117,7 +117,12 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<LocalPhotoDevelopmentStore>();
         services.AddSingleton<InMemoryPhotoUploadInitTracker>();
         services.AddScoped<IPushProviderSender, FcmPushSender>();
-        services.AddScoped<IPushBackgroundScheduler, HangfirePushBackgroundScheduler>();
+        services.AddScoped<IPushBackgroundScheduler, NoOpPushBackgroundScheduler>();
+        if (!isTesting)
+        {
+            services.AddScoped<IPushBackgroundScheduler, HangfirePushBackgroundScheduler>();
+        }
+
         services.AddScoped<IPhotoUploadInitTracker, DbPhotoUploadInitTracker>();
         RegisterPhotoStorageProvider(services, photoStorageOptions, isDevelopmentOrTesting);
         services.AddScoped<IUserRepository, UserRepository>();

--- a/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
+++ b/LgymApi.Infrastructure/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using LgymApi.Infrastructure.Configuration;
+using LgymApi.BackgroundWorker.Common.Push;
 using GridifyExecutionServiceContract = LgymApi.Infrastructure.Pagination.IGridifyExecutionService;
 using QueryPaginationFacade = LgymApi.Infrastructure.Pagination.QueryPaginationService;
 
@@ -41,17 +42,21 @@ public static class ServiceCollectionExtensions
         backgroundCommandOptions.Validate();
 
         var emailOptions = EmailOptionsFactory.Create(configuration, appDefaultsOptions);
+        var pushNotificationOptions = PushNotificationOptionsFactory.Create(configuration);
 
         services.AddSingleton(appDefaultsOptions);
         services.AddSingleton(photoStorageOptions);
         services.AddSingleton(backgroundCommandOptions);
         EmailOptionsFactory.Validate(emailOptions);
         services.AddSingleton(emailOptions);
+        PushNotificationOptionsFactory.Validate(pushNotificationOptions);
+        services.AddSingleton(pushNotificationOptions);
         services.AddHttpContextAccessor();
         // Google auth fallback uses Google userinfo over HTTP when the ID token omits profile/email claims.
         services.AddHttpClient();
         services.AddSingleton<IEmailNotificationsFeature, EmailNotificationsFeature>();
         services.AddSingleton<IEmailMetrics, EmailMetrics>();
+        services.AddSingleton<IStalePushInstallationCleanupSettings, PushInstallationCleanupSettings>();
 
         services.AddDbContext<AppDbContext>((sp, options) =>
         {
@@ -111,9 +116,12 @@ public static class ServiceCollectionExtensions
         });
         services.AddSingleton<LocalPhotoDevelopmentStore>();
         services.AddSingleton<InMemoryPhotoUploadInitTracker>();
+        services.AddScoped<IPushProviderSender, FcmPushSender>();
         services.AddScoped<IPhotoUploadInitTracker, DbPhotoUploadInitTracker>();
         RegisterPhotoStorageProvider(services, photoStorageOptions, isDevelopmentOrTesting);
         services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IPushInstallationRepository, PushInstallationRepository>();
+        services.AddScoped<IPushNotificationMessageRepository, PushNotificationMessageRepository>();
         services.AddScoped<IUserExternalLoginRepository, UserExternalLoginRepository>();
         services.AddScoped<IPasswordResetTokenRepository, PasswordResetTokenRepository>();
         services.AddScoped<IRoleRepository, RoleRepository>();

--- a/LgymApi.Infrastructure/Services/FcmPushSender.cs
+++ b/LgymApi.Infrastructure/Services/FcmPushSender.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using LgymApi.BackgroundWorker.Common.Serialization;
 using Google.Apis.Auth.OAuth2;
 using LgymApi.BackgroundWorker.Common.Push;
 using LgymApi.BackgroundWorker.Common.Push.Models;
@@ -147,7 +148,7 @@ public sealed class FcmPushSender : IPushProviderSender
             }
         };
 
-        var json = JsonSerializer.Serialize(request);
+        var json = JsonSerializer.Serialize(request, SharedSerializationOptions.Current);
         return new StringContent(json, Encoding.UTF8, "application/json");
     }
 

--- a/LgymApi.Infrastructure/Services/FcmPushSender.cs
+++ b/LgymApi.Infrastructure/Services/FcmPushSender.cs
@@ -92,11 +92,11 @@ public sealed class FcmPushSender : IPushProviderSender
         GoogleCredential credential;
         if (!string.IsNullOrWhiteSpace(_options.Fcm.CredentialsJson))
         {
-            credential = GoogleCredential.FromJson(_options.Fcm.CredentialsJson);
+            credential = CreateCredentialFromJson(_options.Fcm.CredentialsJson);
         }
         else if (!string.IsNullOrWhiteSpace(_options.Fcm.CredentialsPath))
         {
-            credential = GoogleCredential.FromFile(_options.Fcm.CredentialsPath);
+            credential = CreateCredentialFromFile(_options.Fcm.CredentialsPath);
         }
         else
         {
@@ -105,6 +105,18 @@ public sealed class FcmPushSender : IPushProviderSender
 
         credential = credential.CreateScoped(MessagingScope);
         return await credential.UnderlyingCredential.GetAccessTokenForRequestAsync(null, cancellationToken);
+    }
+
+    private static GoogleCredential CreateCredentialFromJson(string credentialsJson)
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(credentialsJson));
+        return CredentialFactory.FromStream<ServiceAccountCredential>(stream).ToGoogleCredential();
+    }
+
+    private static GoogleCredential CreateCredentialFromFile(string credentialsPath)
+    {
+        using var stream = File.OpenRead(credentialsPath);
+        return CredentialFactory.FromStream<ServiceAccountCredential>(stream).ToGoogleCredential();
     }
 
     private StringContent BuildRequestContent(PushInstallation installation, PushEventPayload payload)

--- a/LgymApi.Infrastructure/Services/FcmPushSender.cs
+++ b/LgymApi.Infrastructure/Services/FcmPushSender.cs
@@ -209,6 +209,7 @@ public sealed class FcmPushSender : IPushProviderSender
         }
         catch (JsonException)
         {
+            return null;
         }
 
         return null;

--- a/LgymApi.Infrastructure/Services/FcmPushSender.cs
+++ b/LgymApi.Infrastructure/Services/FcmPushSender.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Google.Apis.Auth.OAuth2;
+using LgymApi.BackgroundWorker.Common.Push;
+using LgymApi.BackgroundWorker.Common.Push.Models;
+using LgymApi.Domain.Entities;
+using LgymApi.Infrastructure.Options;
+using Microsoft.Extensions.Logging;
+
+namespace LgymApi.Infrastructure.Services;
+
+public sealed class FcmPushSender : IPushProviderSender
+{
+    private const string MessagingScope = "https://www.googleapis.com/auth/firebase.messaging";
+    private const string NotificationTitle = "LGYM";
+    private const string NotificationBody = "You have a new notification.";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly PushNotificationOptions _options;
+    private readonly ILogger<FcmPushSender> _logger;
+
+    public FcmPushSender(
+        IHttpClientFactory httpClientFactory,
+        PushNotificationOptions options,
+        ILogger<FcmPushSender> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<PushSendAttemptResult> SendAsync(
+        PushInstallation installation,
+        PushEventPayload payload,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_options.IsSendEnabled)
+        {
+            return new PushSendAttemptResult(
+                PushSendOutcome.Skipped,
+                "Skipped",
+                null,
+                "push-disabled",
+                "Push notifications are disabled.");
+        }
+
+        var accessToken = await GetAccessTokenAsync(cancellationToken);
+        using var request = new HttpRequestMessage(HttpMethod.Post, BuildSendUrl())
+        {
+            Content = BuildRequestContent(installation, payload)
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        var client = _httpClientFactory.CreateClient(nameof(FcmPushSender));
+        using var response = await client.SendAsync(request, cancellationToken);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var providerMessageId = TryExtractValue(body, "name");
+            return new PushSendAttemptResult(
+                PushSendOutcome.Sent,
+                response.StatusCode.ToString(),
+                providerMessageId,
+                null,
+                Summarize(body));
+        }
+
+        var summary = Summarize(body);
+        var errorCode = TryExtractValue(body, "status") ?? response.StatusCode.ToString();
+        var outcome = ClassifyFailure(response.StatusCode, summary);
+        _logger.LogWarning(
+            "FCM send failed for installation {InstallationId}, event {EventId}, category {Category} with provider status {ProviderStatus} and outcome {Outcome}.",
+            installation.InstallationId,
+            payload.EventId,
+            payload.Type,
+            response.StatusCode,
+            outcome);
+
+        return new PushSendAttemptResult(
+            outcome,
+            response.StatusCode.ToString(),
+            null,
+            errorCode,
+            summary);
+    }
+
+    private async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken)
+    {
+        GoogleCredential credential;
+        if (!string.IsNullOrWhiteSpace(_options.Fcm.CredentialsJson))
+        {
+            credential = GoogleCredential.FromJson(_options.Fcm.CredentialsJson);
+        }
+        else if (!string.IsNullOrWhiteSpace(_options.Fcm.CredentialsPath))
+        {
+            credential = GoogleCredential.FromFile(_options.Fcm.CredentialsPath);
+        }
+        else
+        {
+            throw new InvalidOperationException("FCM credentials are not configured.");
+        }
+
+        credential = credential.CreateScoped(MessagingScope);
+        return await credential.UnderlyingCredential.GetAccessTokenForRequestAsync(null, cancellationToken);
+    }
+
+    private StringContent BuildRequestContent(PushInstallation installation, PushEventPayload payload)
+    {
+        var request = new
+        {
+            message = new
+            {
+                token = installation.FcmToken,
+                notification = new
+                {
+                    title = NotificationTitle,
+                    body = NotificationBody
+                },
+                android = new
+                {
+                    priority = "HIGH"
+                },
+                data = new Dictionary<string, string>
+                {
+                    ["schemaVersion"] = payload.SchemaVersion.ToString(),
+                    ["type"] = payload.Type,
+                    ["eventId"] = payload.EventId,
+                    ["entityId"] = payload.EntityId ?? string.Empty,
+                    ["inAppNotificationId"] = payload.InAppNotificationId ?? string.Empty,
+                    ["deeplink"] = payload.Deeplink ?? string.Empty
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(request);
+        return new StringContent(json, Encoding.UTF8, "application/json");
+    }
+
+    private string BuildSendUrl()
+    {
+        return $"{_options.Fcm.BaseUrl}/v1/projects/{_options.Fcm.ProjectId}/messages:send";
+    }
+
+    private static PushSendOutcome ClassifyFailure(HttpStatusCode statusCode, string summary)
+    {
+        if (ContainsAny(summary, "unregistered", "registration-token-not-registered", "invalid registration token", "not a valid fcm registration token"))
+        {
+            return PushSendOutcome.InvalidToken;
+        }
+
+        if (statusCode == HttpStatusCode.TooManyRequests
+            || statusCode == HttpStatusCode.RequestTimeout
+            || statusCode == HttpStatusCode.BadGateway
+            || statusCode == HttpStatusCode.ServiceUnavailable
+            || statusCode == HttpStatusCode.GatewayTimeout
+            || (int)statusCode >= 500)
+        {
+            return PushSendOutcome.TransientFailure;
+        }
+
+        if (ContainsAny(summary, "unavailable", "internal", "timeout", "temporar"))
+        {
+            return PushSendOutcome.TransientFailure;
+        }
+
+        return PushSendOutcome.PermanentFailure;
+    }
+
+    private static string? TryExtractValue(string body, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(body);
+            if (document.RootElement.ValueKind == JsonValueKind.Object)
+            {
+                if (document.RootElement.TryGetProperty(propertyName, out var directValue) && directValue.ValueKind == JsonValueKind.String)
+                {
+                    return directValue.GetString();
+                }
+
+                if (document.RootElement.TryGetProperty("error", out var error)
+                    && error.ValueKind == JsonValueKind.Object
+                    && error.TryGetProperty(propertyName, out var nestedValue)
+                    && nestedValue.ValueKind == JsonValueKind.String)
+                {
+                    return nestedValue.GetString();
+                }
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return null;
+    }
+
+    private static bool ContainsAny(string value, params string[] terms)
+    {
+        return terms.Any(term => value.Contains(term, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string Summarize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var normalized = value.Replace("\r", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal)
+            .Trim();
+        return normalized.Length <= 1000 ? normalized : normalized[..1000];
+    }
+}

--- a/LgymApi.Infrastructure/Services/HangfirePushBackgroundScheduler.cs
+++ b/LgymApi.Infrastructure/Services/HangfirePushBackgroundScheduler.cs
@@ -1,0 +1,27 @@
+using Hangfire;
+using LgymApi.BackgroundWorker.Common.Jobs;
+using LgymApi.BackgroundWorker.Common.Push;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.Infrastructure.Services;
+
+public sealed class HangfirePushBackgroundScheduler : IPushBackgroundScheduler
+{
+    private readonly IBackgroundJobClient _backgroundJobClient;
+
+    public HangfirePushBackgroundScheduler(IBackgroundJobClient backgroundJobClient)
+    {
+        _backgroundJobClient = backgroundJobClient;
+    }
+
+    public string? Enqueue(Id<PushNotificationMessage> notificationId)
+    {
+        return _backgroundJobClient.Enqueue<IPushNotificationJob>(job => job.ExecuteAsync(notificationId, CancellationToken.None));
+    }
+
+    public string? ScheduleRetry(Id<PushNotificationMessage> notificationId, TimeSpan delay)
+    {
+        return _backgroundJobClient.Schedule<IPushNotificationJob>(job => job.ExecuteAsync(notificationId, CancellationToken.None), delay);
+    }
+}

--- a/LgymApi.Infrastructure/Services/NoOpPushBackgroundScheduler.cs
+++ b/LgymApi.Infrastructure/Services/NoOpPushBackgroundScheduler.cs
@@ -1,0 +1,18 @@
+using LgymApi.BackgroundWorker.Common.Push;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+
+namespace LgymApi.Infrastructure.Services;
+
+public sealed class NoOpPushBackgroundScheduler : IPushBackgroundScheduler
+{
+    public string? Enqueue(Id<PushNotificationMessage> notificationId)
+    {
+        return null;
+    }
+
+    public string? ScheduleRetry(Id<PushNotificationMessage> notificationId, TimeSpan delay)
+    {
+        return null;
+    }
+}

--- a/LgymApi.Infrastructure/Services/PushInstallationCleanupSettings.cs
+++ b/LgymApi.Infrastructure/Services/PushInstallationCleanupSettings.cs
@@ -1,0 +1,18 @@
+using LgymApi.Application.Notifications;
+using LgymApi.Infrastructure.Options;
+
+namespace LgymApi.Infrastructure.Services;
+
+public sealed class PushInstallationCleanupSettings : IStalePushInstallationCleanupSettings
+{
+    private readonly PushNotificationOptions _options;
+
+    public PushInstallationCleanupSettings(PushNotificationOptions options)
+    {
+        _options = options;
+    }
+
+    public bool Enabled => _options.StaleTokenCleanupEnabled;
+    public int InactivityDays => _options.StaleTokenInactivityDays;
+    public int BatchSize => _options.StaleTokenCleanupBatchSize;
+}

--- a/LgymApi.IntegrationTests/InAppNotifications/PushNotificationAdminApiTests.cs
+++ b/LgymApi.IntegrationTests/InAppNotifications/PushNotificationAdminApiTests.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.Notifications;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LgymApi.IntegrationTests.InAppNotifications;
+
+[TestFixture]
+public sealed class PushNotificationAdminApiTests : IntegrationTestBase
+{
+    [Test]
+    public async Task EnqueueTestEvent_WithLinkedInAppNotification_PersistsPrivacySafePayload()
+    {
+        var admin = await SeedAdminAsync();
+        var recipient = await SeedUserAsync(name: "push-admin-target", email: "push-admin-target@example.com");
+        var linkedNotification = await SeedNotificationAsync(recipient.Id, "Sensitive test body that must stay out of push payload");
+        await SeedPushInstallationAsync(recipient.Id, "device-admin-test", "token-admin-test");
+
+        SetAuthorizationHeader(admin.Id);
+        var response = await PostAsJsonWithApiOptionsAsync(
+            "/api/internal/push/test-event",
+            new EnqueueTestPushEventHttpRequest(
+                recipient.Id.ToString(),
+                "internal.test.push",
+                "event-admin-test-1",
+                "entity-admin-test-1",
+                linkedNotification.Id.ToString(),
+                "/notifications"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var body = await response.Content.ReadFromJsonAsync<MessageResponse>();
+        body.Should().NotBeNull();
+        body!.Message.Should().Be("Push test event queued");
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var message = await db.PushNotificationMessages.SingleAsync(x => x.EventId == "event-admin-test-1");
+
+        message.Type.Should().Be("internal.test.push");
+        message.InAppNotificationId.Should().Be(linkedNotification.Id);
+        message.PayloadJson.Should().Contain(linkedNotification.Id.ToString());
+        message.PayloadJson.Should().Contain("event-admin-test-1");
+        message.PayloadJson.Should().Contain("entity-admin-test-1");
+        message.PayloadJson.Should().NotContain(linkedNotification.Message);
+    }
+
+    [Test]
+    public async Task EnqueueTestEvent_NonAdminUser_ReturnsForbidden()
+    {
+        var user = await SeedUserAsync(name: "push-admin-forbidden", email: "push-admin-forbidden@example.com");
+        var recipient = await SeedUserAsync(name: "push-admin-forbidden-target", email: "push-admin-forbidden-target@example.com");
+        await SeedPushInstallationAsync(recipient.Id, "device-admin-forbidden", "token-admin-forbidden");
+
+        SetAuthorizationHeader(user.Id);
+        var response = await PostAsJsonWithApiOptionsAsync(
+            "/api/internal/push/test-event",
+            new EnqueueTestPushEventHttpRequest(
+                recipient.Id.ToString(),
+                "internal.test.push",
+                "event-admin-test-2",
+                null,
+                null,
+                null));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var count = await db.PushNotificationMessages.CountAsync(x => x.EventId == "event-admin-test-2");
+        count.Should().Be(0);
+    }
+
+    private async Task<InAppNotification> SeedNotificationAsync(Id<User> recipientId, string message)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var notification = new InAppNotification
+        {
+            Id = Id<InAppNotification>.New(),
+            RecipientId = recipientId,
+            IsSystemNotification = true,
+            Message = message,
+            RedirectUrl = "/app/notifications",
+            IsRead = false,
+            Type = InAppNotificationTypes.InvitationSent,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        db.InAppNotifications.Add(notification);
+        await db.SaveChangesAsync();
+        return notification;
+    }
+
+    private async Task SeedPushInstallationAsync(Id<User> userId, string installationId, string token)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        db.PushInstallations.Add(new PushInstallation
+        {
+            Id = Id<PushInstallation>.New(),
+            UserId = userId,
+            InstallationId = installationId,
+            Platform = "android",
+            FcmToken = token,
+            Environment = "development",
+            PermissionStatus = "authorized",
+            LastSeenAt = DateTimeOffset.UtcNow
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    private sealed record EnqueueTestPushEventHttpRequest(
+        [property: JsonPropertyName("recipientUserId")] string RecipientUserId,
+        [property: JsonPropertyName("type")] string Type,
+        [property: JsonPropertyName("eventId")] string EventId,
+        [property: JsonPropertyName("entityId")] string? EntityId,
+        [property: JsonPropertyName("inAppNotificationId")] string? InAppNotificationId,
+        [property: JsonPropertyName("deeplink")] string? Deeplink);
+
+    private sealed class MessageResponse
+    {
+        [JsonPropertyName("msg")]
+        public string Message { get; set; } = string.Empty;
+    }
+}

--- a/LgymApi.IntegrationTests/InAppNotifications/PushNotificationAdminApiTests.cs
+++ b/LgymApi.IntegrationTests/InAppNotifications/PushNotificationAdminApiTests.cs
@@ -33,7 +33,7 @@ public sealed class PushNotificationAdminApiTests : IntegrationTestBase
                 linkedNotification.Id.ToString(),
                 "/notifications"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await response.Content.ReadFromJsonAsync<MessageResponse>();
         body.Should().NotBeNull();
         body!.Message.Should().Be("Push test event queued");

--- a/LgymApi.IntegrationTests/PushInstallationApiTests.cs
+++ b/LgymApi.IntegrationTests/PushInstallationApiTests.cs
@@ -1,0 +1,211 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using LgymApi.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LgymApi.IntegrationTests;
+
+[TestFixture]
+public sealed class PushInstallationApiTests : IntegrationTestBase
+{
+    [Test]
+    public async Task RegisterPushInstallation_WithAuthenticatedUser_CreatesInstallationRow()
+    {
+        var user = await SeedUserAsync(name: "push-user", email: "push-user@example.com", password: "push-pass-123");
+        SetAuthorizationHeader(user.Id);
+
+        var response = await Client.PostAsJsonAsync("/api/push/installations/register", new
+        {
+            installationId = "device-1",
+            platform = "android",
+            fcmToken = "token-1",
+            appVersion = "1.0.0",
+            environment = "development",
+            permissionStatus = "authorized"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var installation = await db.PushInstallations.SingleAsync(x => x.InstallationId == "device-1");
+
+        installation.UserId.Should().Be(user.Id);
+        installation.SessionId.Should().NotBeNull();
+        installation.Platform.Should().Be("android");
+        installation.FcmToken.Should().Be("token-1");
+        installation.AppVersion.Should().Be("1.0.0");
+        installation.Environment.Should().Be("development");
+        installation.PermissionStatus.Should().Be("authorized");
+        installation.DisabledAt.Should().BeNull();
+        installation.DisabledReason.Should().BeNull();
+    }
+
+    [Test]
+    public async Task RegisterPushInstallation_WhenRepeatedForSameInstallation_IsIdempotentAndUpdatesExistingRow()
+    {
+        var user = await SeedUserAsync(name: "push-repeat", email: "push-repeat@example.com", password: "push-pass-123");
+        SetAuthorizationHeader(user.Id);
+
+        var firstResponse = await Client.PostAsJsonAsync("/api/push/installations/register", new
+        {
+            installationId = "device-repeat",
+            platform = "ios",
+            fcmToken = "token-old",
+            appVersion = "1.0.0",
+            environment = "production",
+            permissionStatus = "provisional"
+        });
+        firstResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await Task.Delay(10);
+
+        var secondResponse = await Client.PostAsJsonAsync("/api/push/installations/register", new
+        {
+            installationId = "device-repeat",
+            platform = "ios",
+            fcmToken = "token-new",
+            appVersion = "1.1.0",
+            environment = "production",
+            permissionStatus = "authorized"
+        });
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var installations = await db.PushInstallations
+            .Where(x => x.InstallationId == "device-repeat")
+            .ToListAsync();
+
+        installations.Should().HaveCount(1);
+        installations[0].FcmToken.Should().Be("token-new");
+        installations[0].AppVersion.Should().Be("1.1.0");
+        installations[0].PermissionStatus.Should().Be("authorized");
+        installations[0].UpdatedAt.Should().BeAfter(installations[0].CreatedAt);
+    }
+
+    [Test]
+    public async Task UnregisterPushInstallation_DisablesInstallationWithoutDeletingIt()
+    {
+        var user = await SeedUserAsync(name: "push-unregister", email: "push-unregister@example.com", password: "push-pass-123");
+        SetAuthorizationHeader(user.Id);
+
+        await Client.PostAsJsonAsync("/api/push/installations/register", new
+        {
+            installationId = "device-unregister",
+            platform = "android",
+            fcmToken = "token-unregister",
+            appVersion = "1.0.0",
+            environment = "development"
+        });
+
+        var response = await Client.PostAsJsonAsync("/api/push/installations/unregister", new
+        {
+            installationId = "device-unregister"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var installation = await db.PushInstallations.SingleAsync(x => x.InstallationId == "device-unregister");
+        installation.DisabledAt.Should().NotBeNull();
+        installation.DisabledReason.Should().Be("Unregistered");
+        installation.UserId.Should().Be(user.Id);
+    }
+
+    [Test]
+    public async Task DisassociatePushInstallation_ClearsUserAndSessionBinding()
+    {
+        var user = await SeedUserAsync(name: "push-disassociate", email: "push-disassociate@example.com", password: "push-pass-123");
+        SetAuthorizationHeader(user.Id);
+
+        await Client.PostAsJsonAsync("/api/push/installations/register", new
+        {
+            installationId = "device-disassociate",
+            platform = "ios",
+            fcmToken = "token-disassociate",
+            appVersion = "1.0.0",
+            environment = "production"
+        });
+
+        var response = await Client.PostAsJsonAsync("/api/push/installations/disassociate", new
+        {
+            installationId = "device-disassociate"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var installation = await db.PushInstallations.SingleAsync(x => x.InstallationId == "device-disassociate");
+        installation.UserId.Should().BeNull();
+        installation.SessionId.Should().BeNull();
+        installation.DisabledAt.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Logout_DisassociatesInstallationsBoundToCurrentSession()
+    {
+        await SeedUserAsync(name: "push-logout", email: "push-logout@example.com", password: "push-pass-123");
+        var login = await LoginAsync("push-logout", "push-pass-123");
+        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login.Token);
+
+        await Client.PostAsJsonAsync("/api/push/installations/register", new
+        {
+            installationId = "device-logout",
+            platform = "android",
+            fcmToken = "token-logout",
+            appVersion = "1.0.0",
+            environment = "production"
+        });
+
+        var logoutResponse = await Client.PostAsync("/api/logout", null);
+        logoutResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var installation = await db.PushInstallations.SingleAsync(x => x.InstallationId == "device-logout");
+        installation.UserId.Should().BeNull();
+        installation.SessionId.Should().BeNull();
+    }
+
+    [Test]
+    public async Task RegisterPushInstallation_WithoutAuthorization_IsRejectedAndCreatesNoRows()
+    {
+        var response = await Client.PostAsJsonAsync("/api/push/installations/register", new
+        {
+            installationId = "device-anon",
+            platform = "android",
+            fcmToken = "token-anon",
+            appVersion = "1.0.0",
+            environment = "development"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        (await db.PushInstallations.CountAsync()).Should().Be(0);
+    }
+
+    private async Task<LoginResponse> LoginAsync(string name, string password)
+    {
+        var response = await Client.PostAsJsonAsync("/api/login", new { name, password });
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<LoginResponse>();
+        body.Should().NotBeNull();
+        return body!;
+    }
+
+    private sealed class LoginResponse
+    {
+        [JsonPropertyName("token")]
+        public string Token { get; set; } = string.Empty;
+    }
+}

--- a/LgymApi.IntegrationTests/PushNotificationPipelineIntegrationTests.cs
+++ b/LgymApi.IntegrationTests/PushNotificationPipelineIntegrationTests.cs
@@ -1,0 +1,150 @@
+using FluentAssertions;
+using LgymApi.Application.Notifications;
+using LgymApi.BackgroundWorker.Common.Push;
+using LgymApi.BackgroundWorker.Common.Push.Models;
+using LgymApi.BackgroundWorker.Push;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.Enums;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.Infrastructure.Data;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace LgymApi.IntegrationTests;
+
+[TestFixture]
+public sealed class PushNotificationPipelineIntegrationTests
+{
+    [Test]
+    public async Task EnqueueAsync_PersistsPendingAndSkippedRows_ByInstallationEligibility()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var user = await TestUtils.TestDataFactory.SeedUserAsync(db, "push-int-user", "push-int-user@example.com", "pass123");
+            db.PushInstallations.AddRange(
+                new PushInstallation
+                {
+                    Id = Id<PushInstallation>.New(),
+                    UserId = user.Id,
+                    InstallationId = "device-active",
+                    Platform = "android",
+                    FcmToken = "token-active",
+                    Environment = "development",
+                    PermissionStatus = "authorized",
+                    LastSeenAt = DateTimeOffset.UtcNow
+                },
+                new PushInstallation
+                {
+                    Id = Id<PushInstallation>.New(),
+                    UserId = user.Id,
+                    InstallationId = "device-denied",
+                    Platform = "ios",
+                    FcmToken = "token-denied",
+                    Environment = "development",
+                    PermissionStatus = "denied",
+                    LastSeenAt = DateTimeOffset.UtcNow
+                });
+            await db.SaveChangesAsync();
+
+            var service = scope.ServiceProvider.GetRequiredService<IPushNotificationService>();
+            await service.EnqueueAsync(new Application.Notifications.Models.EnqueuePushNotificationInput(
+                user.Id,
+                1,
+                "trainer.note.updated",
+                "event-integration-1",
+                null,
+                null,
+                null));
+        }
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var rows = db.PushNotificationMessages.OrderBy(x => x.EventId).ToList();
+            rows.Should().HaveCount(2);
+            rows.Should().ContainSingle(x => x.Status == PushNotificationStatus.Pending);
+            rows.Should().ContainSingle(x => x.Status == PushNotificationStatus.Skipped && x.FailureKind == PushNotificationFailureKind.Preference);
+        }
+    }
+
+    [Test]
+    public async Task ProcessAsync_WithInjectedInvalidTokenSender_DisablesInstallationAndPersistsFailure()
+    {
+        var fakeSender = new InvalidTokenPushProviderSender();
+        using var baseFactory = new CustomWebApplicationFactory();
+        using var factory = baseFactory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IPushProviderSender>();
+                services.AddSingleton<IPushProviderSender>(fakeSender);
+            });
+        });
+
+        Id<PushNotificationMessage> notificationId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var user = await TestUtils.TestDataFactory.SeedUserAsync(db, "push-int-send", "push-int-send@example.com", "pass123");
+            var installation = new PushInstallation
+            {
+                Id = Id<PushInstallation>.New(),
+                UserId = user.Id,
+                InstallationId = "device-invalid",
+                Platform = "android",
+                FcmToken = "token-invalid",
+                Environment = "development",
+                PermissionStatus = "authorized",
+                LastSeenAt = DateTimeOffset.UtcNow
+            };
+            db.PushInstallations.Add(installation);
+            await db.SaveChangesAsync();
+
+            var service = scope.ServiceProvider.GetRequiredService<IPushNotificationService>();
+            await service.EnqueueAsync(new Application.Notifications.Models.EnqueuePushNotificationInput(
+                user.Id,
+                1,
+                "trainer.note.updated",
+                "event-integration-2",
+                null,
+                null,
+                null));
+
+            notificationId = db.PushNotificationMessages.Single().Id;
+        }
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var handler = scope.ServiceProvider.GetRequiredService<PushNotificationJobHandlerService>();
+            await handler.ProcessAsync(notificationId);
+        }
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var installation = db.PushInstallations.Single(x => x.InstallationId == "device-invalid");
+            var message = db.PushNotificationMessages.Single(x => x.Id == notificationId);
+
+            installation.DisabledReason.Should().Be("InvalidFcmToken");
+            message.Status.Should().Be(PushNotificationStatus.Failed);
+            message.FailureKind.Should().Be(PushNotificationFailureKind.InvalidToken);
+            message.NextAttemptAt.Should().BeNull();
+        }
+    }
+
+    private sealed class InvalidTokenPushProviderSender : IPushProviderSender
+    {
+        public Task<PushSendAttemptResult> SendAsync(PushInstallation installation, PushEventPayload payload, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new PushSendAttemptResult(
+                PushSendOutcome.InvalidToken,
+                "BadRequest",
+                null,
+                "UNREGISTERED",
+                "registration-token-not-registered"));
+        }
+    }
+}

--- a/LgymApi.UnitTests/InAppNotifications/InAppNotificationServiceTests.cs
+++ b/LgymApi.UnitTests/InAppNotifications/InAppNotificationServiceTests.cs
@@ -90,8 +90,8 @@ public sealed class InAppNotificationServiceTests
         bridge.LastInput!.UserId.Should().Be(userId);
         bridge.LastInput.SchemaVersion.Should().Be(1);
         bridge.LastInput.Type.Should().Be(InAppNotificationTypes.ReportRequestReceived.Value);
-        bridge.LastInput.EventId.Should().Be(result.Value.Id.ToString());
-        bridge.LastInput.EntityId.Should().BeNull();
+        bridge.LastInput.EventKey.Should().Be(result.Value.Id.ToString());
+        bridge.LastInput.EntityKey.Should().BeNull();
         bridge.LastInput.InAppNotificationId.Should().Be(result.Value.Id);
         bridge.LastInput.Deeplink.Should().Be("/trainer/report-requests/request-1");
     }
@@ -323,7 +323,7 @@ public sealed class InAppNotificationServiceTests
         push.PushCalls.Should().Be(0);
         bridge.EnqueueCalls.Should().Be(1);
         bridge.LastInput!.InAppNotificationId.Should().Be(existing.Id);
-        bridge.LastInput.EventId.Should().Be(existing.Id.ToString());
+        bridge.LastInput.EventKey.Should().Be(existing.Id.ToString());
         unitOfWork.SaveChangesCalls.Should().Be(1);
         repo.DetachCalls.Should().Be(1);
     }

--- a/LgymApi.UnitTests/InAppNotifications/InAppNotificationServiceTests.cs
+++ b/LgymApi.UnitTests/InAppNotifications/InAppNotificationServiceTests.cs
@@ -8,6 +8,7 @@ using InAppNotificationService = global::LgymApi.Application.Notifications.InApp
 using IInAppNotificationServiceDependencies = global::LgymApi.Application.Notifications.IInAppNotificationServiceDependencies;
 using IInAppNotificationRepository = global::LgymApi.Application.Notifications.IInAppNotificationRepository;
 using IInAppNotificationPushPublisher = global::LgymApi.Application.Notifications.IInAppNotificationPushPublisher;
+using INotificationEventBridge = global::LgymApi.Application.Notifications.INotificationEventBridge;
 using LgymApi.Application.Notifications.Errors;
 using LgymApi.Application.Notifications.Models;
 using LgymApi.Domain.Notifications;
@@ -65,6 +66,49 @@ public sealed class InAppNotificationServiceTests
 
         push.PushCalls.Should().Be(1);
         push.LastPushed!.Message.Should().Be("Push me");
+    }
+
+    [Test]
+    public async Task CreateAsync_ValidInput_EnqueuesRemotePushNotification()
+    {
+        var bridge = new FakeNotificationEventBridge();
+        var service = CreateService(notificationEventBridge: bridge);
+        var userId = Id<User>.New();
+        var input = new CreateInAppNotificationInput(
+            userId,
+            null,
+            null,
+            true,
+            "Report request received",
+            "/trainer/report-requests/request-1",
+            InAppNotificationTypes.ReportRequestReceived);
+
+        var result = await service.CreateAsync(input);
+
+        bridge.EnqueueCalls.Should().Be(1);
+        bridge.LastInput.Should().NotBeNull();
+        bridge.LastInput!.UserId.Should().Be(userId);
+        bridge.LastInput.SchemaVersion.Should().Be(1);
+        bridge.LastInput.Type.Should().Be(InAppNotificationTypes.ReportRequestReceived.Value);
+        bridge.LastInput.EventId.Should().Be(result.Value.Id.ToString());
+        bridge.LastInput.EntityId.Should().BeNull();
+        bridge.LastInput.InAppNotificationId.Should().Be(result.Value.Id);
+        bridge.LastInput.Deeplink.Should().Be("/trainer/report-requests/request-1");
+    }
+
+    [Test]
+    public async Task CreateAsync_RemotePushEnqueueThrows_PropagatesForRetry()
+    {
+        var bridge = new FakeNotificationEventBridge { ThrowOnEnqueue = true };
+        var service = CreateService(notificationEventBridge: bridge);
+        var input = new CreateInAppNotificationInput(
+            Id<User>.New(), null, null, true, "Still ok", null, InAppNotificationTypes.InvitationSent);
+
+        var action = async () => await service.CreateAsync(input);
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Remote push enqueue failed");
+        bridge.EnqueueCalls.Should().Be(1);
     }
 
     [Test]
@@ -248,7 +292,7 @@ public sealed class InAppNotificationServiceTests
     }
 
     [Test]
-    public async Task CreateAsync_DuplicateDeliveryKey_ReturnsExistingNotificationWithoutPushingAgain()
+    public async Task CreateAsync_DuplicateDeliveryKey_ReturnsExistingNotificationWithoutSignalRPushAndEnqueuesRemotePush()
     {
         var repo = new FakeInAppNotificationRepository();
         var unitOfWork = new FakeUnitOfWork
@@ -256,12 +300,13 @@ public sealed class InAppNotificationServiceTests
             SaveChangesException = new DbUpdateException("duplicate IX_in_app_notifications_RecipientId_Type_DeliveryKey")
         };
         var push = new FakePushPublisher();
+        var bridge = new FakeNotificationEventBridge();
         var userId = Id<User>.New();
         var existing = AddNotification(repo, userId, "Already there");
         existing.Type = InAppNotificationTypes.InvitationSent;
         existing.DeliveryKey = "trainer-invitation:abc:sent";
 
-        var service = CreateService(repository: repo, unitOfWork: unitOfWork, pushPublisher: push);
+        var service = CreateService(repository: repo, unitOfWork: unitOfWork, pushPublisher: push, notificationEventBridge: bridge);
         var input = new CreateInAppNotificationInput(
             userId,
             null,
@@ -276,6 +321,10 @@ public sealed class InAppNotificationServiceTests
         result.IsSuccess.Should().BeTrue();
         result.Value.Id.Should().Be(existing.Id);
         push.PushCalls.Should().Be(0);
+        bridge.EnqueueCalls.Should().Be(1);
+        bridge.LastInput!.InAppNotificationId.Should().Be(existing.Id);
+        bridge.LastInput.EventId.Should().Be(existing.Id.ToString());
+        unitOfWork.SaveChangesCalls.Should().Be(1);
         repo.DetachCalls.Should().Be(1);
     }
 
@@ -284,12 +333,14 @@ public sealed class InAppNotificationServiceTests
     private static InAppNotificationService CreateService(
         FakeInAppNotificationRepository? repository = null,
         FakeUnitOfWork? unitOfWork = null,
-        FakePushPublisher? pushPublisher = null)
+        FakePushPublisher? pushPublisher = null,
+        FakeNotificationEventBridge? notificationEventBridge = null)
     {
         var deps = new TestDependencies(
             repository ?? new FakeInAppNotificationRepository(),
             unitOfWork ?? new FakeUnitOfWork(),
-            pushPublisher ?? new FakePushPublisher());
+            pushPublisher ?? new FakePushPublisher(),
+            notificationEventBridge ?? new FakeNotificationEventBridge());
         return new InAppNotificationService(deps, NullLogger<InAppNotificationService>.Instance);
     }
 
@@ -325,15 +376,18 @@ public sealed class InAppNotificationServiceTests
         public IInAppNotificationRepository InAppNotificationRepository { get; }
         public IUnitOfWork UnitOfWork { get; }
         public IInAppNotificationPushPublisher PushPublisher { get; }
+        public INotificationEventBridge NotificationEventBridge { get; }
 
         public TestDependencies(
             IInAppNotificationRepository repository,
             IUnitOfWork unitOfWork,
-            IInAppNotificationPushPublisher pushPublisher)
+            IInAppNotificationPushPublisher pushPublisher,
+            INotificationEventBridge notificationEventBridge)
         {
             InAppNotificationRepository = repository;
             UnitOfWork = unitOfWork;
             PushPublisher = pushPublisher;
+            NotificationEventBridge = notificationEventBridge;
         }
     }
 
@@ -478,6 +532,25 @@ public sealed class InAppNotificationServiceTests
             {
                 throw new InvalidOperationException("Push failed");
             }
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeNotificationEventBridge : INotificationEventBridge
+    {
+        public int EnqueueCalls { get; private set; }
+        public EnqueueNotificationEventInput? LastInput { get; private set; }
+        public bool ThrowOnEnqueue { get; set; }
+
+        public Task EnqueueAsync(EnqueueNotificationEventInput input, CancellationToken cancellationToken = default)
+        {
+            EnqueueCalls++;
+            LastInput = input;
+            if (ThrowOnEnqueue)
+            {
+                throw new InvalidOperationException("Remote push enqueue failed");
+            }
+
             return Task.CompletedTask;
         }
     }

--- a/LgymApi.UnitTests/InfrastructureServiceCollectionExtensionsTests.cs
+++ b/LgymApi.UnitTests/InfrastructureServiceCollectionExtensionsTests.cs
@@ -12,6 +12,7 @@ using LgymApi.Infrastructure.Options;
 using LgymApi.Infrastructure.Services;
 using LgymApi.BackgroundWorker.Actions;
 using LgymApi.Application.Abstractions.Storage;
+using LgymApi.BackgroundWorker.Common.Push;
 using LgymApi.TestUtils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -204,7 +205,7 @@ public sealed class InfrastructureServiceCollectionExtensionsTests
      }
 
      [Test]
-     public void AddBackgroundWorkerServices_RegistersNoOpScheduler_WhenTesting()
+      public void AddBackgroundWorkerServices_RegistersNoOpScheduler_WhenTesting()
      {
          var services = new ServiceCollection();
          var configuration = TestConfigurationBuilder.BuildConfiguration(new Dictionary<string, string?>
@@ -218,9 +219,38 @@ public sealed class InfrastructureServiceCollectionExtensionsTests
          services.AddScoped<IInAppNotificationPushPublisher, FakeInAppNotificationPushPublisher>();
 
          using var provider = services.BuildServiceProvider();
-         var scheduler = provider.GetRequiredService<IActionMessageScheduler>();
-         scheduler.Should().BeOfType<NoOpActionMessageScheduler>();
-     }
+          var scheduler = provider.GetRequiredService<IActionMessageScheduler>();
+          scheduler.Should().BeOfType<NoOpActionMessageScheduler>();
+          provider.GetRequiredService<IPushBackgroundScheduler>().Should().BeOfType<LgymApi.BackgroundWorker.Services.NoOpPushBackgroundScheduler>();
+      }
+
+      [Test]
+      public void AddInfrastructure_Throws_WhenPushSendsEnabledWithoutProjectId()
+       {
+           var services = new ServiceCollection();
+           var values = TestConfigurationBuilder.ToDictionary(TestConfigurationBuilder.BuildEnabledEmailConfiguration());
+           values["PushNotifications:SendEnabled"] = "true";
+           values["PushNotifications:Fcm:CredentialsJson"] = "{ }";
+
+           var action = () => services.AddInfrastructure(TestConfigurationBuilder.BuildConfiguration(values), enableSensitiveLogging: false, isTesting: true);
+
+          action.Should()
+               .Throw<InvalidOperationException>()
+               .WithMessage("PushNotifications:Fcm:ProjectId is required when push notifications are enabled.");
+       }
+
+      [Test]
+      public void AddInfrastructure_DoesNotRequireFcmCredentials_WhenPushSendsDisabled()
+      {
+          var services = new ServiceCollection();
+          var values = TestConfigurationBuilder.ToDictionary(TestConfigurationBuilder.BuildEnabledEmailConfiguration());
+          values["PushNotifications:SendEnabled"] = "false";
+          values["PushNotifications:StaleTokenCleanupEnabled"] = "true";
+
+          var action = () => services.AddInfrastructure(TestConfigurationBuilder.BuildConfiguration(values), enableSensitiveLogging: false, isTesting: true);
+
+          action.Should().NotThrow();
+      }
 
      [Test]
      public void AddBackgroundWorkerServices_RegistersHangfireScheduler_WhenNotTesting()

--- a/LgymApi.UnitTests/NotificationEventBridgeTests.cs
+++ b/LgymApi.UnitTests/NotificationEventBridgeTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using LgymApi.Application.Notifications;
+using LgymApi.Application.Notifications.Models;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.ValueObjects;
+using NSubstitute;
+
+namespace LgymApi.UnitTests;
+
+[TestFixture]
+public sealed class NotificationEventBridgeTests
+{
+    [Test]
+    public async Task EnqueueAsync_ForwardsOptionalInAppNotificationId()
+    {
+        var pushNotificationService = Substitute.For<IPushNotificationService>();
+        var bridge = new NotificationEventBridge(pushNotificationService);
+        var userId = Id<User>.New();
+        var inAppNotificationId = Id<InAppNotification>.New();
+        var input = new EnqueueNotificationEventInput(
+            userId,
+            1,
+            "test.event",
+            "event-123",
+            "entity-123",
+            inAppNotificationId,
+            "/notifications");
+
+        await bridge.EnqueueAsync(input);
+
+        await pushNotificationService.Received(1).EnqueueAsync(
+            Arg.Is<EnqueuePushNotificationInput>(queued =>
+                queued.UserId == userId
+                && queued.SchemaVersion == 1
+                && queued.Type == "test.event"
+                && queued.EventId == "event-123"
+                && queued.EntityId == "entity-123"
+                && queued.InAppNotificationId == inAppNotificationId
+                && queued.Deeplink == "/notifications"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task EnqueueAsync_AllowsMissingInAppNotificationId()
+    {
+        var pushNotificationService = Substitute.For<IPushNotificationService>();
+        var bridge = new NotificationEventBridge(pushNotificationService);
+        var input = new EnqueueNotificationEventInput(
+            Id<User>.New(),
+            1,
+            "test.event",
+            "event-456",
+            null,
+            null,
+            null);
+
+        await bridge.EnqueueAsync(input);
+
+        await pushNotificationService.Received(1).EnqueueAsync(
+            Arg.Is<EnqueuePushNotificationInput>(queued => queued.InAppNotificationId == null),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/LgymApi.UnitTests/NotificationEventBridgeTests.cs
+++ b/LgymApi.UnitTests/NotificationEventBridgeTests.cs
@@ -33,8 +33,8 @@ public sealed class NotificationEventBridgeTests
                 queued.UserId == userId
                 && queued.SchemaVersion == 1
                 && queued.Type == "test.event"
-                && queued.EventId == "event-123"
-                && queued.EntityId == "entity-123"
+                && queued.EventKey == "event-123"
+                && queued.EntityKey == "entity-123"
                 && queued.InAppNotificationId == inAppNotificationId
                 && queued.Deeplink == "/notifications"),
             Arg.Any<CancellationToken>());

--- a/LgymApi.UnitTests/PushNotificationPipelineTests.cs
+++ b/LgymApi.UnitTests/PushNotificationPipelineTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Reflection;
 using System.Text.Json;
 using FluentAssertions;
@@ -269,6 +270,80 @@ public sealed class PushNotificationPipelineTests
         message.GetProperty("data").GetProperty("inAppNotificationId").GetString().Should().Be("notification-1");
     }
 
+    [Test]
+    public async Task FcmSender_WhenSendingDisabled_ReturnsSkippedWithoutHttpCall()
+    {
+        var httpClientFactory = new FakeHttpClientFactory();
+        var sender = new FcmPushSender(
+            httpClientFactory,
+            new PushNotificationOptions { SendEnabled = false },
+            NullLogger<FcmPushSender>.Instance);
+        var installation = CreateInstallation(Id<User>.New(), permissionStatus: "authorized");
+        var payload = new PushEventPayload(1, "internal.test.push", "event-1", null, null, null);
+
+        var result = await sender.SendAsync(installation, payload);
+
+        result.Outcome.Should().Be(PushSendOutcome.Skipped);
+        result.ProviderStatus.Should().Be("Skipped");
+        result.ProviderErrorCode.Should().Be("push-disabled");
+        httpClientFactory.CreateClientCalls.Should().Be(0);
+    }
+
+    [Test]
+    public void FcmSender_BuildsProjectScopedSendUrl()
+    {
+        var sender = new FcmPushSender(
+            new FakeHttpClientFactory(),
+            new PushNotificationOptions
+            {
+                Fcm = { BaseUrl = "https://fcm.example.test", ProjectId = "lgym-test" }
+            },
+            NullLogger<FcmPushSender>.Instance);
+
+        var url = InvokePrivate<string>(sender, "BuildSendUrl");
+
+        url.Should().Be("https://fcm.example.test/v1/projects/lgym-test/messages:send");
+    }
+
+    [TestCase(HttpStatusCode.BadRequest, "registration-token-not-registered", PushSendOutcome.InvalidToken)]
+    [TestCase(HttpStatusCode.ServiceUnavailable, "provider unavailable", PushSendOutcome.TransientFailure)]
+    [TestCase(HttpStatusCode.BadGateway, "bad gateway", PushSendOutcome.TransientFailure)]
+    [TestCase(HttpStatusCode.BadRequest, "invalid payload", PushSendOutcome.PermanentFailure)]
+    public void FcmSender_ClassifiesProviderFailures(HttpStatusCode statusCode, string summary, PushSendOutcome expectedOutcome)
+    {
+        var outcome = InvokeStaticPrivate<PushSendOutcome>(
+            typeof(FcmPushSender),
+            "ClassifyFailure",
+            statusCode,
+            summary);
+
+        outcome.Should().Be(expectedOutcome);
+    }
+
+    [Test]
+    public void FcmSender_ExtractsProviderValuesFromDirectAndNestedJson()
+    {
+        InvokeStaticPrivate<string?>(typeof(FcmPushSender), "TryExtractValue", "{\"name\":\"projects/lgym/messages/1\"}", "name")
+            .Should().Be("projects/lgym/messages/1");
+        InvokeStaticPrivate<string?>(typeof(FcmPushSender), "TryExtractValue", "{\"error\":{\"status\":\"UNREGISTERED\"}}", "status")
+            .Should().Be("UNREGISTERED");
+        InvokeStaticPrivate<string?>(typeof(FcmPushSender), "TryExtractValue", "not-json", "status")
+            .Should().BeNull();
+        InvokeStaticPrivate<string?>(typeof(FcmPushSender), "TryExtractValue", string.Empty, "status")
+            .Should().BeNull();
+    }
+
+    [Test]
+    public void FcmSender_SummarizesProviderResponses()
+    {
+        InvokeStaticPrivate<string>(typeof(FcmPushSender), "Summarize", " first\r\nsecond ")
+            .Should().Be("first  second");
+        InvokeStaticPrivate<string>(typeof(FcmPushSender), "Summarize", new string('x', 1005))
+            .Should().HaveLength(1000);
+        InvokeStaticPrivate<string>(typeof(FcmPushSender), "Summarize", (object?)null)
+            .Should().BeEmpty();
+    }
+
     private static AppDbContext CreateDbContext(string name)
         => new(new DbContextOptionsBuilder<AppDbContext>()
             .UseInMemoryDatabase($"{name}-{Id<PushNotificationPipelineTests>.New():N}")
@@ -299,6 +374,20 @@ public sealed class PushNotificationPipelineTests
             PayloadJson = "{\"schemaVersion\":1,\"type\":\"trainer.note.updated\",\"eventId\":\"event-1\"}",
             Status = PushNotificationStatus.Pending
         };
+
+    private static TResult InvokePrivate<TResult>(object instance, string methodName, params object?[] parameters)
+    {
+        var method = instance.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Should().NotBeNull();
+        return (TResult)method!.Invoke(instance, parameters)!;
+    }
+
+    private static TResult InvokeStaticPrivate<TResult>(Type type, string methodName, params object?[] parameters)
+    {
+        var method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);
+        method.Should().NotBeNull();
+        return (TResult)method!.Invoke(null, parameters)!;
+    }
 
     private sealed class FakePushBackgroundScheduler : IPushBackgroundScheduler
     {
@@ -338,7 +427,13 @@ public sealed class PushNotificationPipelineTests
 
     private sealed class FakeHttpClientFactory : IHttpClientFactory
     {
-        public HttpClient CreateClient(string name) => new();
+        public int CreateClientCalls { get; private set; }
+
+        public HttpClient CreateClient(string name)
+        {
+            CreateClientCalls += 1;
+            return new HttpClient();
+        }
     }
 
     private sealed class FakePushNotificationMessageRepository : IPushNotificationMessageRepository

--- a/LgymApi.UnitTests/PushNotificationPipelineTests.cs
+++ b/LgymApi.UnitTests/PushNotificationPipelineTests.cs
@@ -1,0 +1,431 @@
+using System.Reflection;
+using System.Text.Json;
+using FluentAssertions;
+using LgymApi.Application.Notifications;
+using LgymApi.Application.Notifications.Models;
+using LgymApi.Application.Repositories;
+using LgymApi.BackgroundWorker.Common.Push;
+using LgymApi.BackgroundWorker.Common.Push.Models;
+using LgymApi.BackgroundWorker.Push;
+using LgymApi.Domain.Entities;
+using LgymApi.Domain.Enums;
+using LgymApi.Domain.ValueObjects;
+using LgymApi.Infrastructure.Data;
+using LgymApi.Infrastructure.Options;
+using LgymApi.Infrastructure.Repositories;
+using LgymApi.Infrastructure.Services;
+using LgymApi.Infrastructure.UnitOfWork;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace LgymApi.UnitTests;
+
+[TestFixture]
+public sealed class PushNotificationPipelineTests
+{
+    [Test]
+    public async Task EnqueueAsync_WhenRepeated_DoesNotCreateDuplicateRowsOrReschedule()
+    {
+        await using var db = CreateDbContext("push-enqueue-duplicate");
+        var userId = Id<User>.New();
+        var installation = CreateInstallation(userId, permissionStatus: "authorized");
+        db.PushInstallations.Add(installation);
+        await db.SaveChangesAsync();
+
+        var scheduler = new FakePushBackgroundScheduler();
+        var service = new PushNotificationService(
+            new PushInstallationRepository(db),
+            new PushNotificationMessageRepository(db),
+            scheduler,
+            new EfUnitOfWork(db),
+            NullLogger<PushNotificationService>.Instance);
+
+        var input = new EnqueuePushNotificationInput(
+            userId,
+            1,
+            "trainer.note.updated",
+            "event-1",
+            "entity-1",
+            null,
+            "/notifications/event-1");
+
+        await service.EnqueueAsync(input);
+        await service.EnqueueAsync(input);
+
+        db.PushNotificationMessages.Should().HaveCount(1);
+        db.PushNotificationMessages.Single().Status.Should().Be(PushNotificationStatus.Pending);
+        scheduler.EnqueuedNotificationIds.Should().HaveCount(1);
+    }
+
+    [Test]
+    public async Task EnqueueAsync_WhenExistingPendingMessageHasNoSchedulerJob_ReschedulesExistingMessage()
+    {
+        await using var db = CreateDbContext("push-enqueue-reschedule-existing");
+        var userId = Id<User>.New();
+        var installation = CreateInstallation(userId, permissionStatus: "authorized");
+        var existing = new PushNotificationMessage
+        {
+            Id = Id<PushNotificationMessage>.New(),
+            UserId = userId,
+            PushInstallationId = installation.Id,
+            SchemaVersion = 1,
+            Type = "trainer.note.updated",
+            EventId = "event-1",
+            PayloadJson = "{}",
+            Status = PushNotificationStatus.Pending,
+            SchedulerJobId = null
+        };
+        db.PushInstallations.Add(installation);
+        db.PushNotificationMessages.Add(existing);
+        await db.SaveChangesAsync();
+
+        var scheduler = new FakePushBackgroundScheduler();
+        var service = new PushNotificationService(
+            new PushInstallationRepository(db),
+            new PushNotificationMessageRepository(db),
+            scheduler,
+            new EfUnitOfWork(db),
+            NullLogger<PushNotificationService>.Instance);
+
+        await service.EnqueueAsync(new EnqueuePushNotificationInput(
+            userId,
+            1,
+            "trainer.note.updated",
+            "event-1",
+            "entity-1",
+            null,
+            "/notifications/event-1"));
+
+        db.PushNotificationMessages.Should().HaveCount(1);
+        scheduler.EnqueuedNotificationIds.Should().ContainSingle().Which.Should().Be(existing.Id);
+        existing.SchedulerJobId.Should().Be("push-job-id");
+    }
+
+    [Test]
+    public async Task EnqueueAsync_WhenPermissionDenied_PersistsSkippedMessageWithoutScheduling()
+    {
+        await using var db = CreateDbContext("push-enqueue-skipped");
+        var userId = Id<User>.New();
+        db.PushInstallations.Add(CreateInstallation(userId, permissionStatus: "denied"));
+        await db.SaveChangesAsync();
+
+        var scheduler = new FakePushBackgroundScheduler();
+        var service = new PushNotificationService(
+            new PushInstallationRepository(db),
+            new PushNotificationMessageRepository(db),
+            scheduler,
+            new EfUnitOfWork(db),
+            NullLogger<PushNotificationService>.Instance);
+
+        await service.EnqueueAsync(new EnqueuePushNotificationInput(
+            userId,
+            1,
+            "trainer.note.updated",
+            "event-2",
+            null,
+            null,
+            null));
+
+        db.PushNotificationMessages.Should().HaveCount(1);
+        var message = db.PushNotificationMessages.Single();
+        message.Status.Should().Be(PushNotificationStatus.Skipped);
+        message.FailureKind.Should().Be(PushNotificationFailureKind.Preference);
+        scheduler.EnqueuedNotificationIds.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ProcessAsync_WhenInvalidToken_DisablesInstallationWithoutRetry()
+    {
+        var installation = CreateInstallation(Id<User>.New(), permissionStatus: "authorized");
+        var message = CreateMessage(installation.Id);
+        var repository = new FakePushNotificationMessageRepository(message);
+        var installationRepository = new FakePushInstallationRepository(installation);
+        var scheduler = new FakePushBackgroundScheduler();
+        var handler = new PushNotificationJobHandlerService(
+            repository,
+            installationRepository,
+            new FakePushProviderSender(new PushSendAttemptResult(PushSendOutcome.InvalidToken, "BadRequest", null, "UNREGISTERED", "registration-token-not-registered")),
+            scheduler,
+            new FakeUnitOfWork(),
+            new PushNotificationOptions(),
+            NullLogger<PushNotificationJobHandlerService>.Instance);
+
+        await handler.ProcessAsync(message.Id);
+
+        message.Status.Should().Be(PushNotificationStatus.Failed);
+        message.FailureKind.Should().Be(PushNotificationFailureKind.InvalidToken);
+        message.NextAttemptAt.Should().BeNull();
+        installation.DisabledReason.Should().Be("InvalidFcmToken");
+        installation.DisabledAt.Should().NotBeNull();
+        scheduler.ScheduledRetries.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ProcessAsync_WhenTransientFailure_SchedulesRetry()
+    {
+        var installation = CreateInstallation(Id<User>.New(), permissionStatus: "authorized");
+        var message = CreateMessage(installation.Id);
+        var repository = new FakePushNotificationMessageRepository(message);
+        var scheduler = new FakePushBackgroundScheduler();
+        var handler = new PushNotificationJobHandlerService(
+            repository,
+            new FakePushInstallationRepository(installation),
+            new FakePushProviderSender(new PushSendAttemptResult(PushSendOutcome.TransientFailure, "ServiceUnavailable", null, "UNAVAILABLE", "temporary outage")),
+            scheduler,
+            new FakeUnitOfWork(),
+            new PushNotificationOptions { RetryDelaysSeconds = [5] },
+            NullLogger<PushNotificationJobHandlerService>.Instance);
+
+        await handler.ProcessAsync(message.Id);
+
+        message.Status.Should().Be(PushNotificationStatus.Failed);
+        message.FailureKind.Should().Be(PushNotificationFailureKind.Transient);
+        message.NextAttemptAt.Should().NotBeNull();
+        scheduler.ScheduledRetries.Should().ContainSingle();
+        scheduler.ScheduledRetries[0].notificationId.Should().Be(message.Id);
+        scheduler.ScheduledRetries[0].delay.Should().Be(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ProcessAsync_WhenClaimFails_DoesNotSendAgain()
+    {
+        var installation = CreateInstallation(Id<User>.New(), permissionStatus: "authorized");
+        var message = CreateMessage(installation.Id);
+        var repository = new FakePushNotificationMessageRepository(message) { TryClaimResult = false };
+        var sender = new FakePushProviderSender(new PushSendAttemptResult(PushSendOutcome.Sent, "OK", "message-1", null, "ok"));
+        var handler = new PushNotificationJobHandlerService(
+            repository,
+            new FakePushInstallationRepository(installation),
+            sender,
+            new FakePushBackgroundScheduler(),
+            new FakeUnitOfWork(),
+            new PushNotificationOptions(),
+            NullLogger<PushNotificationJobHandlerService>.Instance);
+
+        await handler.ProcessAsync(message.Id);
+
+        sender.SendCalls.Should().Be(0);
+        message.Attempts.Should().Be(0);
+    }
+
+    [Test]
+    public async Task CleanupAsync_WhenInstallationIsStale_DisablesItWithoutDeletingAuditState()
+    {
+        var staleInstallation = CreateInstallation(Id<User>.New(), permissionStatus: "authorized");
+        staleInstallation.LastSeenAt = DateTimeOffset.UtcNow.AddDays(-60);
+        var recentInstallation = CreateInstallation(Id<User>.New(), permissionStatus: "authorized");
+        recentInstallation.LastSeenAt = DateTimeOffset.UtcNow.AddDays(-5);
+
+        var repository = new FakePushInstallationRepository(staleInstallation, recentInstallation);
+        var unitOfWork = new FakeUnitOfWork();
+        var service = new StalePushInstallationCleanupService(
+            repository,
+            unitOfWork,
+            new FakeStalePushInstallationCleanupSettings
+            {
+                Enabled = true,
+                InactivityDays = 30,
+                BatchSize = 10
+            },
+            NullLogger<StalePushInstallationCleanupService>.Instance);
+
+        var cleaned = await service.CleanupAsync();
+
+        cleaned.Should().Be(1);
+        staleInstallation.DisabledReason.Should().Be(StalePushInstallationCleanupService.StaleInstallationDisabledReason);
+        staleInstallation.DisabledAt.Should().NotBeNull();
+        recentInstallation.DisabledAt.Should().BeNull();
+        unitOfWork.SaveChangesCalls.Should().Be(1);
+    }
+
+    [Test]
+    public async Task FcmSender_BuildsPrivacySafeNotificationPayloadForAndroidDisplay()
+    {
+        var sender = new FcmPushSender(
+            new FakeHttpClientFactory(),
+            new PushNotificationOptions(),
+            NullLogger<FcmPushSender>.Instance);
+        var installation = CreateInstallation(Id<User>.New(), permissionStatus: "authorized");
+        var payload = new PushEventPayload(
+            1,
+            "internal.test.push",
+            "event-1",
+            "entity-1",
+            "notification-1",
+            "/notifications");
+
+        var method = typeof(FcmPushSender).GetMethod("BuildRequestContent", BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Should().NotBeNull();
+
+        using var content = (StringContent)method!.Invoke(sender, [installation, payload])!;
+        var json = await content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(json);
+        var message = document.RootElement.GetProperty("message");
+
+        message.GetProperty("notification").GetProperty("title").GetString().Should().Be("LGYM");
+        message.GetProperty("notification").GetProperty("body").GetString().Should().Be("You have a new notification.");
+        message.GetProperty("android").GetProperty("priority").GetString().Should().Be("HIGH");
+        message.GetProperty("data").GetProperty("deeplink").GetString().Should().Be("/notifications");
+        message.GetProperty("data").GetProperty("inAppNotificationId").GetString().Should().Be("notification-1");
+    }
+
+    private static AppDbContext CreateDbContext(string name)
+        => new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"{name}-{Id<PushNotificationPipelineTests>.New():N}")
+            .Options);
+
+    private static PushInstallation CreateInstallation(Id<User> userId, string permissionStatus)
+        => new()
+        {
+            Id = Id<PushInstallation>.New(),
+            UserId = userId,
+            InstallationId = $"device-{Id<PushInstallation>.New():N}",
+            Platform = "android",
+            FcmToken = "token-1",
+            Environment = "development",
+            PermissionStatus = permissionStatus,
+            LastSeenAt = DateTimeOffset.UtcNow
+        };
+
+    private static PushNotificationMessage CreateMessage(Id<PushInstallation> installationId)
+        => new()
+        {
+            Id = Id<PushNotificationMessage>.New(),
+            UserId = Id<User>.New(),
+            PushInstallationId = installationId,
+            SchemaVersion = 1,
+            Type = "trainer.note.updated",
+            EventId = "event-1",
+            PayloadJson = "{\"schemaVersion\":1,\"type\":\"trainer.note.updated\",\"eventId\":\"event-1\"}",
+            Status = PushNotificationStatus.Pending
+        };
+
+    private sealed class FakePushBackgroundScheduler : IPushBackgroundScheduler
+    {
+        public List<Id<PushNotificationMessage>> EnqueuedNotificationIds { get; } = [];
+        public List<(Id<PushNotificationMessage> notificationId, TimeSpan delay)> ScheduledRetries { get; } = [];
+
+        public string? Enqueue(Id<PushNotificationMessage> notificationId)
+        {
+            EnqueuedNotificationIds.Add(notificationId);
+            return "push-job-id";
+        }
+
+        public string? ScheduleRetry(Id<PushNotificationMessage> notificationId, TimeSpan delay)
+        {
+            ScheduledRetries.Add((notificationId, delay));
+            return "push-retry-job-id";
+        }
+    }
+
+    private sealed class FakePushProviderSender : IPushProviderSender
+    {
+        private readonly PushSendAttemptResult _result;
+
+        public FakePushProviderSender(PushSendAttemptResult result)
+        {
+            _result = result;
+        }
+
+        public int SendCalls { get; private set; }
+
+        public Task<PushSendAttemptResult> SendAsync(PushInstallation installation, PushEventPayload payload, CancellationToken cancellationToken = default)
+        {
+            SendCalls += 1;
+            return Task.FromResult(_result);
+        }
+    }
+
+    private sealed class FakeHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+
+    private sealed class FakePushNotificationMessageRepository : IPushNotificationMessageRepository
+    {
+        private readonly PushNotificationMessage _message;
+
+        public FakePushNotificationMessageRepository(PushNotificationMessage message)
+        {
+            _message = message;
+        }
+
+        public bool TryClaimResult { get; set; } = true;
+
+        public Task AddAsync(PushNotificationMessage message, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<PushNotificationMessage?> FindByIdAsync(Id<PushNotificationMessage> id, CancellationToken cancellationToken = default)
+            => Task.FromResult<PushNotificationMessage?>(_message.Id == id ? _message : null);
+
+        public Task<PushNotificationMessage?> FindByDeliveryKeyAsync(Id<PushInstallation> installationId, string type, string eventId, CancellationToken cancellationToken = default)
+            => Task.FromResult<PushNotificationMessage?>(null);
+
+        public Task<bool> TryTransitionToSendingAsync(Id<PushNotificationMessage> id, CancellationToken cancellationToken = default)
+            => Task.FromResult(TryClaimResult);
+
+        public Task UpdateAsync(PushNotificationMessage message, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<List<PushNotificationMessage>> GetByStatusAsync(PushNotificationStatus status, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<PushNotificationMessage>());
+    }
+
+    private sealed class FakePushInstallationRepository : IPushInstallationRepository
+    {
+        private readonly List<PushInstallation> _installations;
+
+        public FakePushInstallationRepository(params PushInstallation[] installations)
+        {
+            _installations = installations.ToList();
+        }
+
+        public Task<PushInstallation?> FindByIdAsync(Id<PushInstallation> id, CancellationToken cancellationToken = default)
+            => Task.FromResult<PushInstallation?>(_installations.FirstOrDefault(x => x.Id == id));
+
+        public Task<PushInstallation?> FindByInstallationIdAsync(string installationId, CancellationToken cancellationToken = default)
+            => Task.FromResult<PushInstallation?>(_installations.FirstOrDefault(x => x.InstallationId == installationId));
+
+        public Task<PushInstallation?> FindBoundToUserOrSessionAsync(string installationId, Id<User> userId, Id<UserSession> sessionId, CancellationToken cancellationToken = default)
+            => Task.FromResult<PushInstallation?>(_installations.FirstOrDefault(x => x.InstallationId == installationId && (x.UserId == userId || x.SessionId == sessionId)));
+
+        public Task<List<PushInstallation>> GetActiveByUserIdAsync(Id<User> userId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_installations.Where(x => x.UserId == userId && x.DisabledAt == null).ToList());
+
+        public Task<List<PushInstallation>> GetBySessionIdAsync(Id<UserSession> sessionId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_installations.Where(x => x.SessionId == sessionId).ToList());
+
+        public Task<List<PushInstallation>> GetStaleActiveAsync(DateTimeOffset lastSeenBefore, int limit, CancellationToken cancellationToken = default)
+            => Task.FromResult(_installations.Where(x => x.DisabledAt == null && x.LastSeenAt < lastSeenBefore).OrderBy(x => x.LastSeenAt).Take(limit).ToList());
+
+        public Task AddAsync(PushInstallation installation, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task UpdateAsync(PushInstallation installation, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class FakeUnitOfWork : IUnitOfWork
+    {
+        public int SaveChangesCalls { get; private set; }
+
+        public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            SaveChangesCalls += 1;
+            return Task.FromResult(1);
+        }
+
+        public Task<IUnitOfWorkTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IUnitOfWorkTransaction>(new FakeUnitOfWorkTransaction());
+    }
+
+    private sealed class FakeUnitOfWorkTransaction : IUnitOfWorkTransaction
+    {
+        public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public Task RollbackAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class FakeStalePushInstallationCleanupSettings : IStalePushInstallationCleanupSettings
+    {
+        public bool Enabled { get; init; }
+        public int InactivityDays { get; init; }
+        public int BatchSize { get; init; }
+    }
+}

--- a/LgymApi.UnitTests/ServiceCommitBehaviorTests.cs
+++ b/LgymApi.UnitTests/ServiceCommitBehaviorTests.cs
@@ -484,6 +484,7 @@ public sealed class ServiceCommitBehaviorTests
             AppDefaultsOptions appDefaultsOptions,
             ITutorialService tutorialService)
         {
+            PushInstallationRepository = NSubstitute.Substitute.For<IPushInstallationRepository>();
             UserRepository = userRepository;
             RoleRepository = roleRepository;
             EloRepository = eloRepository;
@@ -498,6 +499,7 @@ public sealed class ServiceCommitBehaviorTests
             TutorialService = tutorialService;
         }
 
+        public IPushInstallationRepository PushInstallationRepository { get; }
         public IUserRepository UserRepository { get; }
         public IRoleRepository RoleRepository { get; }
         public IEloRegistryRepository EloRepository { get; }

--- a/LgymApi.UnitTests/UserControllerTests.cs
+++ b/LgymApi.UnitTests/UserControllerTests.cs
@@ -116,7 +116,7 @@ public sealed class UserControllerTests
         userService.LastPushRegistration.Should().NotBeNull();
         userService.LastPushRegistration!.Value.SessionId.Should().Be(sessionId);
         userService.LastPushRegistration.Value.UserId.Should().Be(userId);
-        userService.LastPushRegistration.Value.Input.InstallationId.Should().Be("device-1");
+        userService.LastPushRegistration.Value.Input.InstallationKey.Should().Be("device-1");
         userService.LastPushRegistration.Value.Input.FcmToken.Should().Be("token-1");
     }
 
@@ -137,7 +137,7 @@ public sealed class UserControllerTests
         action.Should().BeOfType<OkObjectResult>();
         userService.LastPushDisassociate.Should().NotBeNull();
         userService.LastPushDisassociate!.Value.SessionId.Should().Be(sessionId);
-        userService.LastPushDisassociate.Value.Input.InstallationId.Should().Be("device-2");
+        userService.LastPushDisassociate.Value.Input.InstallationKey.Should().Be("device-2");
     }
 
     private static UserController CreateController(IUserService userService)

--- a/LgymApi.UnitTests/UserControllerTests.cs
+++ b/LgymApi.UnitTests/UserControllerTests.cs
@@ -93,6 +93,53 @@ public sealed class UserControllerTests
         ((ResponseMessageDto)objectResult.Value!).Message.Should().Be(message);
     }
 
+    [Test]
+    public async Task RegisterPushInstallation_PassesCurrentSessionIdAndRequestPayload()
+    {
+        var userService = new StubUserService();
+        var controller = CreateController(userService);
+        var userId = Id<User>.New();
+        var sessionId = Id<UserSession>.New();
+        controller.ControllerContext = new ControllerContext { HttpContext = BuildAuthenticatedHttpContext(userId, sessionId) };
+
+        var action = await controller.RegisterPushInstallation(new RegisterPushInstallationRequest
+        {
+            InstallationId = "device-1",
+            Platform = "ios",
+            FcmToken = "token-1",
+            AppVersion = "1.2.3",
+            Environment = "production",
+            PermissionStatus = "authorized"
+        });
+
+        action.Should().BeOfType<OkObjectResult>();
+        userService.LastPushRegistration.Should().NotBeNull();
+        userService.LastPushRegistration!.Value.SessionId.Should().Be(sessionId);
+        userService.LastPushRegistration.Value.UserId.Should().Be(userId);
+        userService.LastPushRegistration.Value.Input.InstallationId.Should().Be("device-1");
+        userService.LastPushRegistration.Value.Input.FcmToken.Should().Be("token-1");
+    }
+
+    [Test]
+    public async Task DisassociatePushInstallation_PassesCurrentSessionIdAndInstallationId()
+    {
+        var userService = new StubUserService();
+        var controller = CreateController(userService);
+        var userId = Id<User>.New();
+        var sessionId = Id<UserSession>.New();
+        controller.ControllerContext = new ControllerContext { HttpContext = BuildAuthenticatedHttpContext(userId, sessionId) };
+
+        var action = await controller.DisassociatePushInstallation(new PushInstallationActionRequest
+        {
+            InstallationId = "device-2"
+        });
+
+        action.Should().BeOfType<OkObjectResult>();
+        userService.LastPushDisassociate.Should().NotBeNull();
+        userService.LastPushDisassociate!.Value.SessionId.Should().Be(sessionId);
+        userService.LastPushDisassociate.Value.Input.InstallationId.Should().Be("device-2");
+    }
+
     private static UserController CreateController(IUserService userService)
     {
         var services = new ServiceCollection();
@@ -101,6 +148,20 @@ public sealed class UserControllerTests
         var mapper = provider.GetRequiredService<IMapper>();
         var stubPasswordResetService = new StubPasswordResetService();
         return new UserController(userService, stubPasswordResetService, mapper);
+    }
+
+    private static DefaultHttpContext BuildAuthenticatedHttpContext(Id<User> userId, Id<UserSession> sessionId)
+    {
+        var context = new DefaultHttpContext();
+        context.Items["User"] = new User { Id = userId, Name = "test-user", Email = "test-user@example.com" };
+        context.User = new System.Security.Claims.ClaimsPrincipal(
+            new System.Security.Claims.ClaimsIdentity(
+            [
+                new System.Security.Claims.Claim("userId", userId.ToString()),
+                new System.Security.Claims.Claim("sid", sessionId.ToString())
+            ],
+            authenticationType: "Test"));
+        return context;
     }
 
     private sealed class StubPasswordResetService : IPasswordResetService
@@ -116,6 +177,8 @@ public sealed class UserControllerTests
     {
         public string? LastPreferredLanguage { get; private set; }
         public Result<Unit, AppError> RegisterResult { get; set; } = Result<Unit, AppError>.Success(Unit.Value);
+        public (Id<User> UserId, Id<UserSession>? SessionId, RegisterPushInstallationInput Input)? LastPushRegistration { get; private set; }
+        public (Id<User> UserId, Id<UserSession>? SessionId, PushInstallationActionInput Input)? LastPushDisassociate { get; private set; }
 
         public Task<Result<Unit, AppError>> RegisterAsync(RegisterUserInput input, CancellationToken cancellationToken = default)
         {
@@ -124,6 +187,21 @@ public sealed class UserControllerTests
         }
 
         public Task<Result<Unit, AppError>> RegisterTrainerAsync(RegisterUserInput input, CancellationToken cancellationToken = default) => Task.FromResult(Result<Unit, AppError>.Success(Unit.Value));
+        public Task<Result<Unit, AppError>> RegisterPushInstallationAsync(User? currentUser, Id<UserSession>? sessionId, RegisterPushInstallationInput input, CancellationToken cancellationToken = default)
+        {
+            LastPushRegistration = (currentUser!.Id, sessionId, input);
+            return Task.FromResult(Result<Unit, AppError>.Success(Unit.Value));
+        }
+
+        public Task<Result<Unit, AppError>> UnregisterPushInstallationAsync(User? currentUser, Id<UserSession>? sessionId, PushInstallationActionInput input, CancellationToken cancellationToken = default)
+            => Task.FromResult(Result<Unit, AppError>.Success(Unit.Value));
+
+        public Task<Result<Unit, AppError>> DisassociatePushInstallationAsync(User? currentUser, Id<UserSession>? sessionId, PushInstallationActionInput input, CancellationToken cancellationToken = default)
+        {
+            LastPushDisassociate = (currentUser!.Id, sessionId, input);
+            return Task.FromResult(Result<Unit, AppError>.Success(Unit.Value));
+        }
+
         public Task<Result<LoginResult, AppError>> LoginAsync(string name, string password, CancellationToken cancellationToken = default) => Task.FromResult(Result<LoginResult, AppError>.Success(new LoginResult()));
         public Task<Result<LoginResult, AppError>> LoginTrainerAsync(string name, string password, CancellationToken cancellationToken = default) => Task.FromResult(Result<LoginResult, AppError>.Success(new LoginResult()));
         public Task<bool> IsAdminAsync(Id<User> userId, CancellationToken cancellationToken = default) => Task.FromResult(false);

--- a/LgymApi.UnitTests/UserControllerTests.cs
+++ b/LgymApi.UnitTests/UserControllerTests.cs
@@ -97,12 +97,12 @@ public sealed class UserControllerTests
     public async Task RegisterPushInstallation_PassesCurrentSessionIdAndRequestPayload()
     {
         var userService = new StubUserService();
-        var controller = CreateController(userService);
+        var controller = CreatePushInstallationController(userService);
         var userId = Id<User>.New();
         var sessionId = Id<UserSession>.New();
         controller.ControllerContext = new ControllerContext { HttpContext = BuildAuthenticatedHttpContext(userId, sessionId) };
 
-        var action = await controller.RegisterPushInstallation(new RegisterPushInstallationRequest
+        var action = await controller.Register(new RegisterPushInstallationRequest
         {
             InstallationId = "device-1",
             Platform = "ios",
@@ -124,12 +124,12 @@ public sealed class UserControllerTests
     public async Task DisassociatePushInstallation_PassesCurrentSessionIdAndInstallationId()
     {
         var userService = new StubUserService();
-        var controller = CreateController(userService);
+        var controller = CreatePushInstallationController(userService);
         var userId = Id<User>.New();
         var sessionId = Id<UserSession>.New();
         controller.ControllerContext = new ControllerContext { HttpContext = BuildAuthenticatedHttpContext(userId, sessionId) };
 
-        var action = await controller.DisassociatePushInstallation(new PushInstallationActionRequest
+        var action = await controller.Disassociate(new PushInstallationActionRequest
         {
             InstallationId = "device-2"
         });
@@ -148,6 +148,15 @@ public sealed class UserControllerTests
         var mapper = provider.GetRequiredService<IMapper>();
         var stubPasswordResetService = new StubPasswordResetService();
         return new UserController(userService, stubPasswordResetService, mapper);
+    }
+
+    private static PushInstallationController CreatePushInstallationController(IUserService userService)
+    {
+        var services = new ServiceCollection();
+        services.AddApplicationMapping(typeof(Program).Assembly, typeof(IMappingProfile).Assembly);
+        using var provider = services.BuildServiceProvider();
+        var mapper = provider.GetRequiredService<IMapper>();
+        return new PushInstallationController(userService, mapper);
     }
 
     private static DefaultHttpContext BuildAuthenticatedHttpContext(Id<User> userId, Id<UserSession> sessionId)

--- a/LgymApi.UnitTests/UserServiceTests.cs
+++ b/LgymApi.UnitTests/UserServiceTests.cs
@@ -8,6 +8,7 @@ using LgymApi.Application.Services;
 using LgymApi.BackgroundWorker.Common;
 using LgymApi.Domain.Entities;
 using LgymApi.Domain.ValueObjects;
+using LgymApi.Resources;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 
@@ -33,5 +34,85 @@ public sealed class UserServiceTests
 
         result.IsFailure.Should().BeTrue();
         result.Error.Should().BeOfType<InvalidUserError>();
+    }
+
+    [Test]
+    public async Task RegisterPushInstallation_WhenUnauthenticated_ReturnsUnauthorizedError()
+    {
+        var result = await _service.RegisterPushInstallationAsync(
+            null,
+            Id<UserSession>.New(),
+            new RegisterPushInstallationInput("device-1", "android", "token-1", "1.0.0", "development", "authorized"));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<UserUnauthorizedError>();
+        result.Error.Message.Should().Be(Messages.Unauthorized);
+    }
+
+    [Test]
+    public async Task RegisterPushInstallation_ReusesExistingInstallationAndClearsDisabledMetadata()
+    {
+        var userId = Id<User>.New();
+        var sessionId = Id<UserSession>.New();
+        var installation = new PushInstallation
+        {
+            Id = Id<PushInstallation>.New(),
+            InstallationId = "device-1",
+            Platform = "android",
+            FcmToken = "old-token",
+            Environment = "development",
+            DisabledAt = DateTimeOffset.UtcNow.AddDays(-1),
+            DisabledReason = "Unregistered"
+        };
+        var currentUser = new User { Id = userId, Name = "user", Email = "user@example.com" };
+
+        _deps.PushInstallationRepository.FindByInstallationIdAsync("device-1", Arg.Any<CancellationToken>())
+            .Returns(installation);
+
+        var result = await _service.RegisterPushInstallationAsync(
+            currentUser,
+            sessionId,
+            new RegisterPushInstallationInput("device-1", "ios", "new-token", "2.0.0", "production", "authorized"));
+
+        result.IsFailure.Should().BeFalse();
+        installation.UserId.Should().Be(userId);
+        installation.SessionId.Should().Be(sessionId);
+        installation.Platform.Should().Be("ios");
+        installation.FcmToken.Should().Be("new-token");
+        installation.AppVersion.Should().Be("2.0.0");
+        installation.Environment.Should().Be("production");
+        installation.PermissionStatus.Should().Be("authorized");
+        installation.DisabledAt.Should().BeNull();
+        installation.DisabledReason.Should().BeNull();
+        await _deps.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task LogoutAsync_RevokesSessionAndDisassociatesInstallationsBoundToSession()
+    {
+        var userId = Id<User>.New();
+        var sessionId = Id<UserSession>.New();
+        var currentUser = new User { Id = userId, Name = "user", Email = "user@example.com" };
+        var installation = new PushInstallation
+        {
+            Id = Id<PushInstallation>.New(),
+            UserId = userId,
+            SessionId = sessionId,
+            InstallationId = "device-1",
+            Platform = "android",
+            FcmToken = "token-1",
+            Environment = "production"
+        };
+
+        _deps.PushInstallationRepository.GetBySessionIdAsync(sessionId, Arg.Any<CancellationToken>())
+            .Returns([installation]);
+
+        var result = await _service.LogoutAsync(currentUser, sessionId);
+
+        result.IsFailure.Should().BeFalse();
+        installation.UserId.Should().BeNull();
+        installation.SessionId.Should().BeNull();
+        await _deps.UserSessionStore.Received(1).RevokeSessionAsync(sessionId, Arg.Any<CancellationToken>());
+        await _deps.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Common environment variable overrides:
 - `PhotoStorage__Provider`
 - `PhotoStorage__AccessKeyId`
 - `PhotoStorage__SecretAccessKey`
+- `PushNotifications__SendEnabled`
+- `PushNotifications__StaleTokenCleanupEnabled`
+- `PushNotifications__Fcm__ProjectId`
+- `PushNotifications__Fcm__CredentialsPath`
+- `PushNotifications__Fcm__CredentialsJson`
 
 ## Container runtime contract
 
@@ -55,6 +60,67 @@ Do not bake secrets or site-specific values into the image.
 
 The process runs from `/app` inside the container, so the mounted config and any relative paths must assume `/app` as the content root.
 Avoid launch profile assumptions when testing the image.
+
+## Push rollout and credentials
+
+Push registration and push delivery are separated on purpose.
+
+- `PushNotifications:SendEnabled=false` disables outbound push sends while keeping installation registration and token refresh active.
+- `PushNotifications:StaleTokenCleanupEnabled=true` keeps the recurring stale-token tombstoning job active even when send delivery is disabled.
+- Stale cleanup marks inactive rows with `DisabledAt` and `DisabledReason=InactiveStale`; it does not delete installation rows or historical push message audit data.
+
+### Credentials by environment
+
+Development:
+
+- Keep `PushNotifications:SendEnabled=false` until local Firebase credentials are present.
+- Prefer .NET user secrets or untracked environment variables for `PushNotifications__Fcm__CredentialsJson` or `PushNotifications__Fcm__CredentialsPath`.
+- If you need end-to-end push locally, point `PushNotifications__Fcm__CredentialsPath` at an untracked service-account JSON file outside the repo.
+
+Staging:
+
+- Use a dedicated Firebase project and service account separate from production.
+- Mount the service-account JSON from the host or secret store and set `PushNotifications__Fcm__CredentialsPath` to that mounted path.
+- Keep `PushNotifications__SendEnabled=false` until test devices register successfully and the admin test-event path is verified.
+
+Production:
+
+- Use a production-only Firebase project/service account with least-privilege access for messaging.
+- Prefer mounted secret files or a secret manager over inline JSON in committed config.
+- Rotate credentials outside the repo and restart the API after secret replacement if your host does not support live secret reload.
+
+Do not commit:
+
+- Firebase service-account JSON files
+- raw `PushNotifications__Fcm__CredentialsJson` values
+- APNs `.p8` files, Apple key IDs, or Apple team IDs
+- any environment-specific credentials in tracked `appsettings.*.json`
+
+### Mobile iOS / APNs requirement
+
+LGYM uses FCM tokens on both Android and iOS. iOS delivery still depends on APNs being configured in Firebase.
+
+- Create a separate Firebase iOS app for each dev/staging/prod bundle setup you actually ship.
+- Upload the matching APNs auth key to Firebase Project Settings -> Cloud Messaging.
+- Keep APNs credentials in Apple/Firebase secret storage only; never in this repository.
+
+### Operator runbook
+
+Rollout:
+
+1. Deploy config with `PushNotifications:SendEnabled=false` and stale cleanup enabled.
+2. Confirm mobile native builds register installations successfully in the target environment.
+3. Verify `/api/internal/push/test-event` creates queued/sent rows for a controlled test user.
+4. Turn `PushNotifications:SendEnabled=true` in staging, validate delivery, then repeat in production.
+5. Watch logs for `eventId`, `category`, and `provider status` fields plus disabled-installation counts from the stale cleanup job.
+
+Troubleshooting:
+
+1. Registration works but no push is sent: check `PushNotifications:SendEnabled`, Firebase project ID, and service-account secret mount.
+2. iOS tokens register but devices never receive pushes: verify APNs auth key upload in Firebase and the shipped iOS bundle identifier.
+3. Rows stay `Failed` with `InvalidToken`: the token was tombstoned immediately; wait for the device to re-register on next app open/token refresh.
+4. Old devices should stop receiving pushes: confirm the `push-stale-installation-cleanup` recurring job is present and `StaleTokenCleanupEnabled=true`.
+5. Investigating delivery issues: use `PushNotificationMessages` plus logs, not raw payload dumps; logs intentionally omit sensitive push payload content.
 
 ### Build the image
 

--- a/appsettings.container.example.json
+++ b/appsettings.container.example.json
@@ -15,5 +15,16 @@
   },
   "Elasticsearch": {
     "Url": "http://host.docker.internal:9200"
+  },
+  "PushNotifications": {
+    "SendEnabled": false,
+    "StaleTokenCleanupEnabled": true,
+    "StaleTokenInactivityDays": 45,
+    "StaleTokenCleanupBatchSize": 500,
+    "Fcm": {
+      "ProjectId": "YOUR_FIREBASE_PROJECT_ID",
+      "CredentialsPath": "/run/secrets/firebase-service-account.json",
+      "CredentialsJson": ""
+    }
   }
 }


### PR DESCRIPTION
## Summary
- adds push installation registration, persistence, and session disassociation on logout
- adds durable push notification messages, FCM HTTP v1 delivery, retry/idempotency handling, stale-token cleanup, and Hangfire jobs
- fans out persisted in-app notifications into privacy-safe push payloads and adds an internal test-event endpoint
- documents rollout, credentials, APNs requirements, and disabled-by-default config placeholders

## Validation
- dotnet test LgymApi.UnitTests/LgymApi.UnitTests.csproj --filter "InAppNotificationServiceTests|PushNotificationPipelineTests|ReportRequestCreatedInAppNotificationCommandHandlerTests|InfrastructureServiceCollectionExtensionsTests|UserServiceTests|UserControllerTests|NotificationEventBridgeTests|ServiceCommitBehaviorTests" --no-restore -p:BaseOutputPath="C:\Users\kubax\AppData\Local\Temp\opencode\lgym-test-output" — passed 94/94
- LSP diagnostics: no errors
- secret scan: no private Firebase/APNs credential material in changed files

## Notes
- Push sends are disabled by default with PushNotifications:SendEnabled=false.
- Existing NU1903 warning for SQLitePCLRaw.lib.e_sqlite3 remains unrelated to this PR.