### PR TITLE
Return exercise formula in edit response

### DIFF
--- a/LgymApi.Api/Features/Exercise/Contracts/ExerciseDtos.cs
+++ b/LgymApi.Api/Features/Exercise/Contracts/ExerciseDtos.cs
@@ -66,6 +66,9 @@ public sealed class ExerciseResponseDto : IResultDto
     [JsonPropertyName("bodyPart")]
     public EnumLookupDto BodyPart { get; set; } = new();
 
+    [JsonPropertyName("eloFormula")]
+    public LookupItemVm? EloFormula { get; set; }
+
     [JsonPropertyName("description")]
     public string? Description { get; set; }
 

--- a/LgymApi.Api/Mapping/Profiles/EnumProfile.cs
+++ b/LgymApi.Api/Mapping/Profiles/EnumProfile.cs
@@ -1,4 +1,5 @@
 using LgymApi.Api.Features.Enum.Contracts;
+using LgymApi.Api.Features.Common.Contracts;
 using LgymApi.Application.Features.Enum.Models;
 using LgymApi.Application.Mapping.Core;
 
@@ -12,6 +13,12 @@ public sealed class EnumProfile : IMappingProfile
         {
             Id = source.Id,
             Name = source.Name,
+            DisplayName = source.DisplayName
+        });
+
+        configuration.CreateMap<EnumLookupDto, LookupItemVm>((source, _) => new LookupItemVm
+        {
+            Id = source.Id,
             DisplayName = source.DisplayName
         });
 

--- a/LgymApi.Api/Mapping/Profiles/ExerciseProfile.cs
+++ b/LgymApi.Api/Mapping/Profiles/ExerciseProfile.cs
@@ -66,6 +66,7 @@ public sealed class ExerciseProfile : IMappingProfile
                 Id = source.Id.ToString(),
                 Name = name,
                 BodyPart = source.BodyPart.ToLookup(),
+                EloFormula = ToLookupItem(source.EloFormula),
                 Description = source.Description,
                 Image = source.Image,
                 UserId = source.UserId?.ToString()
@@ -112,5 +113,15 @@ public sealed class ExerciseProfile : IMappingProfile
         return global::System.Enum.TryParse<ExerciseEloFormula>(formulaId, ignoreCase: true, out var parsed)
             ? parsed
             : null;
+    }
+
+    private static LookupItemVm ToLookupItem(ExerciseEloFormula eloFormula)
+    {
+        var lookup = eloFormula.ToLookup();
+        return new LookupItemVm
+        {
+            Id = lookup.Id,
+            DisplayName = lookup.DisplayName
+        };
     }
 }

--- a/LgymApi.Api/Mapping/Profiles/ExerciseProfile.cs
+++ b/LgymApi.Api/Mapping/Profiles/ExerciseProfile.cs
@@ -1,5 +1,6 @@
 using LgymApi.Api.Extensions;
 using LgymApi.Api.Features.Common.Contracts;
+using LgymApi.Api.Features.Enum.Contracts;
 using LgymApi.Api.Features.Exercise.Contracts;
 using LgymApi.Api.Features.Enum;
 using LgymApi.Api.Middleware;
@@ -66,7 +67,7 @@ public sealed class ExerciseProfile : IMappingProfile
                 Id = source.Id.ToString(),
                 Name = name,
                 BodyPart = source.BodyPart.ToLookup(),
-                EloFormula = ToLookupItem(source.EloFormula),
+                EloFormula = context!.Map<EnumLookupDto, LookupItemVm>(source.EloFormula.ToLookup()),
                 Description = source.Description,
                 Image = source.Image,
                 UserId = source.UserId?.ToString()
@@ -115,13 +116,4 @@ public sealed class ExerciseProfile : IMappingProfile
             : null;
     }
 
-    private static LookupItemVm ToLookupItem(ExerciseEloFormula eloFormula)
-    {
-        var lookup = eloFormula.ToLookup();
-        return new LookupItemVm
-        {
-            Id = lookup.Id,
-            DisplayName = lookup.DisplayName
-        };
-    }
 }

--- a/LgymApi.IntegrationTests/ExerciseTests.cs
+++ b/LgymApi.IntegrationTests/ExerciseTests.cs
@@ -410,7 +410,16 @@ public sealed class ExerciseTests : IntegrationTestBase
      public async Task GetExercise_WithValidId_ReturnsExercise()
      {
          var user = await SeedUserAsync(name: "exerciseuser", email: "exercise@example.com");
-         var exercise = await SeedExerciseAsync(user.Id, "Test Exercise", "Chest");
+         var exercise = await SeedExerciseAsync(user.Id, "Test Exercise", "Chest", eloFormula: ExerciseEloFormula.StrengthWeighted);
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var seededExercise = await db.Exercises.FirstAsync(e => e.Id == exercise.Id);
+            seededExercise.Description = "Detailed description";
+            seededExercise.Image = "https://cdn.example.com/exercise.png";
+            await db.SaveChangesAsync();
+        }
+
         SetAuthorizationHeader(user.Id);
 
         var response = await Client.GetAsync($"/api/exercise/{exercise.Id}/getExercise");
@@ -422,6 +431,10 @@ public sealed class ExerciseTests : IntegrationTestBase
         body!.Name.Should().Be("Test Exercise");
         body.BodyPart.Should().NotBeNull();
         body.BodyPart!.Name.Should().Be("Chest");
+        body.Description.Should().Be("Detailed description");
+        body.Image.Should().Be("https://cdn.example.com/exercise.png");
+        body.EloFormula.Should().NotBeNull();
+        body.EloFormula!.Id.Should().Be(ExerciseEloFormula.StrengthWeighted.ToString());
     }
 
     private async Task<Exercise> SeedExerciseAsync(
@@ -469,6 +482,9 @@ public sealed class ExerciseTests : IntegrationTestBase
         [JsonPropertyName("bodyPart")]
         public BodyPartLookup? BodyPart { get; set; }
 
+        [JsonPropertyName("eloFormula")]
+        public LookupItemResponse? EloFormula { get; set; }
+
         [JsonPropertyName("description")]
         public string? Description { get; set; }
 
@@ -483,6 +499,15 @@ public sealed class ExerciseTests : IntegrationTestBase
     {
         [JsonPropertyName("name")]
         public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("displayName")]
+        public string DisplayName { get; set; } = string.Empty;
+    }
+
+    private sealed class LookupItemResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
 
         [JsonPropertyName("displayName")]
         public string DisplayName { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- add eloFormula to ExerciseResponseDto so getExercise returns the saved ELO formula for edit forms
- map Exercise.EloFormula to a lookup item with stable id/displayName
- extend the getExercise integration test to cover description, image, and eloFormula round-trip data

## Why
The exercise edit flow uses getExercise as its single-item read endpoint. Description and image were already part of the response, but eloFormula was missing, so clients could save a formula but could not hydrate the edit form with the stored value later.

## Validation
- dotnet build LgymApi.Api/LgymApi.Api.csproj --configuration Release --no-restore
- dotnet test LgymApi.IntegrationTests/LgymApi.IntegrationTests.csproj --configuration Release --no-build --filter GetExercise_WithValidId_ReturnsExercise