### PR TITLE
Clarify Google token audience validation logging

### DIFF
--- a/LgymApi.Infrastructure/Services/GoogleTokenValidator.cs
+++ b/LgymApi.Infrastructure/Services/GoogleTokenValidator.cs
@@ -70,7 +70,7 @@ public sealed class GoogleTokenValidator : IGoogleTokenValidator
         }
         catch (InvalidJwtException ex)
         {
-            _logger.LogWarning(ex, "Google token validation failed.");
+            _logger.LogWarning(ex, "Google token validation failed for the configured web/server audience. The token was not logged.");
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- clarify Google token validation logging when backend audience validation fails
- keep backend pinned to the configured web/server GoogleAuth:ClientId audience
- avoid logging raw Google tokens

## Validation
- dotnet test LgymApi.UnitTests/LgymApi.UnitTests.csproj --configuration Release --filter GoogleTokenValidatorTests